### PR TITLE
Remove tinyxml2 dependency replace with expat parsers

### DIFF
--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -1,22 +1,13 @@
 #pragma once
 #include <Print.h>
-#include <tinyxml2.h>
 
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-class ZipFile;
+#include "Epub/EpubTocEntry.h"
 
-class EpubTocEntry {
- public:
-  std::string title;
-  std::string href;
-  std::string anchor;
-  int level;
-  EpubTocEntry(std::string title, std::string href, std::string anchor, const int level)
-      : title(std::move(title)), href(std::move(href)), anchor(std::move(anchor)), level(level) {}
-};
+class ZipFile;
 
 class Epub {
   // the title read from the EPUB meta data
@@ -36,11 +27,9 @@ class Epub {
   // Uniq cache key based on filepath
   std::string cachePath;
 
-  // find the path for the content.opf file
-  static bool findContentOpfFile(const ZipFile& zip, std::string& contentOpfFile);
-  bool parseContentOpf(ZipFile& zip, std::string& content_opf_file);
-  bool parseTocNcxFile(const ZipFile& zip);
-  void recursivelyParseNavMap(tinyxml2::XMLElement* element);
+  bool findContentOpfFile(std::string* contentOpfFile) const;
+  bool parseContentOpf(const std::string& contentOpfFilePath);
+  bool parseTocNcxFile();
 
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {
@@ -59,6 +48,7 @@ class Epub {
   uint8_t* readItemContentsToBytes(const std::string& itemHref, size_t* size = nullptr,
                                    bool trailingNullByte = false) const;
   bool readItemContentsToStream(const std::string& itemHref, Print& out, size_t chunkSize) const;
+  bool getItemSize(const std::string& itemHref, size_t* size) const;
   std::string& getSpineItem(int spineIndex);
   int getSpineItemsCount() const;
   EpubTocEntry& getTocItem(int tocTndex);

--- a/lib/Epub/Epub/EpubTocEntry.h
+++ b/lib/Epub/Epub/EpubTocEntry.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+class EpubTocEntry {
+ public:
+  std::string title;
+  std::string href;
+  std::string anchor;
+  int level;
+  EpubTocEntry(std::string title, std::string href, std::string anchor, const int level)
+      : title(std::move(title)), href(std::move(href)), anchor(std::move(anchor)), level(level) {}
+};

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -5,9 +5,9 @@
 
 #include <fstream>
 
-#include "EpubHtmlParserSlim.h"
 #include "FsHelpers.h"
 #include "Page.h"
+#include "parsers/ChapterHtmlSlimParser.h"
 
 constexpr uint8_t SECTION_FILE_VERSION = 4;
 
@@ -127,9 +127,9 @@ bool Section::persistPageDataToSD(const int fontId, const float lineCompression,
 
   const auto sdTmpHtmlPath = "/sd" + tmpHtmlPath;
 
-  EpubHtmlParserSlim visitor(sdTmpHtmlPath.c_str(), renderer, fontId, lineCompression, marginTop, marginRight,
-                             marginBottom, marginLeft,
-                             [this](std::unique_ptr<Page> page) { this->onPageComplete(std::move(page)); });
+  ChapterHtmlSlimParser visitor(sdTmpHtmlPath.c_str(), renderer, fontId, lineCompression, marginTop, marginRight,
+                                marginBottom, marginLeft,
+                                [this](std::unique_ptr<Page> page) { this->onPageComplete(std::move(page)); });
   success = visitor.parseAndBuildPages();
 
   SD.remove(tmpHtmlPath.c_str());

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -6,15 +6,15 @@
 #include <functional>
 #include <memory>
 
-#include "ParsedText.h"
-#include "blocks/TextBlock.h"
+#include "../ParsedText.h"
+#include "../blocks/TextBlock.h"
 
 class Page;
 class GfxRenderer;
 
 #define MAX_WORD_SIZE 200
 
-class EpubHtmlParserSlim {
+class ChapterHtmlSlimParser {
   const char* filepath;
   GfxRenderer& renderer;
   std::function<void(std::unique_ptr<Page>)> completePageFn;
@@ -44,10 +44,10 @@ class EpubHtmlParserSlim {
   static void XMLCALL endElement(void* userData, const XML_Char* name);
 
  public:
-  explicit EpubHtmlParserSlim(const char* filepath, GfxRenderer& renderer, const int fontId,
-                              const float lineCompression, const int marginTop, const int marginRight,
-                              const int marginBottom, const int marginLeft,
-                              const std::function<void(std::unique_ptr<Page>)>& completePageFn)
+  explicit ChapterHtmlSlimParser(const char* filepath, GfxRenderer& renderer, const int fontId,
+                                 const float lineCompression, const int marginTop, const int marginRight,
+                                 const int marginBottom, const int marginLeft,
+                                 const std::function<void(std::unique_ptr<Page>)>& completePageFn)
       : filepath(filepath),
         renderer(renderer),
         fontId(fontId),
@@ -57,6 +57,6 @@ class EpubHtmlParserSlim {
         marginBottom(marginBottom),
         marginLeft(marginLeft),
         completePageFn(completePageFn) {}
-  ~EpubHtmlParserSlim() = default;
+  ~ChapterHtmlSlimParser() = default;
   bool parseAndBuildPages();
 };

--- a/lib/Epub/Epub/parsers/ContainerParser.cpp
+++ b/lib/Epub/Epub/parsers/ContainerParser.cpp
@@ -1,0 +1,96 @@
+#include "ContainerParser.h"
+
+#include <HardwareSerial.h>
+
+bool ContainerParser::setup() {
+  parser = XML_ParserCreate(nullptr);
+  if (!parser) {
+    Serial.printf("[%lu] [CTR] Couldn't allocate memory for parser\n", millis());
+    return false;
+  }
+
+  XML_SetUserData(parser, this);
+  XML_SetElementHandler(parser, startElement, endElement);
+  return true;
+}
+
+bool ContainerParser::teardown() {
+  if (parser) {
+    XML_ParserFree(parser);
+    parser = nullptr;
+  }
+  return true;
+}
+
+size_t ContainerParser::write(const uint8_t data) { return write(&data, 1); }
+
+size_t ContainerParser::write(const uint8_t* buffer, const size_t size) {
+  if (!parser) return 0;
+
+  const uint8_t* currentBufferPos = buffer;
+  auto remainingInBuffer = size;
+
+  while (remainingInBuffer > 0) {
+    void* const buf = XML_GetBuffer(parser, 1024);
+    if (!buf) {
+      Serial.printf("[%lu] [CTR] Couldn't allocate buffer\n", millis());
+      return 0;
+    }
+
+    const auto toRead = remainingInBuffer < 1024 ? remainingInBuffer : 1024;
+    memcpy(buf, currentBufferPos, toRead);
+
+    if (XML_ParseBuffer(parser, static_cast<int>(toRead), remainingSize == toRead) == XML_STATUS_ERROR) {
+      Serial.printf("[%lu] [CTR] Parse error: %s\n", millis(), XML_ErrorString(XML_GetErrorCode(parser)));
+      return 0;
+    }
+
+    currentBufferPos += toRead;
+    remainingInBuffer -= toRead;
+    remainingSize -= toRead;
+  }
+  return size;
+}
+
+void XMLCALL ContainerParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
+  auto* self = static_cast<ContainerParser*>(userData);
+
+  // Simple state tracking to ensure we are looking at the valid schema structure
+  if (self->state == START && strcmp(name, "container") == 0) {
+    self->state = IN_CONTAINER;
+    return;
+  }
+
+  if (self->state == IN_CONTAINER && strcmp(name, "rootfiles") == 0) {
+    self->state = IN_ROOTFILES;
+    return;
+  }
+
+  if (self->state == IN_ROOTFILES && strcmp(name, "rootfile") == 0) {
+    const char* mediaType = nullptr;
+    const char* path = nullptr;
+
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "media-type") == 0) {
+        mediaType = atts[i + 1];
+      } else if (strcmp(atts[i], "full-path") == 0) {
+        path = atts[i + 1];
+      }
+    }
+
+    // Check if this is the standard OEBPS package
+    if (mediaType && path && strcmp(mediaType, "application/oebps-package+xml") == 0) {
+      self->fullPath = path;
+    }
+  }
+}
+
+void XMLCALL ContainerParser::endElement(void* userData, const XML_Char* name) {
+  auto* self = static_cast<ContainerParser*>(userData);
+
+  if (self->state == IN_ROOTFILES && strcmp(name, "rootfiles") == 0) {
+    self->state = IN_CONTAINER;
+  } else if (self->state == IN_CONTAINER && strcmp(name, "container") == 0) {
+    self->state = START;
+  }
+}

--- a/lib/Epub/Epub/parsers/ContainerParser.h
+++ b/lib/Epub/Epub/parsers/ContainerParser.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <Print.h>
+
+#include <string>
+
+#include "expat.h"
+
+class ContainerParser final : public Print {
+  enum ParserState {
+    START,
+    IN_CONTAINER,
+    IN_ROOTFILES,
+  };
+
+  size_t remainingSize;
+  XML_Parser parser = nullptr;
+  ParserState state = START;
+
+  static void startElement(void* userData, const XML_Char* name, const XML_Char** atts);
+  static void endElement(void* userData, const XML_Char* name);
+
+ public:
+  std::string fullPath;
+
+  explicit ContainerParser(const size_t xmlSize) : remainingSize(xmlSize) {}
+
+  bool setup();
+  bool teardown();
+
+  size_t write(uint8_t) override;
+  size_t write(const uint8_t* buffer, size_t size) override;
+};

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -1,0 +1,161 @@
+#include "ContentOpfParser.h"
+
+#include <HardwareSerial.h>
+#include <ZipFile.h>
+
+bool ContentOpfParser::setup() {
+  parser = XML_ParserCreate(nullptr);
+  if (!parser) {
+    Serial.printf("[%lu] [COF] Couldn't allocate memory for parser\n", millis());
+    return false;
+  }
+
+  XML_SetUserData(parser, this);
+  XML_SetElementHandler(parser, startElement, endElement);
+  XML_SetCharacterDataHandler(parser, characterData);
+  return true;
+}
+
+bool ContentOpfParser::teardown() {
+  if (parser) {
+    XML_ParserFree(parser);
+    parser = nullptr;
+  }
+  return true;
+}
+
+size_t ContentOpfParser::write(const uint8_t data) { return write(&data, 1); }
+
+size_t ContentOpfParser::write(const uint8_t* buffer, const size_t size) {
+  if (!parser) return 0;
+
+  const uint8_t* currentBufferPos = buffer;
+  auto remainingInBuffer = size;
+
+  while (remainingInBuffer > 0) {
+    void* const buf = XML_GetBuffer(parser, 1024);
+
+    if (!buf) {
+      Serial.printf("[%lu] [COF] Couldn't allocate memory for buffer\n", millis());
+      XML_ParserFree(parser);
+      parser = nullptr;
+      return 0;
+    }
+
+    const auto toRead = remainingInBuffer < 1024 ? remainingInBuffer : 1024;
+    memcpy(buf, currentBufferPos, toRead);
+
+    if (XML_ParseBuffer(parser, static_cast<int>(toRead), remainingSize == toRead) == XML_STATUS_ERROR) {
+      Serial.printf("[%lu] [COF] Parse error at line %lu: %s\n", millis(), XML_GetCurrentLineNumber(parser),
+                    XML_ErrorString(XML_GetErrorCode(parser)));
+      XML_ParserFree(parser);
+      parser = nullptr;
+      return 0;
+    }
+
+    currentBufferPos += toRead;
+    remainingInBuffer -= toRead;
+    remainingSize -= toRead;
+  }
+
+  return size;
+}
+
+void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
+  auto* self = static_cast<ContentOpfParser*>(userData);
+  (void)atts;
+
+  if (self->state == START && (strcmp(name, "package") == 0 || strcmp(name, "opf:package") == 0)) {
+    self->state = IN_PACKAGE;
+    return;
+  }
+
+  if (self->state == IN_PACKAGE && (strcmp(name, "metadata") == 0 || strcmp(name, "opf:metadata") == 0)) {
+    self->state = IN_METADATA;
+    return;
+  }
+
+  if (self->state == IN_METADATA && strcmp(name, "dc:title") == 0) {
+    self->state = IN_BOOK_TITLE;
+    return;
+  }
+
+  if (self->state == IN_PACKAGE && (strcmp(name, "manifest") == 0 || strcmp(name, "opf:manifest") == 0)) {
+    self->state = IN_MANIFEST;
+    return;
+  }
+
+  if (self->state == IN_PACKAGE && (strcmp(name, "spine") == 0 || strcmp(name, "opf:spine") == 0)) {
+    self->state = IN_SPINE;
+    return;
+  }
+
+  // TODO: Support book cover
+  // if (self->state == IN_METADATA && (strcmp(name, "meta") == 0 || strcmp(name, "opf:meta") == 0)) {
+  // }
+
+  if (self->state == IN_MANIFEST && (strcmp(name, "item") == 0 || strcmp(name, "opf:item") == 0)) {
+    std::string itemId;
+    std::string href;
+
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "id") == 0) {
+        itemId = atts[i + 1];
+      } else if (strcmp(atts[i], "href") == 0) {
+        href = self->baseContentPath + atts[i + 1];
+      }
+    }
+
+    self->items[itemId] = href;
+    return;
+  }
+
+  if (self->state == IN_SPINE && (strcmp(name, "itemref") == 0 || strcmp(name, "opf:itemref") == 0)) {
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "idref") == 0) {
+        self->spineRefs.emplace_back(atts[i + 1]);
+        break;
+      }
+    }
+    return;
+  }
+}
+
+void XMLCALL ContentOpfParser::characterData(void* userData, const XML_Char* s, const int len) {
+  auto* self = static_cast<ContentOpfParser*>(userData);
+
+  if (self->state == IN_BOOK_TITLE) {
+    self->title.append(s, len);
+    return;
+  }
+}
+
+void XMLCALL ContentOpfParser::endElement(void* userData, const XML_Char* name) {
+  auto* self = static_cast<ContentOpfParser*>(userData);
+  (void)name;
+
+  if (self->state == IN_SPINE && (strcmp(name, "spine") == 0 || strcmp(name, "opf:spine") == 0)) {
+    self->state = IN_PACKAGE;
+    return;
+  }
+
+  if (self->state == IN_MANIFEST && (strcmp(name, "manifest") == 0 || strcmp(name, "opf:manifest") == 0)) {
+    self->state = IN_PACKAGE;
+    return;
+  }
+
+  if (self->state == IN_BOOK_TITLE && strcmp(name, "dc:title") == 0) {
+    self->state = IN_METADATA;
+    return;
+  }
+
+  if (self->state == IN_METADATA && (strcmp(name, "metadata") == 0 || strcmp(name, "opf:metadata") == 0)) {
+    self->state = IN_PACKAGE;
+    return;
+  }
+
+  if (self->state == IN_PACKAGE && (strcmp(name, "package") == 0 || strcmp(name, "opf:package") == 0)) {
+    self->state = START;
+    return;
+  }
+}

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <Print.h>
+
+#include <map>
+
+#include "Epub.h"
+#include "expat.h"
+
+class ContentOpfParser final : public Print {
+  enum ParserState {
+    START,
+    IN_PACKAGE,
+    IN_METADATA,
+    IN_BOOK_TITLE,
+    IN_MANIFEST,
+    IN_SPINE,
+  };
+
+  const std::string& baseContentPath;
+  size_t remainingSize;
+  XML_Parser parser = nullptr;
+  ParserState state = START;
+
+  static void startElement(void* userData, const XML_Char* name, const XML_Char** atts);
+  static void characterData(void* userData, const XML_Char* s, int len);
+  static void endElement(void* userData, const XML_Char* name);
+
+ public:
+  std::string title;
+  std::string tocNcxPath;
+  std::map<std::string, std::string> items;
+  std::vector<std::string> spineRefs;
+
+  explicit ContentOpfParser(const std::string& baseContentPath, const size_t xmlSize)
+      : baseContentPath(baseContentPath), remainingSize(xmlSize) {}
+
+  bool setup();
+  bool teardown();
+
+  size_t write(uint8_t) override;
+  size_t write(const uint8_t* buffer, size_t size) override;
+};

--- a/lib/Epub/Epub/parsers/TocNcxParser.cpp
+++ b/lib/Epub/Epub/parsers/TocNcxParser.cpp
@@ -1,0 +1,165 @@
+#include "TocNcxParser.h"
+
+#include <HardwareSerial.h>
+
+bool TocNcxParser::setup() {
+  parser = XML_ParserCreate(nullptr);
+  if (!parser) {
+    Serial.printf("[%lu] [TOC] Couldn't allocate memory for parser\n", millis());
+    return false;
+  }
+
+  XML_SetUserData(parser, this);
+  XML_SetElementHandler(parser, startElement, endElement);
+  XML_SetCharacterDataHandler(parser, characterData);
+  return true;
+}
+
+bool TocNcxParser::teardown() {
+  if (parser) {
+    XML_ParserFree(parser);
+    parser = nullptr;
+  }
+  return true;
+}
+
+size_t TocNcxParser::write(const uint8_t data) { return write(&data, 1); }
+
+size_t TocNcxParser::write(const uint8_t* buffer, const size_t size) {
+  if (!parser) return 0;
+
+  const uint8_t* currentBufferPos = buffer;
+  auto remainingInBuffer = size;
+
+  while (remainingInBuffer > 0) {
+    void* const buf = XML_GetBuffer(parser, 1024);
+    if (!buf) {
+      Serial.printf("[%lu] [TOC] Couldn't allocate memory for buffer\n", millis());
+      return 0;
+    }
+
+    const auto toRead = remainingInBuffer < 1024 ? remainingInBuffer : 1024;
+    memcpy(buf, currentBufferPos, toRead);
+
+    if (XML_ParseBuffer(parser, static_cast<int>(toRead), remainingSize == toRead) == XML_STATUS_ERROR) {
+      Serial.printf("[%lu] [TOC] Parse error at line %lu: %s\n", millis(), XML_GetCurrentLineNumber(parser),
+                    XML_ErrorString(XML_GetErrorCode(parser)));
+      return 0;
+    }
+
+    currentBufferPos += toRead;
+    remainingInBuffer -= toRead;
+    remainingSize -= toRead;
+  }
+  return size;
+}
+
+void XMLCALL TocNcxParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
+  // NOTE: We rely on navPoint label and content coming before any nested navPoints, this will be fine:
+  // <navPoint>
+  //   <navLabel><text>Chapter 1</text></navLabel>
+  //   <content src="ch1.html"/>
+  //   <navPoint> ...nested... </navPoint>
+  // </navPoint>
+  //
+  // This will NOT:
+  // <navPoint>
+  //   <navPoint> ...nested... </navPoint>
+  //   <navLabel><text>Chapter 1</text></navLabel>
+  //   <content src="ch1.html"/>
+  // </navPoint>
+
+  auto* self = static_cast<TocNcxParser*>(userData);
+
+  if (self->state == START && strcmp(name, "ncx") == 0) {
+    self->state = IN_NCX;
+    return;
+  }
+
+  if (self->state == IN_NCX && strcmp(name, "navMap") == 0) {
+    self->state = IN_NAV_MAP;
+    return;
+  }
+
+  // Handles both top-level and nested navPoints
+  if ((self->state == IN_NAV_MAP || self->state == IN_NAV_POINT) && strcmp(name, "navPoint") == 0) {
+    self->state = IN_NAV_POINT;
+    self->currentDepth++;
+
+    self->currentLabel.clear();
+    self->currentSrc.clear();
+    return;
+  }
+
+  if (self->state == IN_NAV_POINT && strcmp(name, "navLabel") == 0) {
+    self->state = IN_NAV_LABEL;
+    return;
+  }
+
+  if (self->state == IN_NAV_LABEL && strcmp(name, "text") == 0) {
+    self->state = IN_NAV_LABEL_TEXT;
+    return;
+  }
+
+  if (self->state == IN_NAV_POINT && strcmp(name, "content") == 0) {
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "src") == 0) {
+        self->currentSrc = atts[i + 1];
+        break;
+      }
+    }
+    return;
+  }
+}
+
+void XMLCALL TocNcxParser::characterData(void* userData, const XML_Char* s, const int len) {
+  auto* self = static_cast<TocNcxParser*>(userData);
+  if (self->state == IN_NAV_LABEL_TEXT) {
+    self->currentLabel.append(s, len);
+  }
+}
+
+void XMLCALL TocNcxParser::endElement(void* userData, const XML_Char* name) {
+  auto* self = static_cast<TocNcxParser*>(userData);
+
+  if (self->state == IN_NAV_LABEL_TEXT && strcmp(name, "text") == 0) {
+    self->state = IN_NAV_LABEL;
+    return;
+  }
+
+  if (self->state == IN_NAV_LABEL && strcmp(name, "navLabel") == 0) {
+    self->state = IN_NAV_POINT;
+    return;
+  }
+
+  if (self->state == IN_NAV_POINT && strcmp(name, "navPoint") == 0) {
+    self->currentDepth--;
+    if (self->currentDepth == 0) {
+      self->state = IN_NAV_MAP;
+    }
+    return;
+  }
+
+  if (self->state == IN_NAV_POINT && strcmp(name, "content") == 0) {
+    // At this point (end of content tag), we likely have both Label (from previous tags) and Src.
+    // This is the safest place to push the data, assuming <navLabel> always comes before <content>.
+    // NCX spec says navLabel comes before content.
+    if (!self->currentLabel.empty() && !self->currentSrc.empty()) {
+      std::string href = self->baseContentPath + self->currentSrc;
+      std::string anchor;
+
+      const size_t pos = href.find('#');
+      if (pos != std::string::npos) {
+        anchor = href.substr(pos + 1);
+        href = href.substr(0, pos);
+      }
+
+      // Push to vector
+      self->toc.emplace_back(self->currentLabel, href, anchor, self->currentDepth);
+
+      // Clear them so we don't re-add them if there are weird XML structures
+      self->currentLabel.clear();
+      self->currentSrc.clear();
+    }
+  }
+}

--- a/lib/Epub/Epub/parsers/TocNcxParser.h
+++ b/lib/Epub/Epub/parsers/TocNcxParser.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <Print.h>
+
+#include <string>
+#include <vector>
+
+#include "Epub/EpubTocEntry.h"
+#include "expat.h"
+
+class TocNcxParser final : public Print {
+  enum ParserState { START, IN_NCX, IN_NAV_MAP, IN_NAV_POINT, IN_NAV_LABEL, IN_NAV_LABEL_TEXT, IN_CONTENT };
+
+  const std::string& baseContentPath;
+  size_t remainingSize;
+  XML_Parser parser = nullptr;
+  ParserState state = START;
+
+  std::string currentLabel;
+  std::string currentSrc;
+  size_t currentDepth = 0;
+
+  static void startElement(void* userData, const XML_Char* name, const XML_Char** atts);
+  static void characterData(void* userData, const XML_Char* s, int len);
+  static void endElement(void* userData, const XML_Char* name);
+
+ public:
+  std::vector<EpubTocEntry> toc;
+
+  explicit TocNcxParser(const std::string& baseContentPath, const size_t xmlSize)
+      : baseContentPath(baseContentPath), remainingSize(xmlSize) {}
+
+  bool setup();
+  bool teardown();
+
+  size_t write(uint8_t) override;
+  size_t write(const uint8_t* buffer, size_t size) override;
+};

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -162,9 +162,7 @@ int GfxRenderer::getLineHeight(const int fontId) const {
   return fontMap.at(fontId).getData(REGULAR)->advanceY;
 }
 
-uint8_t *GfxRenderer::getFrameBuffer() const {
-  return einkDisplay.getFrameBuffer();
-}
+uint8_t* GfxRenderer::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
 void GfxRenderer::swapBuffers() const { einkDisplay.swapBuffers(); }
 

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -14,6 +14,7 @@ class ZipFile {
  public:
   explicit ZipFile(std::string filePath) : filePath(std::move(filePath)) {}
   ~ZipFile() = default;
+  bool getInflatedFileSize(const char* filename, size_t* size) const;
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false) const;
   bool readFileToStream(const char* filename, Print& out, size_t chunkSize) const;
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,6 @@ board_build.partitions = partitions.csv
 
 ; Libraries
 lib_deps =
-  https://github.com/leethomason/tinyxml2.git#11.0.0
   BatteryMonitor=symlink://open-x4-sdk/libs/hardware/BatteryMonitor
   InputManager=symlink://open-x4-sdk/libs/hardware/InputManager
   EInkDisplay=symlink://open-x4-sdk/libs/display/EInkDisplay

--- a/src/screens/EpubReaderScreen.cpp
+++ b/src/screens/EpubReaderScreen.cpp
@@ -163,7 +163,7 @@ void EpubReaderScreen::renderScreen() {
         const int w = textWidth + margin * 2;
         const int h = renderer.getLineHeight(READER_FONT_ID) + margin * 2;
         renderer.grayscaleRevert();
-        uint8_t *fb1 = renderer.getFrameBuffer();
+        uint8_t* fb1 = renderer.getFrameBuffer();
         renderer.swapBuffers();
         memcpy(fb1, renderer.getFrameBuffer(), EInkDisplay::BUFFER_SIZE);
         renderer.fillRect(x, y, w, h, 0);


### PR DESCRIPTION
- Replaces `tinyxml2` parsing of the `META-INF/container.xml` file, `content.opf` file, and `toc.ncx` file with expat parsers
  - Thanks to `expat`'s stream oriented approach, we don't need to load the whole file into memory to process the XML files
- Should resolve some load issues of files with large `content.opf` and `toc.ncx`
  - Note: It does not fix the issue of massive TOCs still crashing the app

Byproduct of removing tinyxml2 is that this resolves #7 