### PR TITLE
Parse cover image path from content.opf file

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -69,6 +69,9 @@ bool Epub::parseContentOpf(const std::string& contentOpfFilePath) {
 
   // Grab data from opfParser into epub
   title = opfParser.title;
+  if (!opfParser.coverItemId.empty() && opfParser.items.count(opfParser.coverItemId) > 0) {
+    coverImageItem = opfParser.items.at(opfParser.coverItemId);
+  }
 
   if (opfParser.items.count("ncx")) {
     tocNcxItem = opfParser.items.at("ncx");

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -90,9 +90,23 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     return;
   }
 
-  // TODO: Support book cover
-  // if (self->state == IN_METADATA && (strcmp(name, "meta") == 0 || strcmp(name, "opf:meta") == 0)) {
-  // }
+  if (self->state == IN_METADATA && (strcmp(name, "meta") == 0 || strcmp(name, "opf:meta") == 0)) {
+    bool isCover = false;
+    std::string coverItemId;
+
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "name") == 0 && strcmp(atts[i + 1], "cover") == 0) {
+        isCover = true;
+      } else if (strcmp(atts[i], "content") == 0) {
+        coverItemId = atts[i + 1];
+      }
+    }
+
+    if (isCover) {
+      self->coverItemId = coverItemId;
+    }
+    return;
+  }
 
   if (self->state == IN_MANIFEST && (strcmp(name, "item") == 0 || strcmp(name, "opf:item") == 0)) {
     std::string itemId;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -28,6 +28,7 @@ class ContentOpfParser final : public Print {
  public:
   std::string title;
   std::string tocNcxPath;
+  std::string coverItemId;
   std::map<std::string, std::string> items;
   std::vector<std::string> spineRefs;
 


### PR DESCRIPTION
## Summary

* Detect the cover image ID in `<meta name="cover" ... />` tag
* Set the EPUB cover image item once content.opf parsing complete

## Additional Context

* Will be useful once https://github.com/daveallie/crosspoint-reader/pull/23 gets live to be able to render cover images
