### PR TITLE
Add bounds checking for TOC/spine array access

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -322,6 +322,11 @@ int Epub::getTocItemsCount() const { return toc.size(); }
 
 // work out the section index for a toc index
 int Epub::getSpineIndexForTocIndex(const int tocIndex) const {
+  if (tocIndex < 0 || tocIndex >= toc.size()) {
+    Serial.printf("[%lu] [EBP] getSpineIndexForTocIndex: tocIndex %d out of range\n", millis(), tocIndex);
+    return 0;
+  }
+
   // the toc entry should have an href that matches the spine item
   // so we can find the spine index by looking for the href
   for (int i = 0; i < spine.size(); i++) {
@@ -336,6 +341,11 @@ int Epub::getSpineIndexForTocIndex(const int tocIndex) const {
 }
 
 int Epub::getTocIndexForSpineIndex(const int spineIndex) const {
+  if (spineIndex < 0 || spineIndex >= spine.size()) {
+    Serial.printf("[%lu] [EBP] getTocIndexForSpineIndex: spineIndex %d out of range\n", millis(), spineIndex);
+    return -1;
+  }
+
   // the toc entry should have an href that matches the spine item
   // so we can find the toc index by looking for the href
   for (int i = 0; i < toc.size(); i++) {


### PR DESCRIPTION
## Problem
`getSpineIndexForTocIndex()` and `getTocIndexForSpineIndex()` access `toc[tocIndex]` and `spine[spineIndex]` without validating indices are within bounds. Malformed EPUBs or edge cases could trigger out-of-bounds access.

## Fix
Added bounds validation at the start of both functions before accessing the arrays.

## Testing
- Builds successfully with `pio run`
- Affects: `lib/Epub/Epub.cpp`