### PR TITLE
Check SD card initialization and show error on failure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,12 @@ void setup() {
   enterNewActivity(new BootActivity(renderer, inputManager));
 
   // SD Card Initialization
-  SD.begin(SD_SPI_CS, SPI, SPI_FQ);
+  if (!SD.begin(SD_SPI_CS, SPI, SPI_FQ)) {
+    Serial.printf("[%lu] [   ] SD card initialization failed\n", millis());
+    exitActivity();
+    enterNewActivity(new FullScreenMessageActivity(renderer, inputManager, "SD card error", BOLD));
+    return;
+  }
 
   SETTINGS.loadFromFile();
   APP_STATE.loadFromFile();


### PR DESCRIPTION
## Problem
`SD.begin()` return value was ignored. If the SD card fails to initialize, the device continues and crashes when trying to load settings/state.

## Fix
Check return value and display "SD card error" message instead of proceeding with undefined state.

## Testing
- Builds successfully with `pio run`
- Affects: `src/main.cpp`