### PR TITLE
Build out lines when parsing html and holding >750 words in buffer

### DIFF
--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -2,11 +2,11 @@
 
 #include <EpdFontFamily.h>
 
-#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "blocks/TextBlock.h"
 
@@ -18,6 +18,12 @@ class ParsedText {
   TextBlock::BLOCK_STYLE style;
   bool extraParagraphSpacing;
 
+  std::vector<size_t> computeLineBreaks(int pageWidth, int spaceWidth, const std::vector<uint16_t>& wordWidths) const;
+  void extractLine(size_t breakIndex, int pageWidth, int spaceWidth, const std::vector<uint16_t>& wordWidths,
+                   const std::vector<size_t>& lineBreakIndices,
+                   const std::function<void(std::shared_ptr<TextBlock>)>& processLine);
+  std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
+
  public:
   explicit ParsedText(const TextBlock::BLOCK_STYLE style, const bool extraParagraphSpacing)
       : style(style), extraParagraphSpacing(extraParagraphSpacing) {}
@@ -26,7 +32,9 @@ class ParsedText {
   void addWord(std::string word, EpdFontStyle fontStyle);
   void setStyle(const TextBlock::BLOCK_STYLE style) { this->style = style; }
   TextBlock::BLOCK_STYLE getStyle() const { return style; }
+  size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, int horizontalMargin,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine);
+                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -143,6 +143,17 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
 
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }
+
+  // If we have > 750 words buffered up, perform the layout and consume out all but the last line
+  // There should be enough here to build out 1-2 full pages and doing this will free up a lot of
+  // memory.
+  // Spotted when reading Intermezzo, there are some really long text blocks in there.
+  if (self->currentTextBlock->size() > 750) {
+    Serial.printf("[%lu] [EHP] Text block too long, splitting into multiple pages\n", millis());
+    self->currentTextBlock->layoutAndExtractLines(
+        self->renderer, self->fontId, self->marginLeft + self->marginRight,
+        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
+  }
 }
 
 void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* name) {


### PR DESCRIPTION
## Summary

* Build out lines for pages when holding over 750 buffered words
  * Should fix issues with parsing long blocks of text causing memory crashes