### PR TITLE
fix: add NULL checks for frameBuffer in GfxRenderer

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -183,6 +183,10 @@ void GfxRenderer::clearScreen(const uint8_t color) const { einkDisplay.clearScre
 
 void GfxRenderer::invertScreen() const {
   uint8_t* buffer = einkDisplay.getFrameBuffer();
+  if (!buffer) {
+    Serial.printf("[%lu] [GFX] !! No framebuffer in invertScreen\n", millis());
+    return;
+  }
   for (int i = 0; i < EInkDisplay::BUFFER_SIZE; i++) {
     buffer[i] = ~buffer[i];
   }
@@ -256,6 +260,10 @@ void GfxRenderer::freeBwBufferChunks() {
  */
 void GfxRenderer::storeBwBuffer() {
   const uint8_t* frameBuffer = einkDisplay.getFrameBuffer();
+  if (!frameBuffer) {
+    Serial.printf("[%lu] [GFX] !! No framebuffer in storeBwBuffer\n", millis());
+    return;
+  }
 
   // Allocate and copy each chunk
   for (size_t i = 0; i < BW_BUFFER_NUM_CHUNKS; i++) {
@@ -306,6 +314,12 @@ void GfxRenderer::restoreBwBuffer() {
   }
 
   uint8_t* frameBuffer = einkDisplay.getFrameBuffer();
+  if (!frameBuffer) {
+    Serial.printf("[%lu] [GFX] !! No framebuffer in restoreBwBuffer\n", millis());
+    freeBwBufferChunks();
+    return;
+  }
+
   for (size_t i = 0; i < BW_BUFFER_NUM_CHUNKS; i++) {
     // Check if chunk is missing
     if (!bwBufferChunks[i]) {


### PR DESCRIPTION
## Problem
`invertScreen()`, `storeBwBuffer()`, and `restoreBwBuffer()` dereference `frameBuffer` without NULL validation. If the display isn't initialized, these functions will crash.

## Fix
Add NULL checks before using `frameBuffer` in all three functions. Follows the existing pattern from `drawPixel()` (line 11) which already validates the pointer.

Changed `lib/GfxRenderer/GfxRenderer.cpp`.

## Test
- Follows existing validated pattern from `drawPixel()`
- No logic changes - only adds early return on NULL
- Manual device testing appreciated