### PR TITLE
fix: add NULL check after malloc in readFileToMemory()

### DIFF
--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -118,6 +118,11 @@ uint8_t* ZipFile::readFileToMemory(const char* filename, size_t* size, const boo
   const auto inflatedDataSize = static_cast<size_t>(fileStat.m_uncomp_size);
   const auto dataSize = trailingNullByte ? inflatedDataSize + 1 : inflatedDataSize;
   const auto data = static_cast<uint8_t*>(malloc(dataSize));
+  if (data == nullptr) {
+    Serial.printf("[%lu] [ZIP] Failed to allocate memory for output buffer (%zu bytes)\n", millis(), dataSize);
+    fclose(file);
+    return nullptr;
+  }
 
   if (fileStat.m_method == MZ_NO_COMPRESSION) {
     // no deflation, just read content


### PR DESCRIPTION
## Problem
`readFileToMemory()` allocates an output buffer via `malloc()` at line 120 but doesn't check if allocation succeeds. On low memory, the NULL pointer is passed to `fread()` causing a crash.

## Fix
Add NULL check after `malloc()` for the output buffer. Follows the existing pattern already used for `deflatedData` at line 141.

Changed `lib/ZipFile/ZipFile.cpp`.

## Test
- Follows existing validated pattern from same function
- Defensive addition only - no logic changes