### PR TITLE
Paginate book list and avoid out of bounds rendering

### DIFF
--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -5,8 +5,10 @@
 
 #include "config.h"
 
+namespace {
 constexpr int PAGE_ITEMS = 24;
 constexpr int SKIP_PAGE_MS = 700;
+}  // namespace
 
 void EpubReaderChapterSelectionActivity::taskTrampoline(void* param) {
   auto* self = static_cast<EpubReaderChapterSelectionActivity*>(param);


### PR DESCRIPTION
## Summary

* Paginate book list
* Avoid out of bounds rendering of long book titles, truncate with ellipsis instead

## Additional Context

* Should partially help with https://github.com/daveallie/crosspoint-reader/issues/75 as it was previously rendering a lot of content off screen, will need to test with a large directory