### PR TITLE
Fix incorrect justification of last line in paragraph

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -144,7 +144,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   const int spareSpace = pageWidth - lineWordWidthSum;
 
   int spacing = spaceWidth;
-  const bool isLastLine = lineBreak == words.size();
+  const bool isLastLine = breakIndex == lineBreakIndices.size() - 1;
 
   if (style == TextBlock::JUSTIFIED && !isLastLine && lineWordCount >= 2) {
     spacing = spareSpace / (lineWordCount - 1);


### PR DESCRIPTION
## Summary

* Fix incorrect justification of last line in paragraph
* `words` is changing size due to the slice, so `isLastLine` would rarely be right, either removing justification mid-paragraph, or including it in the last line.

## Additional Context

* Introduced in #73 
