### PR TITLE
Feature / Enable CORS for Web API

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -68,7 +68,6 @@ void CrossPointWebServer::begin() {
   // Upload endpoint with special handling for multipart form data
   server->on("/upload", HTTP_ANY, [this] { handleUploadPost(); }, [this] { handleUpload(); });
 
-
   // Create folder endpoint
   server->on("/mkdir", HTTP_POST, [this] { handleCreateFolder(); });
 
@@ -419,7 +418,7 @@ void CrossPointWebServer::handleUploadPost() const {
     }
     return;
   }
-  
+
   server->send(405, "text/plain", "Method Not Allowed");
 }
 
@@ -481,7 +480,6 @@ void CrossPointWebServer::handleDelete() const {
   }
 
   if (server->method() == HTTP_POST) {
-
     // Get path from form data
     if (!server->hasArg("path")) {
       server->send(400, "text/plain", "Missing path");


### PR DESCRIPTION
## Summary

Enable CORS to be able to use API from any web service. It is going to be used by:
https://github.com/gebeto/crosspoint-web-manager

## Additional Context

Currently this Web UI is in development, and there are just some dummy data, but you can use it with your existing device right now, just use link like this, and put your device IP there. But first you need to use this firmware with enabled CORS, otherwise it is not going to work:

https://gebeto.github.io/crosspoint-web-manager/?api_url=http://{YOUR_DEVICE_IP}
