### PR TITLE
Prevent SD card error causing boot loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,6 +158,15 @@ void onGoHome() {
   enterNewActivity(new HomeActivity(renderer, inputManager, onGoToReaderHome, onGoToSettings, onGoToFileTransfer));
 }
 
+void setupDisplayAndFonts() {
+  einkDisplay.begin();
+  Serial.printf("[%lu] [   ] Display initialized\n", millis());
+  renderer.insertFont(READER_FONT_ID, bookerlyFontFamily);
+  renderer.insertFont(UI_FONT_ID, ubuntuFontFamily);
+  renderer.insertFont(SMALL_FONT_ID, smallFontFamily);
+  Serial.printf("[%lu] [   ] Fonts setup\n", millis());
+}
+
 void setup() {
   t1 = millis();
 
@@ -179,6 +188,7 @@ void setup() {
   // SD Card Initialization
   if (!SD.begin(SD_SPI_CS, SPI, SPI_FQ)) {
     Serial.printf("[%lu] [   ] SD card initialization failed\n", millis());
+    setupDisplayAndFonts();
     exitActivity();
     enterNewActivity(new FullScreenMessageActivity(renderer, inputManager, "SD card error", BOLD));
     return;
@@ -189,14 +199,7 @@ void setup() {
   // verify power button press duration after we've read settings.
   verifyWakeupLongPress();
 
-  // Initialize display
-  einkDisplay.begin();
-  Serial.printf("[%lu] [   ] Display initialized\n", millis());
-
-  renderer.insertFont(READER_FONT_ID, bookerlyFontFamily);
-  renderer.insertFont(UI_FONT_ID, ubuntuFontFamily);
-  renderer.insertFont(SMALL_FONT_ID, smallFontFamily);
-  Serial.printf("[%lu] [   ] Fonts setup\n", millis());
+  setupDisplayAndFonts();
 
   exitActivity();
   enterNewActivity(new BootActivity(renderer, inputManager));


### PR DESCRIPTION
## Summary

* Prevent SD card error causing boot loop
  * We need the screen and fonts to be initialized to show the full screen error message
  * Prior to this change, trying to render the font would crash the firmware and boot loop it