### PR TITLE
Optimize glyph lookup with binary search

### DIFF
--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -59,14 +59,28 @@ bool EpdFont::hasPrintableChars(const char* string) const {
 
 const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const {
   const EpdUnicodeInterval* intervals = data->intervals;
-  for (int i = 0; i < data->intervalCount; i++) {
-    const EpdUnicodeInterval* interval = &intervals[i];
-    if (cp >= interval->first && cp <= interval->last) {
+  const int count = data->intervalCount;
+
+  if (count == 0) return nullptr;
+
+  // Binary search for O(log n) lookup instead of O(n)
+  // Critical for Korean fonts with many unicode intervals
+  int left = 0;
+  int right = count - 1;
+
+  while (left <= right) {
+    const int mid = left + (right - left) / 2;
+    const EpdUnicodeInterval* interval = &intervals[mid];
+
+    if (cp < interval->first) {
+      right = mid - 1;
+    } else if (cp > interval->last) {
+      left = mid + 1;
+    } else {
+      // Found: cp >= interval->first && cp <= interval->last
       return &data->glyph[interval->offset + (cp - interval->first)];
     }
-    if (cp < interval->first) {
-      return nullptr;
-    }
   }
+
   return nullptr;
 }


### PR DESCRIPTION
Replace linear O(n) search with binary search O(log n) for unicode interval lookup. Korean fonts have many intervals (~30,000+ glyphs), so this improves text rendering performance during page navigation.

## Summary

* **What is the goal of this PR?** (e.g., Fixes a bug in the user authentication module, Implements the new feature for 
  file uploading.)

Replace linear `O(n)` glyph lookup with binary search `O(log n)` to improve text rendering performance during page navigation.

* **What changes are included?**

- Modified `EpdFont::getGlyph()` to use binary search instead of linear search for unicode interval lookup
- Added early return for empty interval count

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, specific areas to focus on).

- Performance implications: Fonts with many unicode intervals benefit the most. Korean fonts have ~30,000+ glyphs across multiple intervals, but any font with significant glyph coverage (CJK, extended Latin, emoji, etc.) will see improvement.
- Complexity: from `O(n)` to `O(log n)` where n = number of unicode intervals. For fonts with 10+ intervals, this reduces lookup iterations significantly.
- Risk: Low - the binary search logic is straightforward and the intervals are already sorted by unicode codepoint (required for the original early-exit optimization).
