### PR TITLE
fix(parser): remove MAX_LINES limit that truncates long chapters

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -111,16 +111,17 @@ std::vector<size_t> ParsedText::computeLineBreaks(const int pageWidth, const int
   // Stores the index of the word that starts the next line (last_word_index + 1)
   std::vector<size_t> lineBreakIndices;
   size_t currentWordIndex = 0;
-  constexpr size_t MAX_LINES = 1000;
 
   while (currentWordIndex < totalWordCount) {
-    if (lineBreakIndices.size() >= MAX_LINES) {
-      break;
+    size_t nextBreakIndex = ans[currentWordIndex] + 1;
+
+    // Safety check: prevent infinite loop if nextBreakIndex doesn't advance
+    if (nextBreakIndex <= currentWordIndex) {
+      // Force advance by at least one word to avoid infinite loop
+      nextBreakIndex = currentWordIndex + 1;
     }
 
-    size_t nextBreakIndex = ans[currentWordIndex] + 1;
     lineBreakIndices.push_back(nextBreakIndex);
-
     currentWordIndex = nextBreakIndex;
   }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes a bug where text disappears after approximately 25 pages in long chapters during EPUB indexing.

* **What changes are included?**
    - Removed the `MAX_LINES = 1000` hard limit in `ParsedText::computeLineBreaks()`
    - Added safer infinite loop prevention by checking if `nextBreakIndex <= currentWordIndex` and forcing advancement by one word when stuck

## Additional Context

* **Root cause:** The `MAX_LINES = 1000` limit was introduced to prevent infinite loops, but it truncates content in long chapters. For example, a 93KB chapter that generates ~242 pages (~9,680 lines) gets cut off at ~1000 lines, causing blank pages after page 25-27.

* **Solution approach:** Instead of a hard line limit, I now detect when the line break algorithm gets stuck (when `nextBreakIndex` doesn't advance) and force progress by moving one word at a time. This preserves the infinite loop protection while allowing all content to be rendered.

* **Testing:** Verified with a Korean EPUB containing a 93KB chapter - all 242 pages now render correctly without text disappearing.