### PR TITLE
Add 'Open' button hint to File Selection page

### DIFF
--- a/src/activities/reader/FileSelectionActivity.cpp
+++ b/src/activities/reader/FileSelectionActivity.cpp
@@ -162,7 +162,7 @@ void FileSelectionActivity::render() const {
   renderer.drawCenteredText(READER_FONT_ID, 10, "Books", true, BOLD);
 
   // Help text
-  renderer.drawButtonHints(UI_FONT_ID, "« Home", "", "", "");
+  renderer.drawButtonHints(UI_FONT_ID, "« Home", "Open", "", "");
 
   if (files.empty()) {
     renderer.drawText(UI_FONT_ID, 20, 60, "No EPUBs found");


### PR DESCRIPTION
## Summary

In using my build of https://github.com/daveallie/crosspoint-reader/pull/130 I realized that we need a "open" button hint above the second button in the File browser

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, specific areas to focus on).
