### PR TITLE
Use a JSON filter to avoid crashes when checking for updates

### DIFF
--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -27,7 +27,12 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   }
 
   JsonDocument doc;
-  const DeserializationError error = deserializeJson(doc, *client);
+  JsonDocument filter;
+  filter["tag_name"] = true;
+  filter["assets"][0]["name"] = true;
+  filter["assets"][0]["browser_download_url"] = true;
+  filter["assets"][0]["size"] = true;
+  const DeserializationError error = deserializeJson(doc, *client, DeserializationOption::Filter(filter));
   http.end();
   if (error) {
     Serial.printf("[%lu] [OTA] JSON parse failed: %s\n", millis(), error.c_str());


### PR DESCRIPTION
## Summary

* The JSON release data from Github contains the entire release description which can be very large
  * The 0.9.0 release was especially bad
* Use a JSON filter to avoid deserializing anything but the necessary fields

## Additional Context

* https://arduinojson.org/v7/how-to/deserialize-a-very-large-document/#filtering
* Fixes https://github.com/daveallie/crosspoint-reader/issues/124