### PR TITLE
Accept big endian version in XTC files

### DIFF
--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -101,7 +101,9 @@ XtcError XtcParser::readHeader() {
   m_bitDepth = (m_header.magic == XTCH_MAGIC) ? 2 : 1;
 
   // Check version
-  if (m_header.version > 1) {
+  // Currently, version 1 is the only valid version, however some generators are using big endian for the version code
+  // so we also accept version 256 (0x0100)
+  if (m_header.version != 1 && m_header.version != 256) {
     Serial.printf("[%lu] [XTC] Unsupported version: %d\n", millis(), m_header.version);
     return XtcError::INVALID_VERSION;
   }


### PR DESCRIPTION
## Summary

* Accept big endian version in XTC files
  * Recently, two issues (https://github.com/daveallie/crosspoint-reader/issues/157 and https://github.com/daveallie/crosspoint-reader/issues/146) have popped up with XTC files with a big endian encoded version. This is read out as 256.
  * We should be more lax and accept these values.