### PR TITLE
Split XTC file version into major minor bytes

### DIFF
--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -101,10 +101,12 @@ XtcError XtcParser::readHeader() {
   m_bitDepth = (m_header.magic == XTCH_MAGIC) ? 2 : 1;
 
   // Check version
-  // Currently, version 1 is the only valid version, however some generators are using big endian for the version code
-  // so we also accept version 256 (0x0100)
-  if (m_header.version != 1 && m_header.version != 256) {
-    Serial.printf("[%lu] [XTC] Unsupported version: %d\n", millis(), m_header.version);
+  // Currently, version 1.0 is the only valid version, however some generators are swapping the bytes around, so we
+  // accept both 1.0 and 0.1 for compatibility
+  const bool validVersion = m_header.versionMajor == 1 && m_header.versionMinor == 0 ||
+                            m_header.versionMajor == 0 && m_header.versionMinor == 1;
+  if (!validVersion) {
+    Serial.printf("[%lu] [XTC] Unsupported version: %u.%u\n", millis(), m_header.versionMajor, m_header.versionMinor);
     return XtcError::INVALID_VERSION;
   }
 
@@ -113,8 +115,9 @@ XtcError XtcParser::readHeader() {
     return XtcError::CORRUPTED_HEADER;
   }
 
-  Serial.printf("[%lu] [XTC] Header: magic=0x%08X (%s), ver=%u, pages=%u, bitDepth=%u\n", millis(), m_header.magic,
-                (m_header.magic == XTCH_MAGIC) ? "XTCH" : "XTC", m_header.version, m_header.pageCount, m_bitDepth);
+  Serial.printf("[%lu] [XTC] Header: magic=0x%08X (%s), ver=%u.%u, pages=%u, bitDepth=%u\n", millis(), m_header.magic,
+                (m_header.magic == XTCH_MAGIC) ? "XTCH" : "XTC", m_header.versionMajor, m_header.versionMinor,
+                m_header.pageCount, m_bitDepth);
 
   return XtcError::OK;
 }

--- a/lib/Xtc/Xtc/XtcTypes.h
+++ b/lib/Xtc/Xtc/XtcTypes.h
@@ -35,7 +35,8 @@ constexpr uint16_t DISPLAY_HEIGHT = 800;
 #pragma pack(push, 1)
 struct XtcHeader {
   uint32_t magic;            // 0x00: Magic number "XTC\0" (0x00435458)
-  uint16_t version;          // 0x04: Format version (typically 1)
+  uint8_t versionMajor;      // 0x04: Format version major (typically 1) (together with minor = 1.0)
+  uint8_t versionMinor;      // 0x05: Format version minor (typically 0)
   uint16_t pageCount;        // 0x06: Total page count
   uint32_t flags;            // 0x08: Flags/reserved
   uint32_t headerSize;       // 0x0C: Size of header section (typically 88)


### PR DESCRIPTION
## Summary

* Split XTC file version into major minor bytes
  * Continue to support both 1.0 and 0.1

## Additional Context

* See https://github.com/daveallie/crosspoint-reader/issues/146#issuecomment-3698223951 for more detail

FYI @treetrum @eunchurn