### PR TITLE
Parse the author name from content.opf file

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -72,8 +72,7 @@ bool Epub::parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata) {
 
   // Grab data from opfParser into epub
   bookMetadata.title = opfParser.title;
-  // TODO: Parse author
-  bookMetadata.author = "";
+  bookMetadata.author = opfParser.author;
   bookMetadata.coverItemHref = opfParser.coverItemHref;
 
   if (!opfParser.tocNcxPath.empty()) {
@@ -251,6 +250,15 @@ const std::string& Epub::getTitle() const {
   }
 
   return bookMetadataCache->coreMetadata.title;
+}
+
+const std::string& Epub::getAuthor() const {
+  static std::string blank;
+  if (!bookMetadataCache || !bookMetadataCache->isLoaded()) {
+    return blank;
+  }
+
+  return bookMetadataCache->coreMetadata.author;
 }
 
 std::string Epub::getCoverBmpPath() const { return cachePath + "/cover.bmp"; }

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -40,6 +40,7 @@ class Epub {
   const std::string& getCachePath() const;
   const std::string& getPath() const;
   const std::string& getTitle() const;
+  const std::string& getAuthor() const;
   std::string getCoverBmpPath() const;
   bool generateCoverBmp() const;
   uint8_t* readItemContentsToBytes(const std::string& itemHref, size_t* size = nullptr,

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -102,6 +102,11 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     return;
   }
 
+  if (self->state == IN_METADATA && strcmp(name, "dc:creator") == 0) {
+    self->state = IN_BOOK_AUTHOR;
+    return;
+  }
+
   if (self->state == IN_PACKAGE && (strcmp(name, "manifest") == 0 || strcmp(name, "opf:manifest") == 0)) {
     self->state = IN_MANIFEST;
     if (!SdMan.openFileForWrite("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
@@ -209,6 +214,11 @@ void XMLCALL ContentOpfParser::characterData(void* userData, const XML_Char* s, 
     self->title.append(s, len);
     return;
   }
+
+  if (self->state == IN_BOOK_AUTHOR) {
+    self->author.append(s, len);
+    return;
+  }
 }
 
 void XMLCALL ContentOpfParser::endElement(void* userData, const XML_Char* name) {
@@ -228,6 +238,11 @@ void XMLCALL ContentOpfParser::endElement(void* userData, const XML_Char* name) 
   }
 
   if (self->state == IN_BOOK_TITLE && strcmp(name, "dc:title") == 0) {
+    self->state = IN_METADATA;
+    return;
+  }
+
+  if (self->state == IN_BOOK_AUTHOR && strcmp(name, "dc:creator") == 0) {
     self->state = IN_METADATA;
     return;
   }

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -12,6 +12,7 @@ class ContentOpfParser final : public Print {
     IN_PACKAGE,
     IN_METADATA,
     IN_BOOK_TITLE,
+    IN_BOOK_AUTHOR,
     IN_MANIFEST,
     IN_SPINE,
   };
@@ -31,6 +32,7 @@ class ContentOpfParser final : public Print {
 
  public:
   std::string title;
+  std::string author;
   std::string tocNcxPath;
   std::string coverItemHref;
 


### PR DESCRIPTION
## Summary

* Parse the author name from content.opf file
  * Listed in the dc:creator tag within the metadata section