### PR TITLE
Add button mapping for Left, Back, Confirm, Right

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -31,7 +31,7 @@ class CrossPointSettings {
   // Front button layout options
   // Default: Back, Confirm, Left, Right
   // Swapped: Left, Right, Back, Confirm
-  enum FRONT_BUTTON_LAYOUT { BACK_CONFIRM_LEFT_RIGHT = 0, LEFT_RIGHT_BACK_CONFIRM = 1 };
+  enum FRONT_BUTTON_LAYOUT { BACK_CONFIRM_LEFT_RIGHT = 0, LEFT_RIGHT_BACK_CONFIRM = 1, LEFT_BACK_CONFIRM_RIGHT = 2 };
 
   // Side button layout options
   // Default: Previous, Next

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -11,6 +11,8 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
       switch (frontLayout) {
         case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
           return InputManager::BTN_LEFT;
+        case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
+          return InputManager::BTN_CONFIRM;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
         default:
           return InputManager::BTN_BACK;
@@ -19,6 +21,8 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
       switch (frontLayout) {
         case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
           return InputManager::BTN_RIGHT;
+        case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
+          return InputManager::BTN_LEFT;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
         default:
           return InputManager::BTN_CONFIRM;
@@ -26,6 +30,7 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
     case Button::Left:
       switch (frontLayout) {
         case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
+        case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
           return InputManager::BTN_BACK;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
         default:
@@ -36,6 +41,7 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
         case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
           return InputManager::BTN_CONFIRM;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
+        case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
         default:
           return InputManager::BTN_RIGHT;
       }
@@ -85,6 +91,8 @@ MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const
   switch (layout) {
     case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
       return {previous, next, back, confirm};
+    case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
+      return {previous, back, confirm, next};
     case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
     default:
       return {back, confirm, previous, next};

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -23,7 +23,7 @@ const SettingInfo settingsList[settingsCount] = {
     {"Front Button Layout",
      SettingType::ENUM,
      &CrossPointSettings::frontButtonLayout,
-     {"Bck, Cnfrm, Lft, Rght", "Lft, Rght, Bck, Cnfrm"}},
+     {"Bck, Cnfrm, Lft, Rght", "Lft, Rght, Bck, Cnfrm", "Lft, Bck, Cnfrm, Rght"}},
     {"Side Button Layout (reader)",
      SettingType::ENUM,
      &CrossPointSettings::sideButtonLayout,
@@ -171,11 +171,6 @@ void SettingsActivity::render() const {
   // Draw all settings
   for (int i = 0; i < settingsCount; i++) {
     const int settingY = 60 + i * 30;  // 30 pixels between settings
-
-    // Draw selection indicator for the selected setting
-    if (i == selectedSettingIndex) {
-      renderer.drawText(UI_10_FONT_ID, 5, settingY, ">");
-    }
 
     // Draw setting name
     renderer.drawText(UI_10_FONT_ID, 20, settingY, settingsList[i].name, i != selectedSettingIndex);


### PR DESCRIPTION
## Summary

* Add button mapping for Left, Back, Confirm, Right for front buttons

## Additional Context

* Asked for in https://github.com/daveallie/crosspoint-reader/discussions/78#discussioncomment-15375326
