### PR TITLE
Move home screen battery indicator to avoid clashing with button hints

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -316,7 +316,7 @@ void HomeActivity::render() const {
   const auto labels = mappedInput.mapLabels("", "Confirm", "Up", "Down");
   renderer.drawButtonHints(UI_10_FONT_ID, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
-  ScreenComponents::drawBattery(renderer, 20, pageHeight - 30);
+  ScreenComponents::drawBattery(renderer, 20, pageHeight - 70);
 
   renderer.displayBuffer();
 }


### PR DESCRIPTION
## Summary

* Move home screen battery indicator to avoid clashing with button hints
  * Default button mapping was fine, but others clashes with the indicator