### PR TITLE
Fix file browser navigation for non-ASCII folder names

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,8 @@ build_flags =
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
   -std=c++2a
+# Enable UTF-8 long file names in SdFat
+  -DUSE_UTF8_LONG_NAMES=1
 
 ; Board configuration
 board_build.flash_mode = dio

--- a/src/activities/reader/FileSelectionActivity.cpp
+++ b/src/activities/reader/FileSelectionActivity.cpp
@@ -30,7 +30,15 @@ void FileSelectionActivity::taskTrampoline(void* param) {
 void FileSelectionActivity::loadFiles() {
   files.clear();
   selectorIndex = 0;
+
   auto root = SdMan.open(basepath.c_str());
+  if (!root || !root.isDirectory()) {
+    if (root) root.close();
+    return;
+  }
+
+  root.rewindDirectory();
+
   char name[128];
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
     file.getName(name, sizeof(name));


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Fix file browser failing to navigate into subdirectories with non-ASCII (Korean/Unicode) folder names.

* **What changes are included?**

- Enable UTF-8 long file names in SdFat (`USE_UTF8_LONG_NAMES=1`)
- Add directory validation before iterating files
- Add `rewindDirectory()` call for stability

## Additional Context
