### PR TITLE
Hide "System Volume Information" folder

### DIFF
--- a/src/activities/reader/FileSelectionActivity.cpp
+++ b/src/activities/reader/FileSelectionActivity.cpp
@@ -42,7 +42,7 @@ void FileSelectionActivity::loadFiles() {
   char name[128];
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
     file.getName(name, sizeof(name));
-    if (name[0] == '.') {
+    if (name[0] == '.' || strcmp(name, "System Volume Information") == 0) {
       file.close();
       continue;
     }


### PR DESCRIPTION
## Summary

* Hide "System Volume Information" folder
* It's a FAT filesystem folder, shouldn't be used

## Additional Context

* Fixes https://github.com/daveallie/crosspoint-reader/issues/177
