### PR TITLE
Add EPUB 3 nav.xhtml TOC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project is **not affiliated with Xteink**; it's built as a community projec
 
 ## Features & Usage
 
-- [x] EPUB parsing and rendering
+- [x] EPUB parsing and rendering (EPUB 2 and EPUB 3)
 - [ ] Image support within EPUB
 - [x] Saved reading position
 - [x] File explorer with file picker

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -12,8 +12,10 @@
 class ZipFile;
 
 class Epub {
-  // the ncx file
+  // the ncx file (EPUB 2)
   std::string tocNcxItem;
+  // the nav file (EPUB 3)
+  std::string tocNavItem;
   // where is the EPUBfile?
   std::string filepath;
   // the base path for items in the EPUB file
@@ -26,6 +28,7 @@ class Epub {
   bool findContentOpfFile(std::string* contentOpfFile) const;
   bool parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata);
   bool parseTocNcxFile() const;
+  bool parseTocNavFile() const;
 
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -161,6 +161,7 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     std::string itemId;
     std::string href;
     std::string mediaType;
+    std::string properties;
 
     for (int i = 0; atts[i]; i += 2) {
       if (strcmp(atts[i], "id") == 0) {
@@ -169,6 +170,8 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
         href = self->baseContentPath + atts[i + 1];
       } else if (strcmp(atts[i], "media-type") == 0) {
         mediaType = atts[i + 1];
+      } else if (strcmp(atts[i], "properties") == 0) {
+        properties = atts[i + 1];
       }
     }
 
@@ -186,6 +189,15 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
       } else {
         Serial.printf("[%lu] [COF] Warning: Multiple NCX files found in manifest. Ignoring duplicate: %s\n", millis(),
                       href.c_str());
+      }
+    }
+
+    // EPUB 3: Check for nav document (properties contains "nav")
+    if (!properties.empty() && self->tocNavPath.empty()) {
+      // Properties is space-separated, check if "nav" is present as a word
+      if (properties == "nav" || properties.find("nav ") == 0 || properties.find(" nav") != std::string::npos) {
+        self->tocNavPath = href;
+        Serial.printf("[%lu] [COF] Found EPUB 3 nav document: %s\n", millis(), href.c_str());
       }
     }
     return;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -35,6 +35,7 @@ class ContentOpfParser final : public Print {
   std::string title;
   std::string author;
   std::string tocNcxPath;
+  std::string tocNavPath;  // EPUB 3 nav document path
   std::string coverItemHref;
   std::string textReferenceHref;
 

--- a/lib/Epub/Epub/parsers/TocNavParser.cpp
+++ b/lib/Epub/Epub/parsers/TocNavParser.cpp
@@ -1,0 +1,184 @@
+#include "TocNavParser.h"
+
+#include <HardwareSerial.h>
+
+#include "../BookMetadataCache.h"
+
+bool TocNavParser::setup() {
+  parser = XML_ParserCreate(nullptr);
+  if (!parser) {
+    Serial.printf("[%lu] [NAV] Couldn't allocate memory for parser\n", millis());
+    return false;
+  }
+
+  XML_SetUserData(parser, this);
+  XML_SetElementHandler(parser, startElement, endElement);
+  XML_SetCharacterDataHandler(parser, characterData);
+  return true;
+}
+
+TocNavParser::~TocNavParser() {
+  if (parser) {
+    XML_StopParser(parser, XML_FALSE);
+    XML_SetElementHandler(parser, nullptr, nullptr);
+    XML_SetCharacterDataHandler(parser, nullptr);
+    XML_ParserFree(parser);
+    parser = nullptr;
+  }
+}
+
+size_t TocNavParser::write(const uint8_t data) { return write(&data, 1); }
+
+size_t TocNavParser::write(const uint8_t* buffer, const size_t size) {
+  if (!parser) return 0;
+
+  const uint8_t* currentBufferPos = buffer;
+  auto remainingInBuffer = size;
+
+  while (remainingInBuffer > 0) {
+    void* const buf = XML_GetBuffer(parser, 1024);
+    if (!buf) {
+      Serial.printf("[%lu] [NAV] Couldn't allocate memory for buffer\n", millis());
+      XML_StopParser(parser, XML_FALSE);
+      XML_SetElementHandler(parser, nullptr, nullptr);
+      XML_SetCharacterDataHandler(parser, nullptr);
+      XML_ParserFree(parser);
+      parser = nullptr;
+      return 0;
+    }
+
+    const auto toRead = remainingInBuffer < 1024 ? remainingInBuffer : 1024;
+    memcpy(buf, currentBufferPos, toRead);
+
+    if (XML_ParseBuffer(parser, static_cast<int>(toRead), remainingSize == toRead) == XML_STATUS_ERROR) {
+      Serial.printf("[%lu] [NAV] Parse error at line %lu: %s\n", millis(), XML_GetCurrentLineNumber(parser),
+                    XML_ErrorString(XML_GetErrorCode(parser)));
+      XML_StopParser(parser, XML_FALSE);
+      XML_SetElementHandler(parser, nullptr, nullptr);
+      XML_SetCharacterDataHandler(parser, nullptr);
+      XML_ParserFree(parser);
+      parser = nullptr;
+      return 0;
+    }
+
+    currentBufferPos += toRead;
+    remainingInBuffer -= toRead;
+    remainingSize -= toRead;
+  }
+  return size;
+}
+
+void XMLCALL TocNavParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
+  auto* self = static_cast<TocNavParser*>(userData);
+
+  // Track HTML structure loosely - we mainly care about finding <nav epub:type="toc">
+  if (strcmp(name, "html") == 0) {
+    self->state = IN_HTML;
+    return;
+  }
+
+  if (self->state == IN_HTML && strcmp(name, "body") == 0) {
+    self->state = IN_BODY;
+    return;
+  }
+
+  // Look for <nav epub:type="toc"> anywhere in body (or nested elements)
+  if (self->state >= IN_BODY && strcmp(name, "nav") == 0) {
+    for (int i = 0; atts[i]; i += 2) {
+      if ((strcmp(atts[i], "epub:type") == 0 || strcmp(atts[i], "type") == 0) && strcmp(atts[i + 1], "toc") == 0) {
+        self->state = IN_NAV_TOC;
+        Serial.printf("[%lu] [NAV] Found nav toc element\n", millis());
+        return;
+      }
+    }
+    return;
+  }
+
+  // Only process ol/li/a if we're inside the toc nav
+  if (self->state < IN_NAV_TOC) {
+    return;
+  }
+
+  if (strcmp(name, "ol") == 0) {
+    self->olDepth++;
+    self->state = IN_OL;
+    return;
+  }
+
+  if (self->state == IN_OL && strcmp(name, "li") == 0) {
+    self->state = IN_LI;
+    self->currentLabel.clear();
+    self->currentHref.clear();
+    return;
+  }
+
+  if (self->state == IN_LI && strcmp(name, "a") == 0) {
+    self->state = IN_ANCHOR;
+    // Get href attribute
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "href") == 0) {
+        self->currentHref = atts[i + 1];
+        break;
+      }
+    }
+    return;
+  }
+}
+
+void XMLCALL TocNavParser::characterData(void* userData, const XML_Char* s, const int len) {
+  auto* self = static_cast<TocNavParser*>(userData);
+
+  // Only collect text when inside an anchor within the TOC nav
+  if (self->state == IN_ANCHOR) {
+    self->currentLabel.append(s, len);
+  }
+}
+
+void XMLCALL TocNavParser::endElement(void* userData, const XML_Char* name) {
+  auto* self = static_cast<TocNavParser*>(userData);
+
+  if (strcmp(name, "a") == 0 && self->state == IN_ANCHOR) {
+    // Create TOC entry when closing anchor tag (we have all data now)
+    if (!self->currentLabel.empty() && !self->currentHref.empty()) {
+      std::string href = self->baseContentPath + self->currentHref;
+      std::string anchor;
+
+      const size_t pos = href.find('#');
+      if (pos != std::string::npos) {
+        anchor = href.substr(pos + 1);
+        href = href.substr(0, pos);
+      }
+
+      if (self->cache) {
+        // olDepth gives us the nesting level (1-based from the outer ol)
+        self->cache->createTocEntry(self->currentLabel, href, anchor, self->olDepth);
+      }
+
+      self->currentLabel.clear();
+      self->currentHref.clear();
+    }
+    self->state = IN_LI;
+    return;
+  }
+
+  if (strcmp(name, "li") == 0 && (self->state == IN_LI || self->state == IN_OL)) {
+    self->state = IN_OL;
+    return;
+  }
+
+  if (strcmp(name, "ol") == 0 && self->state >= IN_NAV_TOC) {
+    self->olDepth--;
+    if (self->olDepth == 0) {
+      self->state = IN_NAV_TOC;
+    } else {
+      self->state = IN_LI;  // Back to parent li
+    }
+    return;
+  }
+
+  if (strcmp(name, "nav") == 0 && self->state >= IN_NAV_TOC) {
+    self->state = IN_BODY;
+    Serial.printf("[%lu] [NAV] Finished parsing nav toc\n", millis());
+    return;
+  }
+}

--- a/lib/Epub/Epub/parsers/TocNavParser.h
+++ b/lib/Epub/Epub/parsers/TocNavParser.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <Print.h>
+#include <expat.h>
+
+#include <string>
+
+class BookMetadataCache;
+
+// Parser for EPUB 3 nav.xhtml navigation documents
+// Parses HTML5 nav elements with epub:type="toc" to extract table of contents
+class TocNavParser final : public Print {
+  enum ParserState {
+    START,
+    IN_HTML,
+    IN_BODY,
+    IN_NAV_TOC,  // Inside <nav epub:type="toc">
+    IN_OL,       // Inside <ol>
+    IN_LI,       // Inside <li>
+    IN_ANCHOR,   // Inside <a>
+  };
+
+  const std::string& baseContentPath;
+  size_t remainingSize;
+  XML_Parser parser = nullptr;
+  ParserState state = START;
+  BookMetadataCache* cache;
+
+  // Track nesting depth for <ol> elements to determine TOC depth
+  uint8_t olDepth = 0;
+  // Current entry data being collected
+  std::string currentLabel;
+  std::string currentHref;
+
+  static void startElement(void* userData, const XML_Char* name, const XML_Char** atts);
+  static void characterData(void* userData, const XML_Char* s, int len);
+  static void endElement(void* userData, const XML_Char* name);
+
+ public:
+  explicit TocNavParser(const std::string& baseContentPath, const size_t xmlSize, BookMetadataCache* cache)
+      : baseContentPath(baseContentPath), remainingSize(xmlSize), cache(cache) {}
+  ~TocNavParser() override;
+
+  bool setup();
+
+  size_t write(uint8_t) override;
+  size_t write(const uint8_t* buffer, size_t size) override;
+};


### PR DESCRIPTION
## Summary

  * **What is the goal of this PR?** Add EPUB 3 support by implementing native navigation document (nav.xhtml) parsing with NCX fallback, addressing issue Fixes: #143.

  * **What changes are included?**
    - New `TocNavParser` for parsing EPUB 3 HTML5 navigation documents (`<nav epub:type="toc">`)
    - Detection of nav documents via `properties="nav"` attribute in OPF manifest
    - Fallback logic: try EPUB 3 nav first, fall back to NCX (EPUB 2) if unavailable
    - Graceful degradation: books without any TOC now load with a warning instead of failing

  ## Additional Context

  * The implementation follows the existing streaming XML parser pattern using Expat to minimize RAM usage on the ESP32-C3
  * EPUB 3 books that include both nav.xhtml and toc.ncx will prefer the nav document (per EPUB 3 spec recommendation)
  * No breaking changes - existing EPUB 2 books continue to work as before
  * Tested on examples from https://idpf.github.io/epub3-samples/30/samples.html
