### PR TITLE
Add support for uploading multiple epubs

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -869,6 +869,8 @@ function uploadFile() {
     formData.append('file', file);
 
     const xhr = new XMLHttpRequest();
+    // Include path as query parameter since multipart form data doesn't make
+    // form fields available until after file upload completes
     xhr.open('POST', '/upload?path=' + encodeURIComponent(currentPath), true);
 
     progressFill.style.width = '0%';


### PR DESCRIPTION
Upload multiple files at once in sequence. Add retry button for files that fail

## Summary

* **What is the goal of this PR?**
Add support for selecting multiple epub files in one go, before uploading them all to the device
* **What changes are included?**
Allow multiple selections to be submitted to the input field.
Sends each file to the device one by one in a loop
Adds retry logic and UI for easy re-trying of failed uploads

Addresses #201 


button now says "Choose Files", and shows the number of files you selected
<img width="506" height="199" alt="image" src="https://github.com/user-attachments/assets/64b0b921-1e67-438e-9cd7-57d5466f2456" />

Shows which file is uploading:
<img width="521" height="283" alt="image" src="https://github.com/user-attachments/assets/17b4d349-0698-4712-984c-b72fcdcb0918" />

Failed upload dialog:
<img width="851" height="441" alt="image" src="https://github.com/user-attachments/assets/e8bf4aa6-d3d2-4c0b-9c7a-420e8c413033" />
<img width="834" height="641" alt="image" src="https://github.com/user-attachments/assets/656a9732-3963-4844-94e3-4d8736f6d9d5" />