### PR TITLE
Prevent device sleep during WiFi file transfer and OTA updates

### DIFF
--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -22,4 +22,5 @@ class Activity {
   virtual void onExit() { Serial.printf("[%lu] [ACT] Exiting activity: %s\n", millis(), name.c_str()); }
   virtual void loop() {}
   virtual bool skipLoopDelay() { return false; }
+  virtual bool preventAutoSleep() { return false; }
 };

--- a/src/activities/network/CrossPointWebServerActivity.h
+++ b/src/activities/network/CrossPointWebServerActivity.h
@@ -70,4 +70,5 @@ class CrossPointWebServerActivity final : public ActivityWithSubactivity {
   void onExit() override;
   void loop() override;
   bool skipLoopDelay() override { return webServer && webServer->isRunning(); }
+  bool preventAutoSleep() override { return webServer && webServer->isRunning(); }
 };

--- a/src/activities/settings/OtaUpdateActivity.h
+++ b/src/activities/settings/OtaUpdateActivity.h
@@ -41,4 +41,5 @@ class OtaUpdateActivity : public ActivityWithSubactivity {
   void onEnter() override;
   void onExit() override;
   void loop() override;
+  bool preventAutoSleep() override { return state == CHECKING_FOR_UPDATE || state == UPDATE_IN_PROGRESS; }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,9 +316,10 @@ void loop() {
     lastMemPrint = millis();
   }
 
-  // Check for any user activity (button press or release)
+  // Check for any user activity (button press or release) or active background work
   static unsigned long lastActivityTime = millis();
-  if (inputManager.wasAnyPressed() || inputManager.wasAnyReleased()) {
+  if (inputManager.wasAnyPressed() || inputManager.wasAnyReleased() ||
+      (currentActivity && currentActivity->preventAutoSleep())) {
     lastActivityTime = millis();  // Reset inactivity timer
   }
 


### PR DESCRIPTION
## Summary

  * **What is the goal of this PR?** Fixes #199 - Device falls asleep during WiFi file transfer after 10 minutes of inactivity, disconnecting the web server.

  * **What changes are included?**
    - Add `preventAutoSleep()` virtual method to `Activity` base class
    - Modify main loop to reset inactivity timer when `preventAutoSleep()` returns true
    - Override `preventAutoSleep()` in `CrossPointWebServerActivity` (returns true when web server running)
    - Override `preventAutoSleep()` in `OtaUpdateActivity` (returns true during update check/download)

  ## Additional Context

  * The existing `skipLoopDelay()` method controls loop timing (yield vs delay) for HTTP responsiveness. The new `preventAutoSleep()` method is semantically separate - it explicitly signals that an activity should keep the device awake.
  * `CrossPointWebServerActivity` uses both methods: `skipLoopDelay()` for responsive HTTP handling, `preventAutoSleep()` for staying awake.
  * `OtaUpdateActivity` only needs `preventAutoSleep()` since the OTA library handles HTTP internally.