### PR TITLE
Fix race condition with keyboard and Wifi entry

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -447,7 +447,16 @@ std::string WifiSelectionActivity::getSignalStrengthIndicator(const int32_t rssi
 
 void WifiSelectionActivity::displayTaskLoop() {
   while (true) {
+    // If a subactivity is active, yield CPU time but don't render
     if (subActivity) {
+      vTaskDelay(10 / portTICK_PERIOD_MS);
+      continue;
+    }
+
+    // Don't render if we're in PASSWORD_ENTRY state - we're just transitioning
+    // from the keyboard subactivity back to the main activity
+    if (state == WifiSelectionState::PASSWORD_ENTRY) {
+      vTaskDelay(10 / portTICK_PERIOD_MS);
       continue;
     }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes a bug - https://github.com/daveallie/crosspoint-reader/issues/187 - where the screen would freeze after entering a WiFi password, causing the device to appear hung.

* **What changes are included?**
  - Fixed a race condition in `WifiSelectionActivity::displayTaskLoop()` that caused rendering of an empty screen when transitioning from the keyboard subactivity
  - Added `vTaskDelay()` when a subactivity is active to prevent CPU starvation from a tight `continue` loop
  - Added a check to skip rendering when in `PASSWORD_ENTRY` state, allowing the state machine to properly transition to `CONNECTING` before the display updates

## Additional Context

* **Root cause:** When the keyboard subactivity exited after password entry, the display task would wake up and attempt to render. However, the `state` was still `PASSWORD_ENTRY` (before `attemptConnection()` changed it to `CONNECTING`), and since there was no render case for `PASSWORD_ENTRY`, the display would show a cleared/empty buffer, appearing frozen.

* **Performance implications:** The added `vTaskDelay(10)` calls when subactivity is active or in `PASSWORD_ENTRY` state actually improve performance by preventing CPU starvation - previously the display task would spin in a tight loop with `continue` while a subactivity was present.

* **Testing focus:** Test the full WiFi connection flow:
  1. Enter network selection
  2. Select a network requiring a password
  3. Enter password and press OK
  4. Verify "Connecting..." screen appears
  5. Verify connection completes and prompts to save password