### PR TITLE
Refactor semantic version comparison for OTA updates

### DIFF
--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -23,8 +23,8 @@ class OtaUpdater {
   size_t totalSize = 0;
 
   OtaUpdater() = default;
-  bool isUpdateNewer();
-  const std::string& getLatestVersion();
+  bool isUpdateNewer() const;
+  const std::string& getLatestVersion() const;
   OtaUpdaterError checkForUpdate();
   OtaUpdaterError installUpdate(const std::function<void(size_t, size_t)>& onProgress);
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Fixes a bug in the user authentication module, Implements the new feature for 
  file uploading.)

This PR refactors the semantic version comparison logic used during OTA update checks.

Memory stats before : 
RAM:   [===       ]  30.8% (used 101068 bytes from 327680 bytes)
Flash: [========= ]  85.7% (used **5617830** bytes from 6553600 bytes)

Memory stats before : 
RAM:   [===       ]  30.8% (used 101068 bytes from 327680 bytes)
Flash: [========= ]  85.7% (used **5616870** bytes from 6553600 bytes)


* **What changes are included?**

Replaced std::string::substr() and std::stoi() based parsing with a lightweight, heap-free approach.
Version parsing is now done in a single pass without creating temporary std::string objects.
Behavior remains identical: versions are still compared as MAJOR.MINOR.PATCH.

## Additional Context

`std::string::substr() ` creates a new string and performs heap allocation

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, specific areas to focus on).
