### PR TITLE
Remove authentication type from hotspot QR code

### DIFF
--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -381,7 +381,7 @@ void CrossPointWebServerActivity::renderServerRunning() const {
     renderer.drawCenteredText(SMALL_FONT_ID, startY + LINE_SPACING * 3,
                               "or scan QR code with your phone to connect to Wifi.");
     // Show QR code for URL
-    std::string wifiConfig = std::string("WIFI:T:WPA;S:") + connectedSSID + ";P:" + "" + ";;";
+    const std::string wifiConfig = std::string("WIFI:S:") + connectedSSID + ";;";
     drawQRCode(renderer, (480 - 6 * 33) / 2, startY + LINE_SPACING * 4, wifiConfig);
 
     startY += 6 * 29 + 3 * LINE_SPACING;


### PR DESCRIPTION
## Summary

* Remove the `T` parameter (authentication type), and `P` parameter (password) for the SoftAP wifi config QR code

## Additional Context

* It is optional according to the spec: https://www.wi-fi.org/system/files/WPA3%20Specification%20v3.2.pdf#page=25 so should either be omitted or set to nopass
* Fixes https://github.com/daveallie/crosspoint-reader/issues/229