### PR TITLE
Fix scrolling wrap-around in settings menu

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -114,11 +114,9 @@ void SettingsActivity::loop() {
     updateRequired = true;
   } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
              mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    // Move selection down
-    if (selectedSettingIndex < settingsCount - 1) {
-      selectedSettingIndex++;
-      updateRequired = true;
-    }
+    // Move selection down (with wrap around)
+    selectedSettingIndex = (selectedSettingIndex < settingsCount - 1) ? (selectedSettingIndex + 1) : 0;
+    updateRequired = true;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug in the settings menu, where previously wrap-around only worked when scrolling upwards. Now, scrolling downwards on the last list element wraps around to the top as expected. 

Resolves #236.
