### PR TITLE
add per book reading time tracking and display on home screen

### DIFF
--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -14,6 +14,7 @@ class HomeActivity final : public Activity {
   bool updateRequired = false;
   bool hasContinueReading = false;
   bool hasOpdsUrl = false;
+  uint32_t lastBookSeconds = 0;
   std::string lastBookTitle;
   std::string lastBookAuthor;
   const std::function<void()> onContinueReading;
@@ -26,6 +27,8 @@ class HomeActivity final : public Activity {
   [[noreturn]] void displayTaskLoop();
   void render() const;
   int getMenuItemCount() const;
+  void loadReadingTime();
+  static std::string formatDuration(uint32_t seconds);
 
  public:
   explicit HomeActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -16,6 +16,8 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   int nextPageNumber = 0;
   int pagesUntilFullRefresh = 0;
   bool updateRequired = false;
+  unsigned long lastPageInteractionMs = 0;
+  uint32_t currentBookSeconds = 0;
   const std::function<void()> onGoBack;
   const std::function<void()> onGoHome;
 
@@ -25,6 +27,9 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,
                       int orientedMarginBottom, int orientedMarginLeft);
   void renderStatusBar(int orientedMarginRight, int orientedMarginBottom, int orientedMarginLeft) const;
+  void recordReadingTimeDelta();
+  void loadReadingStats();
+  void persistReadingStats() const;
 
  public:
   explicit EpubReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Epub> epub,


### PR DESCRIPTION
## Summary

 What is the goal of this PR? 
- Add per-book reading-time tracking and surface the total read time on the home “Continue Reading” card; persist stats in a user-accessible file.

What changes are included? 
- Track time between page turns (>=1s and <= sleep timeout), 
- persist per-book seconds to /ReadingStats.csv on SD, 
- load totals on enter, 
- log before exits (Back/home/chapter picker), 
- render the formatted total read time on the home card beneath title/author.

## Additional Context:
- Format is simple CSV `bookPath, seconds` (saved in /ReadingStats.csv), should be easy for anyone to parse. 
- doesn't add any time when auto-sleep is triggered 
- currently only implemented for the epub reader

## Screenshot
Read time on homescreen (mostly implemented for debugging purposes, could also be removed or moved somewhere else):
<img width="814" height="1085" alt="image" src="https://github.com/user-attachments/assets/ad5b92cc-4583-4b94-85fc-a24027184281" />

## Status
- builds and tested on device, ready for review