### PR TITLE
fix: Wi-Fi Selection on Calibre Library launch

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -79,10 +79,10 @@ void OpdsBookBrowserActivity::loop() {
       if (WiFi.status() == WL_CONNECTED && WiFi.localIP() != IPAddress(0, 0, 0, 0)) {
         // WiFi connected - just retry fetching the feed
         Serial.printf("[%lu] [OPDS] Retry: WiFi connected, retrying fetch\n", millis());
-      state = BrowserState::LOADING;
-      statusMessage = "Loading...";
-      updateRequired = true;
-      fetchFeed(currentPath);
+        state = BrowserState::LOADING;
+        statusMessage = "Loading...";
+        updateRequired = true;
+        fetchFeed(currentPath);
       } else {
         // WiFi not connected - launch WiFi selection
         Serial.printf("[%lu] [OPDS] Retry: WiFi not connected, launching selection\n", millis());
@@ -382,9 +382,8 @@ void OpdsBookBrowserActivity::launchWifiSelection() {
   state = BrowserState::WIFI_SELECTION;
   updateRequired = true;
 
-  enterNewActivity(new WifiSelectionActivity(renderer, mappedInput, [this](const bool connected) {
-    onWifiSelectionComplete(connected);
-  }));
+  enterNewActivity(new WifiSelectionActivity(renderer, mappedInput,
+                                             [this](const bool connected) { onWifiSelectionComplete(connected); }));
 }
 
 void OpdsBookBrowserActivity::onWifiSelectionComplete(const bool connected) {

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -18,12 +18,12 @@
 class OpdsBookBrowserActivity final : public ActivityWithSubactivity {
  public:
   enum class BrowserState {
-    CHECK_WIFI,       // Checking WiFi connection
-    WIFI_SELECTION,   // WiFi selection subactivity is active
-    LOADING,          // Fetching OPDS feed
-    BROWSING,         // Displaying entries (navigation or books)
-    DOWNLOADING,      // Downloading selected EPUB
-    ERROR             // Error state with message
+    CHECK_WIFI,      // Checking WiFi connection
+    WIFI_SELECTION,  // WiFi selection subactivity is active
+    LOADING,         // Fetching OPDS feed
+    BROWSING,        // Displaying entries (navigation or books)
+    DOWNLOADING,     // Downloading selected EPUB
+    ERROR            // Error state with message
   };
 
   explicit OpdsBookBrowserActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
Fixes the Wi-Fi connection issue when launching the Calibre Library (OPDS browser). The previous implementation always attempted to connect using the first saved WiFi credential, which caused connection failures when users were in locations where only other saved networks (not the first one) were available. Now, the activity launches a WiFi selection screen allowing users to choose from available networks.

* **What changes are included?**

## Additional Context
**Bug Fixed**: Previously, the code used `credentials[0]` (always the first saved WiFi), so users in areas with only their secondary/tertiary saved networks available could never connect.
