### PR TITLE
ci: add dependabot.yml file for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+
+    open-pull-requests-limit: 10
+
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
**Description**:

Add a new file `dependabot.yml` to keep the actions used in `.github/workflows` up to date. This will automatically open PRs when a new version of an action becomes available.

**Related Issue(s)**:

Implements #324

**NOTE TO REVIEWER/MAINTAINER**:

You may need to enable dependabot functionality in the settings on this repo. I can help dig into that if you need help. Thanks!
