### PR TITLE
ci: add PR format check workflow

### DIFF
--- a/.github/workflows/pr-formatting-check.yml
+++ b/.github/workflows/pr-formatting-check.yml
@@ -3,20 +3,9 @@ name: "PR Formatting"
 on:
   pull_request_target:
     types:
-      - assigned
-      - unassigned
-      - labeled
-      - unlabeled
       - opened
       - reopened
       - edited
-      - converted_to_draft
-      - ready_for_review
-      - review_requested
-      - review_request_removed
-      - locked
-      - unlocked
-      - synchronize
 
 permissions:
   statuses: write
@@ -32,6 +21,6 @@ jobs:
           egress-policy: audit
 
       - name: Check PR Title
-        uses: step-security/conventional-pr-title-action@101b3d5adffb51b5789997fea508c8313c8ddf02 # v3.2.2
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**:

Add a new workflow to check the PR formatting to ensure consistency on PR titles. We can also use this for semantic release versioning later, if we so desire.

**Related Issue(s)**:

Implements first portion of #327

