### PR TITLE
Only indent paragraphs for justify/left-align

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -43,7 +43,7 @@ std::vector<uint16_t> ParsedText::calculateWordWidths(const GfxRenderer& rendere
   wordWidths.reserve(totalWordCount);
 
   // add em-space at the beginning of first word in paragraph to indent
-  if (!extraParagraphSpacing) {
+  if ((style == TextBlock::JUSTIFIED || style == TextBlock::LEFT_ALIGN) && !extraParagraphSpacing) {
     std::string& first_word = words.front();
     first_word.insert(0, "\xe2\x80\x83");
   }


### PR DESCRIPTION
Currently, when Extra Paragraph Spacing is off, an em-space is added to the beginning of each ParsedText even for blocks like headers that are centered. This whitespace makes the centering slightly off. Change the calculation here to only add the em-space for left/justified text.