### PR TITLE
Add a bullet to the beginning of any <li>

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -97,6 +97,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->startNewTextBlock(self->currentTextBlock->getStyle());
     } else {
       self->startNewTextBlock((TextBlock::Style)self->paragraphAlignment);
+      if (strcmp(name, "li") == 0) {
+        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+      }
     }
   } else if (matches(name, BOLD_TAGS, NUM_BOLD_TAGS)) {
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);


### PR DESCRIPTION
Currently there is no visual indication whatsoever if something is in a list. An `<li>` is essentially just another paragraph.

As a partial remedy for this, add a bullet character to the beginning of `<li>` text blocks so that the user can see that they're list items. This is incomplete in that an `<ol>` should also have a counter so that its list items can get numbers instead of bullets (right now I don't think we track if we're in a `<ul>` or an `<ol>` at all), but it's strictly better than the current situation.