### PR TITLE
feat: Add EPUB table omitted placeholder

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -65,15 +65,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
   // Special handling for tables - show placeholder text instead of dropping silently
   if (strcmp(name, "table") == 0) {
-    // Flush any partial word
-    if (self->partWordBufferIndex > 0 && self->currentTextBlock) {
-      self->partWordBuffer[self->partWordBufferIndex] = '\0';
-      self->currentTextBlock->addWord(self->partWordBuffer, EpdFontFamily::REGULAR);
-      self->partWordBufferIndex = 0;
-    }
-
     // Add placeholder text
-    self->startNewTextBlock((TextBlock::Style)self->paragraphAlignment);
+    self->startNewTextBlock(TextBlock::CENTER_ALIGN);
     if (self->currentTextBlock) {
       self->currentTextBlock->addWord("[Table omitted]", EpdFontFamily::ITALIC);
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**: Fix the bug I reported in https://github.com/daveallie/crosspoint-reader/issues/292
* **What changes are included?**: Instead of silently dropping table content in EPUBs., replace with an italicized '[Table omitted]' message where tables appear.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY **_
