### PR TITLE
feat: Change keyboard "caps" to "shift" & Wrap Keyboard

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -145,6 +145,11 @@ void KeyboardEntryActivity::loop() {
       // Clamp column to valid range for new row
       const int maxCol = getRowLength(selectedRow) - 1;
       if (selectedCol > maxCol) selectedCol = maxCol;
+    } else {
+      // Wrap to bottom row
+      selectedRow = NUM_ROWS - 1;
+      const int maxCol = getRowLength(selectedRow) - 1;
+      if (selectedCol > maxCol) selectedCol = maxCol;
     }
     updateRequired = true;
   }
@@ -154,16 +159,24 @@ void KeyboardEntryActivity::loop() {
       selectedRow++;
       const int maxCol = getRowLength(selectedRow) - 1;
       if (selectedCol > maxCol) selectedCol = maxCol;
+    } else {
+      // Wrap to top row
+      selectedRow = 0;
+      const int maxCol = getRowLength(selectedRow) - 1;
+      if (selectedCol > maxCol) selectedCol = maxCol;
     }
     updateRequired = true;
   }
 
   if (mappedInput.wasPressed(MappedInputManager::Button::Left)) {
+    const int maxCol = getRowLength(selectedRow) - 1;
+
     // Special bottom row case
     if (selectedRow == SPECIAL_ROW) {
       // Bottom row has special key widths
       if (selectedCol >= SHIFT_COL && selectedCol < SPACE_COL) {
-        // In shift key, do nothing
+        // In shift key, wrap to end of row
+        selectedCol = maxCol;
       } else if (selectedCol >= SPACE_COL && selectedCol < BACKSPACE_COL) {
         // In space bar, move to shift
         selectedCol = SHIFT_COL;
@@ -180,10 +193,9 @@ void KeyboardEntryActivity::loop() {
 
     if (selectedCol > 0) {
       selectedCol--;
-    } else if (selectedRow > 0) {
-      // Wrap to previous row
-      selectedRow--;
-      selectedCol = getRowLength(selectedRow) - 1;
+    } else {
+      // Wrap to end of current row
+      selectedCol = maxCol;
     }
     updateRequired = true;
   }
@@ -204,7 +216,8 @@ void KeyboardEntryActivity::loop() {
         // In backspace, move to done
         selectedCol = DONE_COL;
       } else if (selectedCol >= DONE_COL) {
-        // At done button, do nothing
+        // At done button, wrap to beginning of row
+        selectedCol = SHIFT_COL;
       }
       updateRequired = true;
       return;
@@ -212,9 +225,8 @@ void KeyboardEntryActivity::loop() {
 
     if (selectedCol < maxCol) {
       selectedCol++;
-    } else if (selectedRow < NUM_ROWS - 1) {
-      // Wrap to next row
-      selectedRow++;
+    } else {
+      // Wrap to beginning of current row
       selectedCol = 0;
     }
     updateRequired = true;


### PR DESCRIPTION
## Summary

* This PR solves issue https://github.com/crosspoint-reader/crosspoint-reader/issues/357 in the first commit
* I then added an additional commit which means when you reach the end of the keyboard, if you go 'beyond', you wrap back to the other side.
    * This replaces existing behaviour, so if you would rather this be removed, let me know and I'll just do the `caps` -> `shift` change

## Additional Context

### Screenshots for the new shift display

I thought it might not fit and need column size changes, but ended up fitting fine, see screenshots showing this below:

<img width="573" height="366" alt="image" src="https://github.com/user-attachments/assets/b8f6a4ec-94f5-4f5e-b9a6-06cc5f250ddb" />

<img width="570" height="308" alt="image" src="https://github.com/user-attachments/assets/7d775518-4784-4120-a20a-a9dc67af8565" />


### Gif showing the wrap-around of the text


![IMG_7648](https://github.com/user-attachments/assets/7eec9066-e1cc-49a1-8b6b-a61556038d31)

---

### AI Usage

Did you use AI tools to help write this code?  **PARTIALLY** - used to double check the text wrapping had no edge-cases. (It did also suggest rewriting the function, but I decided that was too big of a change for a working part of the codebase, for now!)
