### PR TITLE
fix: also apply longPressChapterSkip setting to xtc reader

### DIFF
--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -127,7 +127,7 @@ void XtcReaderActivity::loop() {
     return;
   }
 
-  const bool skipPages = mappedInput.getHeldTime() > skipPageMs;
+  const bool skipPages = SETTINGS.longPressChapterSkip && mappedInput.getHeldTime() > skipPageMs;
   const int skipAmount = skipPages ? 10 : 1;
 
   if (prevReleased) {


### PR DESCRIPTION
## Summary

* This builds upon the helpful PR https://github.com/crosspoint-reader/crosspoint-reader/pull/341, and adds support for the setting to also apply to the XTC reader, which I believed has just been missed and was not intentionally left out.
* XTC does not have chapter support yet, but it does skip 10 pages when long-pressed, and so I think this is useful.

---

### AI Usage

Did you use AI tools to help write this code? No
