### PR TITLE
feat: Add MAC address display to WiFi Networks screen

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -37,6 +37,14 @@ void WifiSelectionActivity::onEnter() {
   savePromptSelection = 0;
   forgetPromptSelection = 0;
 
+  // Cache MAC address for display
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  char macStr[32];
+  snprintf(macStr, sizeof(macStr), "MAC address: %02x-%02x-%02x-%02x-%02x-%02x", mac[0], mac[1], mac[2], mac[3], mac[4],
+           mac[5]);
+  cachedMacAddress = std::string(macStr);
+
   // Trigger first update to show scanning message
   updateRequired = true;
 
@@ -571,6 +579,9 @@ void WifiSelectionActivity::renderNetworkList() const {
     snprintf(countStr, sizeof(countStr), "%zu networks found", networks.size());
     renderer.drawText(SMALL_FONT_ID, 20, pageHeight - 90, countStr);
   }
+
+  // Show MAC address above the network count and legend
+  renderer.drawText(SMALL_FONT_ID, 20, pageHeight - 105, cachedMacAddress.c_str());
 
   // Draw help text
   renderer.drawText(SMALL_FONT_ID, 20, pageHeight - 75, "* = Encrypted | + = Saved");

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -62,6 +62,9 @@ class WifiSelectionActivity final : public ActivityWithSubactivity {
   // Password to potentially save (from keyboard or saved credentials)
   std::string enteredPassword;
 
+  // Cached MAC address string for display
+  std::string cachedMacAddress;
+
   // Whether network was connected using a saved password (skip save prompt)
   bool usedSavedPassword = false;
 


### PR DESCRIPTION
## Summary

* Implements #380, allowing the user to see the device's MAC address in order to register on wifi networks

## Additional Context

* Although @markatlnk suggested showing on the settings screen, I implemented display at the bottom of the WiFi Networks selection screen (accessed via "File Transfer" > "Join a Network") since I think it makes more sense there.
* Tested on my own device

![IMG_2873](https://github.com/user-attachments/assets/b82a20dc-41a0-4b21-81f1-20876aa2c6b0)


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
