### PR TITLE
fix: Invert colors on home screen cover overlay when recent book is selected

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -327,8 +327,7 @@ void HomeActivity::render() {
   if (hasContinueReading) {
     // Invert text colors based on selection state:
     // - With cover: selected = white text on black box, unselected = black text on white box
-    // - Without cover: selected = white text on black card, unselected = black text
-    const bool invertText = coverRendered ? bookSelected : !bookSelected;
+    // - Without cover: selected = white text on black card, unselected = black text on white card
 
     // Split into words (avoid stringstream to keep this light on the MCU)
     std::vector<std::string> words;
@@ -412,7 +411,7 @@ void HomeActivity::render() {
     // Vertically center the title block within the card
     int titleYStart = bookY + (bookHeight - totalTextHeight) / 2;
 
-    // If cover image was rendered, draw white box behind title and author
+    // If cover image was rendered, draw box behind title and author
     if (coverRendered) {
       constexpr int boxPadding = 8;
       // Calculate the max text width for the box
@@ -450,7 +449,7 @@ void HomeActivity::render() {
     }
 
     for (const auto& line : lines) {
-      renderer.drawCenteredText(UI_12_FONT_ID, titleYStart, line.c_str(), !invertText);
+      renderer.drawCenteredText(UI_12_FONT_ID, titleYStart, line.c_str(), !bookSelected);
       titleYStart += renderer.getLineHeight(UI_12_FONT_ID);
     }
 
@@ -471,7 +470,7 @@ void HomeActivity::render() {
         }
         trimmedAuthor.append("...");
       }
-      renderer.drawCenteredText(UI_10_FONT_ID, titleYStart, trimmedAuthor.c_str(), !invertText);
+      renderer.drawCenteredText(UI_10_FONT_ID, titleYStart, trimmedAuthor.c_str(), !bookSelected);
     }
 
     // "Continue Reading" label at the bottom
@@ -487,9 +486,9 @@ void HomeActivity::render() {
       const int continueBoxY = continueY - continuePadding / 2;
       renderer.fillRect(continueBoxX, continueBoxY, continueBoxWidth, continueBoxHeight, bookSelected);
       renderer.drawRect(continueBoxX, continueBoxY, continueBoxWidth, continueBoxHeight, !bookSelected);
-      renderer.drawCenteredText(UI_10_FONT_ID, continueY, continueText, !invertText);
+      renderer.drawCenteredText(UI_10_FONT_ID, continueY, continueText, !bookSelected);
     } else {
-      renderer.drawCenteredText(UI_10_FONT_ID, continueY, "Continue Reading", !invertText);
+      renderer.drawCenteredText(UI_10_FONT_ID, continueY, "Continue Reading", !bookSelected);
     }
   } else {
     // No book to continue reading


### PR DESCRIPTION
## Summary

* Fixes #388 

## Additional Context

* Tested on my own device
  * See images at #388 for what home screen looked like before.
  * With this PR the home screen shows the following (selected and unselected recent book × cover image rendered or not)

![Picsew_20260115153419](https://github.com/user-attachments/assets/44193f9d-76b7-4c77-b890-72b0dbae01c4)


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES**