### PR TITLE
feat: hold confirm/select for caps

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -226,13 +226,12 @@ void KeyboardEntryActivity::loop() {
   }
 
   // Selection
-  if (mappedInput.isPressed(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() >= capsMs) {
-    onCapsHeld();
-    return;
-  }
-
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() < capsMs) {
-    handleKeyPress();
+  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+    if (mappedInput.getHeldTime() >= capsMs) {
+      shiftActive = !shiftActive;
+    } else {
+      handleKeyPress();
+    }
     updateRequired = true;
   }
 
@@ -357,14 +356,4 @@ void KeyboardEntryActivity::renderItemWithSelector(const int x, const int y, con
     renderer.drawText(UI_10_FONT_ID, x + itemWidth, y, "]");
   }
   renderer.drawText(UI_10_FONT_ID, x, y, item);
-}
-
-void KeyboardEntryActivity::onCapsHeld() {
-  waitForCapsRelease();
-  shiftActive = !shiftActive;
-  updateRequired = true;
-}
-
-void KeyboardEntryActivity::waitForCapsRelease() {
-  while (mappedInput.isPressed(MappedInputManager::Button::Confirm)) delay(50);
 }

--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -96,7 +96,4 @@ class KeyboardEntryActivity : public Activity {
   int getRowLength(int row) const;
   void render() const;
   void renderItemWithSelector(int x, int y, const char* item, bool isSelected) const;
-
-  void onCapsHeld();
-  void waitForCapsRelease();
 };


### PR DESCRIPTION
## Summary

Implements a quick caps feature in the keyboard entry activity. Previously you would have to navigate the cursor to the shift key each time they need to change case. With this change, users can hold confirm/select for a short period and release it to toggle caps. Resolves #374.

## Additional Context

This is a draft pull request because I still have no way to test the firmware myself (waiting for the device to ship.) I'm not completely sure this commit works out of the box since I have no way of trying it out myself.

### AI Usage

I didn't use any AI tools in making this change.