### PR TITLE
fix: Allow line break after ellipsis and underscore

### DIFF
--- a/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp
+++ b/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp
@@ -125,11 +125,8 @@ bool isExplicitHyphen(const uint32_t cp) {
     case 0xFE58:  // small em dash
     case 0xFE63:  // small hyphen-minus
     case 0xFF0D:  // fullwidth hyphen-minus
-    case 0x005C:  // Backslash
     case 0x005F:  // Underscore
-    case 0x00B7:  // Middle dot
     case 0x2026:  // Ellipsis
-    case 0x22EF:  // Midline horizontal ellipsis
       return true;
     default:
       return false;


### PR DESCRIPTION
## Summary

* Add additional punctuation marks to the list of characters that can be immediately followed by a line break even where there is no explicit space

## Additional Context

* Huge appreciation to @osteotek for his amazing work on hyphenation. Reading on the device is so much better now.
* I am getting bad line breaks when ellipses (…) are between words and book file does not explicitly include some kind of breaking space.
* Per [discussion](https://github.com/crosspoint-reader/crosspoint-reader/pull/305#issuecomment-3765411406), several new characters are added in this PR to the `isExplicitHyphen` list to allow line breaks immediately after them:

Character | Unicode | Usage | Why include it?
-- | -- | -- | --
Solidus (Slash) | U+002F | / | Essential for breaking URLs and "and/or" constructs.
Backslash | U+005C | \ | Critical for technical text, file paths, and coding documentation.
Underscore | U+005F | _ | Prevents "runaway" line lengths in usernames or code snippets.
Middle Dot | U+00B7 | · | Acts as a semantic separator in dictionaries or stylistic lists.
Ellipsis | U+2026 | … | Prevents justification failure when dialogue lacks following spaces.
Midline Horizontal Ellipsis | U+22EF | ⋯ | Useful for mathematical sequences and technical notation.


### Example:

This shows an example of what line breaking looks like *with* this PR. Note the line break after "matter…" (which would not previously have been allowed). It's particularly important here because the book includes non-breaking spaces in "Mr. Aldrich" and "Mr. Rockefeller."

![IMG_2917](https://github.com/user-attachments/assets/8fa610a9-91dd-407f-8526-0019a8a7195f)

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **PARTIALLY**