### PR TITLE
Fix Calibre wireless exit freeze and improve stability

### DIFF
--- a/src/activities/network/CalibreWirelessActivity.h
+++ b/src/activities/network/CalibreWirelessActivity.h
@@ -6,6 +6,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
+#include <atomic>
 #include <functional>
 #include <string>
 
@@ -66,6 +67,7 @@ class CalibreWirelessActivity final : public Activity {
   SemaphoreHandle_t renderingMutex = nullptr;
   SemaphoreHandle_t stateMutex = nullptr;
   bool updateRequired = false;
+  std::atomic<bool> shouldStop{false};  // Signal for graceful task shutdown
 
   WirelessState state = WirelessState::DISCOVERING;
   const std::function<void()> onComplete;
@@ -95,8 +97,8 @@ class CalibreWirelessActivity final : public Activity {
 
   static void displayTaskTrampoline(void* param);
   static void networkTaskTrampoline(void* param);
-  [[noreturn]] void displayTaskLoop();
-  [[noreturn]] void networkTaskLoop();
+  void displayTaskLoop();
+  void networkTaskLoop();
   void render() const;
 
   // Network operations
@@ -119,6 +121,7 @@ class CalibreWirelessActivity final : public Activity {
 
   // Utility
   std::string getDeviceUuid() const;
+  uint64_t getSDCardFreeSpace() const;
   void setState(WirelessState newState);
   void setStatus(const std::string& message);
   void setError(const std::string& message);


### PR DESCRIPTION
This commit applies all Calibre fixes to the 0.14.0 base:

1. **Exit freeze fix (Issue #342)**:
   - Add atomic `shouldStop` flag for cooperative task shutdown
   - Close network connections before deleting tasks (unblocks I/O)
   - Tasks check shouldStop and self-delete gracefully
   - Use eTaskGetState() to avoid double-deletion
   - Break discovery wait into 50ms chunks for faster exit

2. **Free space reporting**:
   - Probe actual SD card space using preAllocate()
   - Remove confusing "ignore free space" message
   - Report accurate space to Calibre for transfer decisions

3. **Write buffer (4KB)**:
   - Batch SD card writes to reduce I/O overhead
   - Improves transfer throughput significantly

4. **Watchdog resets**:
   - Add esp_task_wdt_reset() throughout long operations
   - Prevents WDT crashes during file operations

5. **Exception safety**:
   - Replace std::stoul with strtoul to avoid abort() on ESP32
   - ESP32 has exceptions disabled by default

6. **Larger network buffer**:
   - Increase receive buffer from 1KB to 4KB

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_
