### PR TITLE
feat: add new configuration for front buttons, more usable on landscape ccw

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -116,6 +116,7 @@ The Settings screen allows you to configure the device's behavior. There are a f
   - Back, Confirm, Left, Right (default)
   - Left, Right, Back, Confirm
   - Left, Back, Confirm, Right
+  - Back, Confirm, Right, Left
 - **Side Button Layout (reader)**: Swap the order of the up and down volume buttons from Previous/Next to Next/Previous. This change is only in effect when reading.
 - **Long-press Chapter Skip**: Set whether long-pressing page turn buttons skip to the next/previous chapter.
   - "Chapter Skip" (default) - Long-pressing skips to next/previous chapter

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -32,7 +32,12 @@ class CrossPointSettings {
   // Front button layout options
   // Default: Back, Confirm, Left, Right
   // Swapped: Left, Right, Back, Confirm
-  enum FRONT_BUTTON_LAYOUT { BACK_CONFIRM_LEFT_RIGHT = 0, LEFT_RIGHT_BACK_CONFIRM = 1, LEFT_BACK_CONFIRM_RIGHT = 2 };
+  enum FRONT_BUTTON_LAYOUT {
+    BACK_CONFIRM_LEFT_RIGHT = 0,
+    LEFT_RIGHT_BACK_CONFIRM = 1,
+    LEFT_BACK_CONFIRM_RIGHT = 2,
+    BACK_CONFIRM_RIGHT_LEFT = 3
+  };
 
   // Side button layout options
   // Default: Previous, Next

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -14,6 +14,9 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
         case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
           return InputManager::BTN_CONFIRM;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
+          /* fall through */
+        case CrossPointSettings::BACK_CONFIRM_RIGHT_LEFT:
+          /* fall through */
         default:
           return InputManager::BTN_BACK;
       }
@@ -24,15 +27,22 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
         case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
           return InputManager::BTN_LEFT;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
+          /* fall through */
+        case CrossPointSettings::BACK_CONFIRM_RIGHT_LEFT:
+          /* fall through */
         default:
           return InputManager::BTN_CONFIRM;
       }
     case Button::Left:
       switch (frontLayout) {
         case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
+          /* fall through */
         case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
           return InputManager::BTN_BACK;
+        case CrossPointSettings::BACK_CONFIRM_RIGHT_LEFT:
+          return InputManager::BTN_RIGHT;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
+          /* fall through */
         default:
           return InputManager::BTN_LEFT;
       }
@@ -40,8 +50,12 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
       switch (frontLayout) {
         case CrossPointSettings::LEFT_RIGHT_BACK_CONFIRM:
           return InputManager::BTN_CONFIRM;
+        case CrossPointSettings::BACK_CONFIRM_RIGHT_LEFT:
+          return InputManager::BTN_LEFT;
         case CrossPointSettings::BACK_CONFIRM_LEFT_RIGHT:
+          /* fall through */
         case CrossPointSettings::LEFT_BACK_CONFIRM_RIGHT:
+          /* fall through */
         default:
           return InputManager::BTN_RIGHT;
       }
@@ -56,6 +70,7 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
         case CrossPointSettings::NEXT_PREV:
           return InputManager::BTN_DOWN;
         case CrossPointSettings::PREV_NEXT:
+          /* fall through */
         default:
           return InputManager::BTN_UP;
       }
@@ -64,6 +79,7 @@ decltype(InputManager::BTN_BACK) MappedInputManager::mapButton(const Button butt
         case CrossPointSettings::NEXT_PREV:
           return InputManager::BTN_UP;
         case CrossPointSettings::PREV_NEXT:
+          /* fall through */
         default:
           return InputManager::BTN_DOWN;
       }

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -37,8 +37,9 @@ const SettingInfo readerSettings[readerSettingsCount] = {
 
 constexpr int controlsSettingsCount = 4;
 const SettingInfo controlsSettings[controlsSettingsCount] = {
-    SettingInfo::Enum("Front Button Layout", &CrossPointSettings::frontButtonLayout,
-                      {"Bck, Cnfrm, Lft, Rght", "Lft, Rght, Bck, Cnfrm", "Lft, Bck, Cnfrm, Rght"}),
+    SettingInfo::Enum(
+        "Front Button Layout", &CrossPointSettings::frontButtonLayout,
+        {"Bck, Cnfrm, Lft, Rght", "Lft, Rght, Bck, Cnfrm", "Lft, Bck, Cnfrm, Rght", "Bck, Cnfrm, Rght, Lft"}),
     SettingInfo::Enum("Side Button Layout (reader)", &CrossPointSettings::sideButtonLayout,
                       {"Prev, Next", "Next, Prev"}),
     SettingInfo::Toggle("Long-press Chapter Skip", &CrossPointSettings::longPressChapterSkip),


### PR DESCRIPTION
When reading on Landscape Counter ClockWise mode, the left/right button appear inverted: the upper button (left) goes down and the lower button (right) goes up.

Discussion: #449

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
Add a new configuration for the front buttons: Back, Confirm, Right, Left

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
