### PR TITLE
fix: short-press power button to wakeup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,13 +289,6 @@ bool isUsbConnected() {
   return digitalRead(UART0_RXD) == HIGH;
 }
 
-bool isWakeupAfterFlashing() {
-  const auto wakeupCause = esp_sleep_get_wakeup_cause();
-  const auto resetReason = esp_reset_reason();
-
-  return isUsbConnected() && (wakeupCause == ESP_SLEEP_WAKEUP_UNDEFINED) && (resetReason == ESP_RST_UNKNOWN);
-}
-
 bool isWakeupByPowerButton() {
   const auto wakeupCause = esp_sleep_get_wakeup_cause();
   const auto resetReason = esp_reset_reason();


### PR DESCRIPTION
## Summary

Fix https://github.com/crosspoint-reader/crosspoint-reader/issues/288

Based on my observation, it seems like the problem was that `inputManager.isPressed(InputManager::BTN_POWER)` takes a bit of time after waking up to report the correct value. I haven't tested this behavior with a standalone ESP32C3, but if you know more about this, feel free to comment.

However, if we just want short press, I think it's enough to check for wake up source. If we plan to allow multiple buttons to wake up in the future, may consider using ext1 / `esp_sleep_get_ext1_wakeup_status()` to allow identify which pin triggered wake up.

Note that I'm not particularly experienced in esp32 developments, just happen to have prior knowledge hacking esphome.

## Additional Context

N/A

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? NO
