### PR TITLE
feat: add bluetooth file transfers

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -48,6 +48,7 @@ lib_deps =
   bblanchon/ArduinoJson @ 7.4.2
   ricmoo/QRCode @ 0.0.1
   links2004/WebSockets @ 2.7.3
+  h2zero/NimBLE-Arduino @ 2.3.7
 
 [env:default]
 extends = base

--- a/src/activities/bluetooth/BluetoothActivity.cpp
+++ b/src/activities/bluetooth/BluetoothActivity.cpp
@@ -1,0 +1,321 @@
+#include "BluetoothActivity.h"
+
+#include <GfxRenderer.h>
+#include <BLE2902.h>
+
+#include "MappedInputManager.h"
+#include "fontIds.h"
+
+#define DEVICE_NAME         "EPaper"
+#define SERVICE_UUID        "4ae29d01-499a-480a-8c41-a82192105125"
+#define REQUEST_CHARACTERISTIC_UUID  "a00e530d-b48b-48c8-aadb-d062a1b91792"
+#define RESPONSE_CHARACTERISTIC_UUID "0c656023-dee6-47c5-9afb-e601dfbdaa1d"
+
+#define OUTPUT_DIRECTORY "/bt"
+
+#define PROTOCOL_ASSERT(cond, fmt, ...)                            \
+    do {                                                           \
+        if (!(cond))                                               \
+        {                                                          \
+            snprintf(errorMessage, sizeof(errorMessage), fmt, ##__VA_ARGS__); \
+            intoState(STATE_ERROR);                                \
+            return;                                                \
+        }                                                          \
+    } while (0)
+
+void BluetoothActivity::taskTrampoline(void* param) {
+  auto* self = static_cast<BluetoothActivity*>(param);
+  self->displayTaskLoop();
+}
+
+void BluetoothActivity::startAdvertising() {
+  BLEDevice::startAdvertising();
+}
+
+void BluetoothActivity::stopAdvertising() {
+  BLEDevice::stopAdvertising();
+}
+
+void BluetoothActivity::onEnter() {
+  Activity::onEnter();
+
+  BLEDevice::init(DEVICE_NAME);
+  pServer = BLEDevice::createServer();
+  pServer->setCallbacks(&serverCallbacks);
+  pService = pServer->createService(SERVICE_UUID);
+  pRequestChar = pService->createCharacteristic(
+    REQUEST_CHARACTERISTIC_UUID,
+    BLECharacteristic::PROPERTY_WRITE | BLECharacteristic::PROPERTY_WRITE_NR
+  );
+  pRequestChar->setCallbacks(&requestCallbacks);
+  pResponseChar = pService->createCharacteristic(
+    RESPONSE_CHARACTERISTIC_UUID,
+    BLECharacteristic::PROPERTY_INDICATE
+  );
+  pResponseChar->addDescriptor(new BLE2902());
+  pService->start();
+
+  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
+  pAdvertising->addServiceUUID(SERVICE_UUID);
+  pAdvertising->setScanResponse(true);
+  pAdvertising->setMinPreferred(0x06);
+  pAdvertising->setMinPreferred(0x12);
+
+  renderingMutex = xSemaphoreCreateMutex();
+
+  state = STATE_INITIALIZING;
+  intoState(STATE_WAITING);
+
+  xTaskCreate(&BluetoothActivity::taskTrampoline, "BluetoothTask",
+              // TODO: figure out how much stack we actually need
+              4096,               // Stack size
+              this,               // Parameters
+              1,                  // Priority
+              &displayTaskHandle  // Task handle
+  );
+}
+
+void BluetoothActivity::intoState(State newState) {
+  if (state == newState) {
+    return;
+  }
+
+  switch (newState) {
+    case STATE_WAITING:
+      file.close();
+      startAdvertising();
+      txnId = 0;
+      break;
+    case STATE_OFFERED:
+      // caller sets filename, totalBytes, file, txnId
+      receivedBytes = 0;
+      break;
+    case STATE_ERROR:
+    {
+      // caller sets errorMessage
+      file.close();
+      auto connId = pServer->getConnId();
+      if (connId != ESP_GATT_IF_NONE) {
+        // TODO: send back a response over BLE?
+        pServer->disconnect(connId);
+      }
+      break;
+    }
+  }
+
+  state = newState;
+  updateRequired = true;
+}
+
+void BluetoothActivity::onExit() {
+  Activity::onExit();
+
+  file.close();
+
+  stopAdvertising();
+
+  pService->stop();
+  BLEDevice::deinit();
+
+  // Wait until not rendering to delete task
+  xSemaphoreTake(renderingMutex, portMAX_DELAY);
+  if (displayTaskHandle) {
+    vTaskDelete(displayTaskHandle);
+    displayTaskHandle = nullptr;
+  }
+  vSemaphoreDelete(renderingMutex);
+  renderingMutex = nullptr;
+}
+
+void BluetoothActivity::loop() {
+  // Handle back button - cancel
+  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+    onCancel();
+    return;
+  }
+
+  if (state == STATE_ERROR) {
+    if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      // restart
+      intoState(STATE_WAITING);
+    }
+  }
+}
+
+void BluetoothActivity::displayTaskLoop() {
+  while (true) {
+    if (updateRequired) {
+      updateRequired = false;
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      render();
+      xSemaphoreGive(renderingMutex);
+    }
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+  }
+}
+
+void BluetoothActivity::render() const {
+  renderer.clearScreen();
+
+  renderer.drawCenteredText(UI_12_FONT_ID, 15, "Bluetooth", true, EpdFontFamily::BOLD);
+  renderer.drawCenteredText(UI_10_FONT_ID, 50, "Use the Longform app to transfer files.");
+
+  std::string stateText;
+  switch (state) {
+    case STATE_WAITING:
+      stateText = "Waiting for a connection.";
+      break;
+    case STATE_CONNECTED:
+      stateText = "Connected.";
+      break;
+    case STATE_OFFERED:
+      stateText = "Ready to receive.";
+      break;
+    case STATE_RECEIVING:
+      stateText = "Receiving.";
+      break;
+    case STATE_DONE:
+      stateText = "Transfer complete.";
+      break;
+    case STATE_ERROR:
+      stateText = "An error occurred.";
+      break;
+    default:
+      stateText = "UNKNOWN STATE.";
+  }
+  renderer.drawCenteredText(UI_10_FONT_ID, 75, stateText.c_str());
+
+  if (state == STATE_OFFERED || state == STATE_RECEIVING || state == STATE_DONE) {
+    renderer.drawCenteredText(UI_12_FONT_ID, 110, filename);
+  } else if (state == STATE_ERROR) {
+    renderer.drawCenteredText(UI_10_FONT_ID, 110, errorMessage);
+  }
+
+  if (state == STATE_RECEIVING) {
+    const int percent = (totalBytes > 0) ? (receivedBytes * 100) / totalBytes : 0;
+
+    const int barWidth = renderer.getScreenWidth() * 3 / 4;
+    const int barHeight = 20;
+    const int boxX = (renderer.getScreenWidth() - barWidth) / 2;
+    const int boxY = 160;
+    renderer.drawRect(boxX, boxY, barWidth, barHeight);
+    const int fillWidth = (barWidth - 2) * percent / 100;
+    renderer.fillRect(boxX + 1, boxY + 1, fillWidth, barHeight - 2);
+
+    char dynamicText[64];
+    snprintf(dynamicText, sizeof(dynamicText), "Received %zu / %zu bytes (%d%%)", receivedBytes, totalBytes, percent);
+    renderer.drawCenteredText(UI_10_FONT_ID, 200, dynamicText);
+  }
+
+  // Draw help text at bottom
+  const auto labels = mappedInput.mapLabels(
+    "« Back",
+    (state == STATE_ERROR) ? "Restart" : "",
+    "",
+    ""
+  );
+  renderer.drawButtonHints(UI_10_FONT_ID, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+
+  renderer.displayBuffer();
+}
+
+void BluetoothActivity::ServerCallbacks::onConnect(BLEServer* pServer) {
+  Serial.printf("BLE connected\n");
+  activity->onConnected(true);
+}
+
+void BluetoothActivity::ServerCallbacks::onDisconnect(BLEServer* pServer) {
+  Serial.printf("BLE disconnected\n");
+  activity->onConnected(false);
+}
+
+void BluetoothActivity::onConnected(bool isConnected) {
+  if (state == STATE_ERROR) {
+    // stay in error state so the user can read the error message even after disconnect
+    return;
+  }
+
+  intoState(isConnected ? STATE_CONNECTED : STATE_WAITING);
+}
+
+void BluetoothActivity::onRequest(lfbt_message* msg, size_t msg_len) {
+  if (state == STATE_ERROR) {
+    // ignore further messages in error state
+    return;
+  }
+
+  PROTOCOL_ASSERT((txnId == 0) || (txnId == msg->txnId), "Multiple transfers happening at once (%x != %x)", txnId, msg->txnId);
+
+  switch (msg->type) {
+    case 0: // client_offer
+    {
+      PROTOCOL_ASSERT(state == STATE_CONNECTED, "Invalid state for client_offer: %d", state);
+      PROTOCOL_ASSERT(msg->body.clientOffer.version == 1, "Unsupported protocol version: %u", msg->body.clientOffer.version);
+
+      totalBytes = msg->body.clientOffer.bodyLength;
+      
+      size_t filenameLen = msg_len - 8 - sizeof(lfbt_msg_client_offer);
+      if (filenameLen > MAX_FILENAME) {
+        filenameLen = MAX_FILENAME;
+      }
+
+      memcpy(filename, msg->body.clientOffer.name, filenameLen);
+      filename[filenameLen] = 0;
+
+      // sanitize filename
+      for (char *p = filename; *p; p++) {
+        if (*p == '/' || *p == '\\' || *p == ':') {
+          *p = '_';
+        }
+      }
+
+      PROTOCOL_ASSERT(SdMan.ensureDirectoryExists(OUTPUT_DIRECTORY), "Couldn't create output directory %s", OUTPUT_DIRECTORY);
+      char filepath[MAX_FILENAME + strlen(OUTPUT_DIRECTORY) + 2];
+      snprintf(filepath, sizeof(filepath), "%s/%s", OUTPUT_DIRECTORY, filename);
+      // TODO: we could check if file already exists and append a number to filename to avoid overwriting
+      PROTOCOL_ASSERT(SdMan.openFileForWrite("BT", filepath, file), "Couldn't open file %s for writing", filepath);
+      // TODO: would be neat to check if we have enough space, but SDCardManager doesn't seem to expose that info currently
+
+      txnId = msg->txnId;
+
+      intoState(STATE_OFFERED);
+
+      lfbt_message response = {
+        .type = 1, // server_response
+        .txnId = txnId,
+        .body = {.serverResponse = {.status = 0}}
+      };
+      pResponseChar->setValue((uint8_t*)&response, 8 + sizeof(lfbt_msg_server_response));
+      pResponseChar->indicate(); // TODO: indicate should not be called in a callback, this ends up timing out
+
+      updateRequired = true;
+      break;
+    }
+    case 2: // client_chunk
+    {
+      Serial.printf("Received client_chunk, offset %u, length %zu\n", msg->body.clientChunk.offset, msg_len - 8 - sizeof(lfbt_msg_client_chunk));
+      PROTOCOL_ASSERT(state == STATE_OFFERED || state == STATE_RECEIVING, "Invalid state for client_chunk: %d", state);
+      PROTOCOL_ASSERT(msg->body.clientChunk.offset == receivedBytes, "Expected chunk %d, got %d", receivedBytes, msg->body.clientChunk.offset);
+
+      size_t written = file.write((uint8_t*)msg->body.clientChunk.body, msg_len - 8 - sizeof(lfbt_msg_client_chunk));
+      PROTOCOL_ASSERT(written > 0, "Couldn't write to file");
+      receivedBytes += msg_len - 8 - sizeof(lfbt_msg_client_chunk);
+      if (receivedBytes >= totalBytes) {
+        PROTOCOL_ASSERT(receivedBytes == totalBytes, "Got more bytes than expected: %zu > %zu", receivedBytes, totalBytes);
+        PROTOCOL_ASSERT(file.close(), "Couldn't finalize writing the file");
+        // TODO: automatically open file in reader
+        intoState(STATE_DONE);
+      } else {
+        intoState(STATE_RECEIVING);
+      }
+      updateRequired = true;
+      break;
+    }
+  }
+}
+
+void BluetoothActivity::RequestCallbacks::onWrite(BLECharacteristic* pCharacteristic, esp_ble_gatts_cb_param_t* param) {
+  lfbt_message *msg = (lfbt_message*) param->write.value;
+  Serial.printf("Received BLE message of type %u, txnId %x, length %d\n", msg->type, msg->txnId, param->write.len);
+  activity->onRequest(msg, param->write.len);
+}

--- a/src/activities/bluetooth/BluetoothActivity.h
+++ b/src/activities/bluetooth/BluetoothActivity.h
@@ -89,10 +89,7 @@ class BluetoothActivity final : public Activity {
 
   RequestCallbacks requestCallbacks;
 
-  NimBLEServer *pServer;
-  NimBLEService *pService;
-  NimBLECharacteristic *pRequestChar, *pResponseChar;
-  NimBLEAdvertising *pAdvertising;
+  NimBLECharacteristic *pResponseChar = nullptr;
   void startAdvertising();
   void stopAdvertising();
 
@@ -111,8 +108,8 @@ class BluetoothActivity final : public Activity {
   FsFile file;
   size_t receivedBytes = 0;
   size_t totalBytes = 0; 
-  char errorMessage[256];
-  uint32_t txnId;
+  char errorMessage[256] = {};
+  uint32_t txnId = 0;
 
   void intoState(State newState);
 

--- a/src/activities/bluetooth/BluetoothActivity.h
+++ b/src/activities/bluetooth/BluetoothActivity.h
@@ -13,8 +13,6 @@
 
 #include "../Activity.h"
 
-#define MAX_FILENAME 200
-
 typedef struct  __attribute__((packed)) {
   uint32_t version;
   uint32_t bodyLength;
@@ -104,7 +102,7 @@ class BluetoothActivity final : public Activity {
   } State;
 
   State state = STATE_INITIALIZING;
-  char filename[MAX_FILENAME + 1];
+  std::string filename;
   FsFile file;
   size_t receivedBytes = 0;
   size_t totalBytes = 0; 

--- a/src/activities/bluetooth/BluetoothActivity.h
+++ b/src/activities/bluetooth/BluetoothActivity.h
@@ -3,9 +3,9 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
-#include <BLEDevice.h>
-#include <BLEUtils.h>
-#include <BLEServer.h>
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEServer.h>
 
 #include <functional>
 
@@ -61,12 +61,12 @@ class BluetoothActivity final : public Activity {
   void onConnected(bool isConnected);
   void onRequest(lfbt_message *msg, size_t msg_len);
 
-  class ServerCallbacks : public BLEServerCallbacks {
+  class ServerCallbacks : public NimBLEServerCallbacks {
     friend class BluetoothActivity;
     BluetoothActivity *activity;
 
-    void onConnect(BLEServer* pServer);
-    void onDisconnect(BLEServer* pServer);
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason);
 
     protected:
     explicit ServerCallbacks(BluetoothActivity *activity) : activity(activity) {}
@@ -74,11 +74,11 @@ class BluetoothActivity final : public Activity {
 
   ServerCallbacks serverCallbacks;
 
-  class RequestCallbacks : public BLECharacteristicCallbacks {
+  class RequestCallbacks : public NimBLECharacteristicCallbacks {
     friend class BluetoothActivity;
     BluetoothActivity *activity;
 
-    void onWrite(BLECharacteristic* pCharacteristic, esp_ble_gatts_cb_param_t* param);
+    void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
 
     protected:
     explicit RequestCallbacks(BluetoothActivity *activity) : activity(activity) {}
@@ -86,10 +86,10 @@ class BluetoothActivity final : public Activity {
 
   RequestCallbacks requestCallbacks;
 
-  BLEServer *pServer;
-  BLEService *pService;
-  BLECharacteristic *pRequestChar, *pResponseChar;
-  BLEAdvertising *pAdvertising;
+  NimBLEServer *pServer;
+  NimBLEService *pService;
+  NimBLECharacteristic *pRequestChar, *pResponseChar;
+  NimBLEAdvertising *pAdvertising;
   void startAdvertising();
   void stopAdvertising();
 

--- a/src/activities/bluetooth/BluetoothActivity.h
+++ b/src/activities/bluetooth/BluetoothActivity.h
@@ -62,7 +62,7 @@ class BluetoothActivity final : public Activity {
   void report();
 
   void onConnected(bool isConnected);
-  void onRequest(lfbt_message *msg, size_t msg_len);
+  void onRequest(const lfbt_message *msg, size_t msg_len);
 
   class ServerCallbacks : public NimBLEServerCallbacks {
     friend class BluetoothActivity;

--- a/src/activities/bluetooth/BluetoothActivity.h
+++ b/src/activities/bluetooth/BluetoothActivity.h
@@ -1,0 +1,124 @@
+#pragma once
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+
+#include <BLEDevice.h>
+#include <BLEUtils.h>
+#include <BLEServer.h>
+
+#include <functional>
+
+#include <SDCardManager.h>
+
+#include "../Activity.h"
+
+#define MAX_FILENAME 200
+
+typedef struct  __attribute__((packed)) {
+  uint32_t version;
+  uint32_t bodyLength;
+  uint32_t nameLength;
+  char name[];
+} lfbt_msg_client_offer; // msg type 0
+
+typedef struct  __attribute__((packed)) {
+  uint32_t status;
+} lfbt_msg_server_response; // msg type 1
+
+typedef struct  __attribute__((packed)) {
+  uint32_t offset;
+  char body[];
+} lfbt_msg_client_chunk; // msg type 2
+
+typedef union {
+  lfbt_msg_client_offer clientOffer;
+  lfbt_msg_server_response serverResponse;
+  lfbt_msg_client_chunk clientChunk;
+} lfbt_message_body;
+
+typedef struct __attribute__((packed)) {
+  uint32_t type;
+  uint32_t txnId;
+  lfbt_message_body body;
+} lfbt_message;
+
+/**
+ * BluetoothActivity receives files over a custom BLE protocol and stores them on the SD card.
+ * 
+ * The onCancel callback is called if the user presses back.
+ */
+class BluetoothActivity final : public Activity {
+  TaskHandle_t displayTaskHandle = nullptr;
+  SemaphoreHandle_t renderingMutex = nullptr;
+  bool updateRequired = false;
+  const std::function<void()> onCancel;
+
+  static void taskTrampoline(void* param);
+  [[noreturn]] void displayTaskLoop();
+  void render() const;
+
+  void onConnected(bool isConnected);
+  void onRequest(lfbt_message *msg, size_t msg_len);
+
+  class ServerCallbacks : public BLEServerCallbacks {
+    friend class BluetoothActivity;
+    BluetoothActivity *activity;
+
+    void onConnect(BLEServer* pServer);
+    void onDisconnect(BLEServer* pServer);
+
+    protected:
+    explicit ServerCallbacks(BluetoothActivity *activity) : activity(activity) {}
+  };
+
+  ServerCallbacks serverCallbacks;
+
+  class RequestCallbacks : public BLECharacteristicCallbacks {
+    friend class BluetoothActivity;
+    BluetoothActivity *activity;
+
+    void onWrite(BLECharacteristic* pCharacteristic, esp_ble_gatts_cb_param_t* param);
+
+    protected:
+    explicit RequestCallbacks(BluetoothActivity *activity) : activity(activity) {}
+  };
+
+  RequestCallbacks requestCallbacks;
+
+  BLEServer *pServer;
+  BLEService *pService;
+  BLECharacteristic *pRequestChar, *pResponseChar;
+  BLEAdvertising *pAdvertising;
+  void startAdvertising();
+  void stopAdvertising();
+
+  typedef enum {
+    STATE_INITIALIZING,
+    STATE_WAITING,
+    STATE_CONNECTED,
+    STATE_OFFERED,
+    STATE_RECEIVING,
+    STATE_DONE,
+    STATE_ERROR
+  } State;
+
+  State state = STATE_INITIALIZING;
+  char filename[MAX_FILENAME + 1];
+  FsFile file;
+  size_t receivedBytes = 0;
+  size_t totalBytes = 0; 
+  char errorMessage[256];
+  uint32_t txnId;
+
+  void intoState(State newState);
+
+ public:
+  explicit BluetoothActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                                        const std::function<void()>& onCancel)
+      : Activity("Bluetooth", renderer, mappedInput), onCancel(onCancel),
+        serverCallbacks(this), requestCallbacks(this) {}
+  void onEnter() override;
+  void onExit() override;
+  void loop() override;
+};

--- a/src/activities/bluetooth/BluetoothActivity.h
+++ b/src/activities/bluetooth/BluetoothActivity.h
@@ -1,33 +1,31 @@
 #pragma once
+#include <NimBLEDevice.h>
+#include <NimBLEServer.h>
+#include <NimBLEUtils.h>
+#include <SDCardManager.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
-#include <NimBLEDevice.h>
-#include <NimBLEUtils.h>
-#include <NimBLEServer.h>
-
 #include <functional>
-
-#include <SDCardManager.h>
 
 #include "../Activity.h"
 
-typedef struct  __attribute__((packed)) {
+typedef struct __attribute__((packed)) {
   uint32_t version;
   uint32_t bodyLength;
   uint32_t nameLength;
   char name[];
-} lfbt_msg_client_offer; // msg type 0
+} lfbt_msg_client_offer;  // msg type 0
 
-typedef struct  __attribute__((packed)) {
+typedef struct __attribute__((packed)) {
   uint32_t status;
-} lfbt_msg_server_response; // msg type 1
+} lfbt_msg_server_response;  // msg type 1
 
-typedef struct  __attribute__((packed)) {
+typedef struct __attribute__((packed)) {
   uint32_t offset;
   char body[];
-} lfbt_msg_client_chunk; // msg type 2
+} lfbt_msg_client_chunk;  // msg type 2
 
 typedef union {
   lfbt_msg_client_offer clientOffer;
@@ -43,7 +41,7 @@ typedef struct __attribute__((packed)) {
 
 /**
  * BluetoothActivity receives files over a custom BLE protocol and stores them on the SD card.
- * 
+ *
  * The onCancel callback is called if the user presses back.
  * onFileReceived is called when a file is successfully received with the path to the file.
  */
@@ -62,34 +60,34 @@ class BluetoothActivity final : public Activity {
   void report();
 
   void onConnected(bool isConnected);
-  void onRequest(const lfbt_message *msg, size_t msg_len);
+  void onRequest(const lfbt_message* msg, size_t msg_len);
 
   class ServerCallbacks : public NimBLEServerCallbacks {
     friend class BluetoothActivity;
-    BluetoothActivity *activity;
+    BluetoothActivity* activity;
 
     void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
     void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason);
 
-    protected:
-    explicit ServerCallbacks(BluetoothActivity *activity) : activity(activity) {}
+   protected:
+    explicit ServerCallbacks(BluetoothActivity* activity) : activity(activity) {}
   };
 
   ServerCallbacks serverCallbacks;
 
   class RequestCallbacks : public NimBLECharacteristicCallbacks {
     friend class BluetoothActivity;
-    BluetoothActivity *activity;
+    BluetoothActivity* activity;
 
     void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
 
-    protected:
-    explicit RequestCallbacks(BluetoothActivity *activity) : activity(activity) {}
+   protected:
+    explicit RequestCallbacks(BluetoothActivity* activity) : activity(activity) {}
   };
 
   RequestCallbacks requestCallbacks;
 
-  NimBLECharacteristic *pResponseChar = nullptr;
+  NimBLECharacteristic* pResponseChar = nullptr;
   void startAdvertising();
   void stopAdvertising();
 
@@ -107,7 +105,7 @@ class BluetoothActivity final : public Activity {
   std::string filename;
   FsFile file;
   size_t receivedBytes = 0;
-  size_t totalBytes = 0; 
+  size_t totalBytes = 0;
   char errorMessage[256] = {};
   uint32_t txnId = 0;
 
@@ -115,10 +113,13 @@ class BluetoothActivity final : public Activity {
 
  public:
   explicit BluetoothActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                        const std::function<void()>& onCancel,
-                                        const std::function<void(const std::string&)>& onFileReceived)
-      : Activity("Bluetooth", renderer, mappedInput), onCancel(onCancel), onFileReceived(onFileReceived),
-        serverCallbacks(this), requestCallbacks(this) {}
+                             const std::function<void()>& onCancel,
+                             const std::function<void(const std::string&)>& onFileReceived)
+      : Activity("Bluetooth", renderer, mappedInput),
+        onCancel(onCancel),
+        onFileReceived(onFileReceived),
+        serverCallbacks(this),
+        requestCallbacks(this) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -23,7 +23,7 @@ void HomeActivity::taskTrampoline(void* param) {
 }
 
 int HomeActivity::getMenuItemCount() const {
-  int count = 3;  // My Library, File transfer, Settings
+  int count = 4;  // My Library, File transfer, Bluetooth, Settings
   if (hasContinueReading) count++;
   if (hasOpdsUrl) count++;
   return count;
@@ -172,6 +172,7 @@ void HomeActivity::loop() {
     const int myLibraryIdx = idx++;
     const int opdsLibraryIdx = hasOpdsUrl ? idx++ : -1;
     const int fileTransferIdx = idx++;
+    const int bluetoothIdx = idx++;
     const int settingsIdx = idx;
 
     if (selectorIndex == continueIdx) {
@@ -182,6 +183,8 @@ void HomeActivity::loop() {
       onOpdsBrowserOpen();
     } else if (selectorIndex == fileTransferIdx) {
       onFileTransferOpen();
+    } else if (selectorIndex == bluetoothIdx) {
+      onBluetoothOpen();
     } else if (selectorIndex == settingsIdx) {
       onSettingsOpen();
     }
@@ -500,7 +503,7 @@ void HomeActivity::render() {
 
   // --- Bottom menu tiles ---
   // Build menu items dynamically
-  std::vector<const char*> menuItems = {"My Library", "File Transfer", "Settings"};
+  std::vector<const char*> menuItems = {"My Library", "File Transfer", "Bluetooth", "Settings"};
   if (hasOpdsUrl) {
     // Insert Calibre Library after My Library
     menuItems.insert(menuItems.begin() + 1, "Calibre Library");

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -25,6 +25,7 @@ class HomeActivity final : public Activity {
   const std::function<void()> onMyLibraryOpen;
   const std::function<void()> onSettingsOpen;
   const std::function<void()> onFileTransferOpen;
+  const std::function<void()> onBluetoothOpen;
   const std::function<void()> onOpdsBrowserOpen;
 
   static void taskTrampoline(void* param);
@@ -39,12 +40,13 @@ class HomeActivity final : public Activity {
   explicit HomeActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                         const std::function<void()>& onContinueReading, const std::function<void()>& onMyLibraryOpen,
                         const std::function<void()>& onSettingsOpen, const std::function<void()>& onFileTransferOpen,
-                        const std::function<void()>& onOpdsBrowserOpen)
+                        const std::function<void()>& onBluetoothOpen, const std::function<void()>& onOpdsBrowserOpen)
       : Activity("Home", renderer, mappedInput),
         onContinueReading(onContinueReading),
         onMyLibraryOpen(onMyLibraryOpen),
         onSettingsOpen(onSettingsOpen),
         onFileTransferOpen(onFileTransferOpen),
+        onBluetoothOpen(onBluetoothOpen),
         onOpdsBrowserOpen(onOpdsBrowserOpen) {}
   void onEnter() override;
   void onExit() override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -230,17 +230,12 @@ void onGoToFileTransfer() {
 
 void onGoToBluetooth() {
   exitActivity();
-  enterNewActivity(new BluetoothActivity(
-    renderer,
-    mappedInputManager,
-    onGoHome,
-    [](const std::string& filepath) {
-      Serial.printf("[%lu] [   ] File received over Bluetooth: %s\n", millis(), filepath.c_str());
-      if (StringUtils::readableFileExtension(filepath)) {
-        onGoToReader(filepath, MyLibraryActivity::Tab::Recent);
-      }
+  enterNewActivity(new BluetoothActivity(renderer, mappedInputManager, onGoHome, [](const std::string& filepath) {
+    Serial.printf("[%lu] [   ] File received over Bluetooth: %s\n", millis(), filepath.c_str());
+    if (StringUtils::readableFileExtension(filepath)) {
+      onGoToReader(filepath, MyLibraryActivity::Tab::Recent);
     }
-  ));
+  }));
 }
 
 void onGoToSettings() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "activities/settings/SettingsActivity.h"
 #include "activities/util/FullScreenMessageActivity.h"
 #include "fontIds.h"
+#include "util/StringUtils.h"
 
 #define SPI_FQ 40000000
 // Display SPI pins (custom pins for XteinkX4, not hardware SPI defaults)
@@ -229,7 +230,17 @@ void onGoToFileTransfer() {
 
 void onGoToBluetooth() {
   exitActivity();
-  enterNewActivity(new BluetoothActivity(renderer, mappedInputManager, onGoHome));
+  enterNewActivity(new BluetoothActivity(
+    renderer,
+    mappedInputManager,
+    onGoHome,
+    [](const std::string& filepath) {
+      Serial.printf("[%lu] [   ] File received over Bluetooth: %s\n", millis(), filepath.c_str());
+      if (StringUtils::readableFileExtension(filepath)) {
+        onGoToReader(filepath, MyLibraryActivity::Tab::Recent);
+      }
+    }
+  ));
 }
 
 void onGoToSettings() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "KOReaderCredentialStore.h"
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
+#include "activities/bluetooth/BluetoothActivity.h"
 #include "activities/boot_sleep/BootActivity.h"
 #include "activities/boot_sleep/SleepActivity.h"
 #include "activities/browser/OpdsBookBrowserActivity.h"
@@ -226,6 +227,11 @@ void onGoToFileTransfer() {
   enterNewActivity(new CrossPointWebServerActivity(renderer, mappedInputManager, onGoHome));
 }
 
+void onGoToBluetooth() {
+  exitActivity();
+  enterNewActivity(new BluetoothActivity(renderer, mappedInputManager, onGoHome));
+}
+
 void onGoToSettings() {
   exitActivity();
   enterNewActivity(new SettingsActivity(renderer, mappedInputManager, onGoHome));
@@ -249,7 +255,7 @@ void onGoToBrowser() {
 void onGoHome() {
   exitActivity();
   enterNewActivity(new HomeActivity(renderer, mappedInputManager, onContinueReading, onGoToMyLibrary, onGoToSettings,
-                                    onGoToFileTransfer, onGoToBrowser));
+                                    onGoToFileTransfer, onGoToBluetooth, onGoToBrowser));
 }
 
 void setupDisplayAndFonts() {

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -61,6 +61,14 @@ bool checkFileExtension(const String& fileName, const char* extension) {
   return localFile.endsWith(localExtension);
 }
 
+std::pair<std::string, std::string> splitFileName(const std::string& name) {
+  size_t lastDot = name.find_last_of('.');
+  if (lastDot == std::string::npos) {
+    return std::make_pair(name, "");
+  }
+  return std::make_pair(name.substr(0, lastDot), name.substr(lastDot));
+}
+
 size_t utf8RemoveLastChar(std::string& str) {
   if (str.empty()) return 0;
   size_t pos = str.size() - 1;

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -61,6 +61,11 @@ bool checkFileExtension(const String& fileName, const char* extension) {
   return localFile.endsWith(localExtension);
 }
 
+bool readableFileExtension(const std::string& fileName) {
+  return (StringUtils::checkFileExtension(fileName, ".epub") || StringUtils::checkFileExtension(fileName, ".xtch") ||
+          StringUtils::checkFileExtension(fileName, ".xtc") || StringUtils::checkFileExtension(fileName, ".txt"));
+}
+
 std::pair<std::string, std::string> splitFileName(const std::string& name) {
   size_t lastDot = name.find_last_of('.');
   if (lastDot == std::string::npos) {

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -19,6 +19,12 @@ std::string sanitizeFilename(const std::string& name, size_t maxLength = 100);
 bool checkFileExtension(const std::string& fileName, const char* extension);
 bool checkFileExtension(const String& fileName, const char* extension);
 
+/**
+ * Split a filename into base name and extension.
+ * If there is no extension, the second element of the pair will be an empty string.
+ */
+std::pair<std::string, std::string> splitFileName(const std::string& name);
+
 // UTF-8 safe string truncation - removes one character from the end
 // Returns the new size after removing one UTF-8 character
 size_t utf8RemoveLastChar(std::string& str);

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -20,6 +20,11 @@ bool checkFileExtension(const std::string& fileName, const char* extension);
 bool checkFileExtension(const String& fileName, const char* extension);
 
 /**
+ * Check if the given filename ends with an extension we can open.
+ */
+bool readableFileExtension(const std::string& fileName);
+
+/**
  * Split a filename into base name and extension.
  * If there is no extension, the second element of the pair will be an empty string.
  */


### PR DESCRIPTION
## Summary

This PR adds support for a very simple [custom BLE protocol](https://github.com/aleksejspopovs/longform/blob/main/app/docs/BLE%20Protocol.md) for receiving files from a phone. It is intended to be used with an Android app I'm also working on called [Longform](https://github.com/aleksejspopovs/longform) that can send arbitrary files over to the X4 but can also use the Accessibility API to scrape text from any app on your phone, so that you can quickly send an article from any app to your reader.

Here's a 35s demo:

https://github.com/user-attachments/assets/e4f54e89-335b-47e7-888b-db0e7e43e245

I figure this is not quite ready to merge yet given that Longform is not yet available on the Play Store, but getting there might still take me a bit because there's still a bit of polishing to be done and probably some work to be compliant with the store's requirements for apps using Accessibility APIs. So I wanted to share this branch here and see if there's any interest in this in the first place, or any feedback (is there a more standard BLE protocol I should be using here? did I fundamentally misunderstand anything about the architecture of Crosspoint?).

## Additional Context

* the ESP32-C3 only supports BLE, not Bluetooth Classic, so we cannot implement the Object Push Profile, the usual Bluetooth file transfer protocol
* framework-arduinoespressif32 comes with a Bluedroid-based BLE stack included, but it uses a lot of Flash/RAM and has a weird callback implementation that makes it impossible to actually use BLE Write With Response as intended. That's why I pull in the lighter (and supposedly more performant) h2zero/NimBLE-Arduino.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_

The code in this PR was written by hand with some AI autocomplete. (The Android app, which is not part of this PR, is 100% vibe-coded.)
