### PR TITLE
fix: goes to relative position when reader settings are changed

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -56,11 +56,16 @@ void EpubReaderActivity::onEnter() {
 
   FsFile f;
   if (SdMan.openFileForRead("ERS", epub->getCachePath() + "/progress.bin", f)) {
-    uint8_t data[4];
-    if (f.read(data, 4) == 4) {
+    uint8_t data[6];
+    int dataSize = f.read(data, 6);
+    if (dataSize == 4 || dataSize == 6) {
       currentSpineIndex = data[0] + (data[1] << 8);
       nextPageNumber = data[2] + (data[3] << 8);
+      cachedSpineIndex = currentSpineIndex;
       Serial.printf("[%lu] [ERS] Loaded cache: %d, %d\n", millis(), currentSpineIndex, nextPageNumber);
+    }
+    if (dataSize == 6) {
+      cachedChapterTotalPageCount = data[4] + (data[5] << 8);
     }
     f.close();
   }
@@ -341,6 +346,17 @@ void EpubReaderActivity::renderScreen() {
     } else {
       section->currentPage = nextPageNumber;
     }
+
+    // handles changes in reader settings and reset to approximate position based on cached progress
+    if (cachedChapterTotalPageCount > 0) {
+      // only goes to relative position if spine index matches cached value
+      if (currentSpineIndex == cachedSpineIndex && section->pageCount != cachedChapterTotalPageCount) {
+        float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
+        int newPage = static_cast<int>(progress * section->pageCount);
+        section->currentPage = newPage;
+      }
+      cachedChapterTotalPageCount = 0;  // resets to 0 to prevent reading cached progress again
+    }
   }
 
   renderer.clearScreen();
@@ -376,12 +392,14 @@ void EpubReaderActivity::renderScreen() {
 
   FsFile f;
   if (SdMan.openFileForWrite("ERS", epub->getCachePath() + "/progress.bin", f)) {
-    uint8_t data[4];
+    uint8_t data[6];
     data[0] = currentSpineIndex & 0xFF;
     data[1] = (currentSpineIndex >> 8) & 0xFF;
     data[2] = section->currentPage & 0xFF;
     data[3] = (section->currentPage >> 8) & 0xFF;
-    f.write(data, 4);
+    data[4] = section->pageCount & 0xFF;
+    data[5] = (section->pageCount >> 8) & 0xFF;
+    f.write(data, 6);
     f.close();
   }
 }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -15,6 +15,8 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   int currentSpineIndex = 0;
   int nextPageNumber = 0;
   int pagesUntilFullRefresh = 0;
+  int cachedSpineIndex = 0;
+  int cachedChapterTotalPageCount = 0;
   bool updateRequired = false;
   const std::function<void()> onGoBack;
   const std::function<void()> onGoHome;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* Aims to fix Issue #220 

* **What changes are included?**
- Increased size of `progress.bin` such that total page count of current section can be stored
- Comparison of total page count is done to determine if reader settings were changed
- New position/page number is calculated using percentage calculated from read progress

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
