### PR TITLE
feat: allow last content to display in sleep mode

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -90,6 +90,7 @@ The Settings screen allows you to configure the device's behavior. There are a f
   - "Custom" - Custom images from the SD card; see [Sleep Screen](#36-sleep-screen) below for more information
   - "Cover" - The book cover image (Note: this is experimental and may not work as expected)
   - "None" - A blank screen
+  - "Last" - Preserve the last content displayed on the screen
 - **Sleep Screen Cover Mode**: How to display the book cover when "Cover" sleep screen is selected:
   - "Fit" (default) - Scale the image down to fit centered on the screen, padding with white borders as necessary
   - "Crop" - Scale the image down and crop as necessary to try to to fill the screen (Note: this is experimental and may not work as expected)

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -16,7 +16,7 @@ class CrossPointSettings {
   CrossPointSettings& operator=(const CrossPointSettings&) = delete;
 
   // Should match with SettingsActivity text
-  enum SLEEP_SCREEN_MODE { DARK = 0, LIGHT = 1, CUSTOM = 2, COVER = 3, BLANK = 4 };
+  enum SLEEP_SCREEN_MODE { DARK = 0, LIGHT = 1, CUSTOM = 2, COVER = 3, BLANK = 4, LAST = 5 };
   enum SLEEP_SCREEN_COVER_MODE { FIT = 0, CROP = 1 };
 
   // Status bar display type enum

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -14,6 +14,11 @@
 
 void SleepActivity::onEnter() {
   Activity::onEnter();
+
+  if (SETTINGS.sleepScreen == CrossPointSettings::SLEEP_SCREEN_MODE::LAST) {
+    return renderLastSleepScreen();
+  }
+
   renderPopup("Entering Sleep...");
 
   if (SETTINGS.sleepScreen == CrossPointSettings::SLEEP_SCREEN_MODE::BLANK) {
@@ -271,4 +276,17 @@ void SleepActivity::renderCoverSleepScreen() const {
 void SleepActivity::renderBlankSleepScreen() const {
   renderer.clearScreen();
   renderer.displayBuffer(EInkDisplay::HALF_REFRESH);
+}
+
+void SleepActivity::renderLastSleepScreen() const {
+  const char * text = "SLEEPING";
+  const int textWidth = renderer.getTextWidth(UI_10_FONT_ID, text, EpdFontFamily::BOLD);
+  constexpr int margin = 5;
+  const int x = (renderer.getScreenWidth() - textWidth - margin * 2) / 2;
+  const int y = (renderer.getScreenHeight() - renderer.getLineHeight(UI_10_FONT_ID) - 20);
+  const int w = textWidth + margin * 2;
+  const int h = renderer.getLineHeight(UI_10_FONT_ID) + margin * 2;
+  renderer.fillRect(x, y, w, h, true);
+  renderer.drawText(UI_10_FONT_ID, x + margin, y + margin, text, false, EpdFontFamily::BOLD);
+  renderer.displayBuffer();
 }

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -16,4 +16,5 @@ class SleepActivity final : public Activity {
   void renderCoverSleepScreen() const;
   void renderBitmapSleepScreen(const Bitmap& bitmap) const;
   void renderBlankSleepScreen() const;
+  void renderLastSleepScreen() const;
 };

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -14,7 +14,7 @@ namespace {
 constexpr int displaySettingsCount = 5;
 const SettingInfo displaySettings[displaySettingsCount] = {
     // Should match with SLEEP_SCREEN_MODE
-    SettingInfo::Enum("Sleep Screen", &CrossPointSettings::sleepScreen, {"Dark", "Light", "Custom", "Cover", "None"}),
+    SettingInfo::Enum("Sleep Screen", &CrossPointSettings::sleepScreen, {"Dark", "Light", "Custom", "Cover", "None", "Last"}),
     SettingInfo::Enum("Sleep Screen Cover Mode", &CrossPointSettings::sleepScreenCoverMode, {"Fit", "Crop"}),
     SettingInfo::Enum("Status Bar", &CrossPointSettings::statusBar, {"None", "No Progress", "Full"}),
     SettingInfo::Enum("Hide Battery %", &CrossPointSettings::hideBatteryPercentage, {"Never", "In Reader", "Always"}),


### PR DESCRIPTION
## Summary

Allow the current content to continue to display in sleep mode. This is actually a feature mirrored from KOReader.

Not quite sure if this should be called "Off", "Disabled" or "Last"

A small "Sleeping" message will be shown at the bottom of the screen:

<img width="484" height="263" alt="image" src="https://github.com/user-attachments/assets/aeba7ef5-15ad-44b3-b958-d56f40fdef6e" />

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? NO
