### PR TITLE
feat: rework CrossPointSettings

### DIFF
--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -49,4 +49,12 @@ static void readString(FsFile& file, std::string& s) {
   s.resize(len);
   file.read(&s[0], len);
 }
+
+static void readString(FsFile& file, char* buffer, size_t maxLen) {
+  uint32_t len;
+  readPod(file, len);
+  const uint32_t bytesToRead = (len < maxLen - 1) ? len : (maxLen - 1);
+  file.read(reinterpret_cast<uint8_t*>(buffer), bytesToRead);
+  buffer[bytesToRead] = '\0';
+}
 }  // namespace serialization

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -1,6 +1,112 @@
 #pragma once
+#include <array>
 #include <cstdint>
 #include <iosfwd>
+#include <string>
+#include <vector>
+
+// Setting descriptor infrastructure
+enum class SettingType { TOGGLE, ENUM, VALUE, STRING };
+
+// Validator function pointer (not std::function to save memory)
+using SettingValidator = bool (*)(uint8_t);
+
+// Forward declare for descriptors
+class CrossPointSettings;
+
+// Forward declare file type
+class FsFile;
+
+// Base descriptor for all settings (non-virtual for constexpr)
+struct SettingDescriptorBase {
+  const char* name;  // Display name
+  SettingType type;
+};
+
+// Value range for VALUE type settings
+struct ValueRange {
+  uint8_t min, max, step;
+};
+
+// Concrete descriptor for uint8_t settings (constexpr-compatible)
+struct SettingDescriptor : public SettingDescriptorBase {
+  union {
+    uint8_t CrossPointSettings::* memberPtr;  // For TOGGLE/ENUM/VALUE types
+    char* stringPtr;                          // For STRING type
+  };
+  uint8_t defaultValue;
+  SettingValidator validator;  // Optional validator function
+
+  union {
+    // For ENUM types
+    struct {
+      const char* const* values;
+      uint8_t count;
+    } enumData;
+
+    // For VALUE types
+    ValueRange valueRange;
+
+    // For STRING types
+    struct {
+      const char* defaultString;  // Default string value
+      size_t maxSize;             // Max size of the string buffer
+    } stringData;
+  };
+
+  // Constexpr constructors for different setting types
+  // TOGGLE/ENUM constructor
+  constexpr SettingDescriptor(const char* name_, SettingType type_, uint8_t CrossPointSettings::* ptr, uint8_t defVal,
+                              SettingValidator val, const char* const* enumVals, uint8_t enumCnt)
+      : SettingDescriptorBase{name_, type_},
+        memberPtr(ptr),
+        defaultValue(defVal),
+        validator(val),
+        enumData{enumVals, enumCnt} {}
+
+  // VALUE constructor
+  constexpr SettingDescriptor(const char* name_, SettingType type_, uint8_t CrossPointSettings::* ptr, uint8_t defVal,
+                              SettingValidator val, ValueRange valRange)
+      : SettingDescriptorBase{name_, type_},
+        memberPtr(ptr),
+        defaultValue(defVal),
+        validator(val),
+        valueRange(valRange) {}
+
+  // STRING constructor
+  constexpr SettingDescriptor(const char* name_, SettingType type_, char* strPtr, const char* defStr, size_t maxSz)
+      : SettingDescriptorBase{name_, type_},
+        stringPtr(strPtr),
+        defaultValue(0),
+        validator(nullptr),
+        stringData{defStr, maxSz} {}
+
+  bool validate(const CrossPointSettings& settings) const;
+  uint8_t getValue(const CrossPointSettings& settings) const;
+  void setValue(CrossPointSettings& settings, uint8_t value) const;
+  void resetToDefault(CrossPointSettings& settings) const;
+  void save(FsFile& file, const CrossPointSettings& settings) const;
+  void load(FsFile& file, CrossPointSettings& settings) const;
+
+  // Helper to get enum value as string
+  const char* getEnumValueString(uint8_t index) const {
+    if (index < enumData.count && enumData.values) {
+      return enumData.values[index];
+    }
+    return "";
+  }
+};
+
+// Validator functions (constexpr for compile-time optimization)
+constexpr bool validateToggle(uint8_t v) { return v <= 1; }
+template <uint8_t MAX>
+constexpr bool validateEnum(uint8_t v) {
+  return v < MAX;
+}
+template <uint8_t MIN, uint8_t MAX>
+constexpr bool validateRange(uint8_t v) {
+  return v >= MIN && v <= MAX;
+}
 
 class CrossPointSettings {
  private:
@@ -15,13 +121,17 @@ class CrossPointSettings {
   CrossPointSettings(const CrossPointSettings&) = delete;
   CrossPointSettings& operator=(const CrossPointSettings&) = delete;
 
-  enum SLEEP_SCREEN_MODE { DARK = 0, LIGHT = 1, CUSTOM = 2, COVER = 3, BLANK = 4, SLEEP_SCREEN_MODE_COUNT };
-  enum SLEEP_SCREEN_COVER_MODE { FIT = 0, CROP = 1, SLEEP_SCREEN_COVER_MODE_COUNT };
+  // Static constexpr array of all setting descriptors
+  static constexpr size_t DESCRIPTOR_COUNT = 23;
+  static const std::array<SettingDescriptor, DESCRIPTOR_COUNT> descriptors;
+
+  // Should match with SettingsActivity text
+  enum SLEEP_SCREEN_MODE { DARK = 0, LIGHT = 1, CUSTOM = 2, COVER = 3, BLANK = 4 };
+  enum SLEEP_SCREEN_COVER_MODE { FIT = 0, CROP = 1 };
   enum SLEEP_SCREEN_COVER_FILTER {
     NO_FILTER = 0,
     BLACK_AND_WHITE = 1,
     INVERTED_BLACK_AND_WHITE = 2,
-    SLEEP_SCREEN_COVER_FILTER_COUNT
   };
 
   // Status bar display type enum
@@ -31,7 +141,6 @@ class CrossPointSettings {
     FULL = 2,
     FULL_WITH_PROGRESS_BAR = 3,
     ONLY_PROGRESS_BAR = 4,
-    STATUS_BAR_MODE_COUNT
   };
 
   enum ORIENTATION {
@@ -39,7 +148,6 @@ class CrossPointSettings {
     LANDSCAPE_CW = 1,   // 800x480 logical coordinates, rotated 180° (swap top/bottom)
     INVERTED = 2,       // 480x800 logical coordinates, inverted
     LANDSCAPE_CCW = 3,  // 800x480 logical coordinates, native panel orientation
-    ORIENTATION_COUNT
   };
 
   // Front button layout options
@@ -50,25 +158,23 @@ class CrossPointSettings {
     LEFT_RIGHT_BACK_CONFIRM = 1,
     LEFT_BACK_CONFIRM_RIGHT = 2,
     BACK_CONFIRM_RIGHT_LEFT = 3,
-    FRONT_BUTTON_LAYOUT_COUNT
   };
 
   // Side button layout options
   // Default: Previous, Next
   // Swapped: Next, Previous
-  enum SIDE_BUTTON_LAYOUT { PREV_NEXT = 0, NEXT_PREV = 1, SIDE_BUTTON_LAYOUT_COUNT };
+  enum SIDE_BUTTON_LAYOUT { PREV_NEXT = 0, NEXT_PREV = 1 };
 
   // Font family options
-  enum FONT_FAMILY { BOOKERLY = 0, NOTOSANS = 1, OPENDYSLEXIC = 2, FONT_FAMILY_COUNT };
+  enum FONT_FAMILY { BOOKERLY = 0, NOTOSANS = 1, OPENDYSLEXIC = 2 };
   // Font size options
-  enum FONT_SIZE { SMALL = 0, MEDIUM = 1, LARGE = 2, EXTRA_LARGE = 3, FONT_SIZE_COUNT };
-  enum LINE_COMPRESSION { TIGHT = 0, NORMAL = 1, WIDE = 2, LINE_COMPRESSION_COUNT };
+  enum FONT_SIZE { SMALL = 0, MEDIUM = 1, LARGE = 2, EXTRA_LARGE = 3 };
+  enum LINE_COMPRESSION { TIGHT = 0, NORMAL = 1, WIDE = 2 };
   enum PARAGRAPH_ALIGNMENT {
     JUSTIFIED = 0,
     LEFT_ALIGN = 1,
     CENTER_ALIGN = 2,
     RIGHT_ALIGN = 3,
-    PARAGRAPH_ALIGNMENT_COUNT
   };
 
   // Auto-sleep timeout options (in minutes)
@@ -78,7 +184,6 @@ class CrossPointSettings {
     SLEEP_10_MIN = 2,
     SLEEP_15_MIN = 3,
     SLEEP_30_MIN = 4,
-    SLEEP_TIMEOUT_COUNT
   };
 
   // E-ink refresh frequency (pages between full refreshes)
@@ -88,14 +193,13 @@ class CrossPointSettings {
     REFRESH_10 = 2,
     REFRESH_15 = 3,
     REFRESH_30 = 4,
-    REFRESH_FREQUENCY_COUNT
   };
 
   // Short power button press actions
-  enum SHORT_PWRBTN { IGNORE = 0, SLEEP = 1, PAGE_TURN = 2, SHORT_PWRBTN_COUNT };
+  enum SHORT_PWRBTN { IGNORE = 0, SLEEP = 1, PAGE_TURN = 2 };
 
   // Hide battery percentage
-  enum HIDE_BATTERY_PERCENTAGE { HIDE_NEVER = 0, HIDE_READER = 1, HIDE_ALWAYS = 2, HIDE_BATTERY_PERCENTAGE_COUNT };
+  enum HIDE_BATTERY_PERCENTAGE { HIDE_NEVER = 0, HIDE_READER = 1, HIDE_ALWAYS = 2 };
 
   // Sleep screen settings
   uint8_t sleepScreen = DARK;

--- a/src/activities/settings/CategorySettingsActivity.h
+++ b/src/activities/settings/CategorySettingsActivity.h
@@ -7,38 +7,14 @@
 #include <string>
 #include <vector>
 
+#include "CrossPointSettings.h"
 #include "activities/ActivityWithSubactivity.h"
 
-class CrossPointSettings;
-
-enum class SettingType { TOGGLE, ENUM, ACTION, VALUE };
-
-struct SettingInfo {
+// Action items for the System category
+struct ActionItem {
   const char* name;
-  SettingType type;
-  uint8_t CrossPointSettings::* valuePtr;
-  std::vector<std::string> enumValues;
-
-  struct ValueRange {
-    uint8_t min;
-    uint8_t max;
-    uint8_t step;
-  };
-  ValueRange valueRange;
-
-  static SettingInfo Toggle(const char* name, uint8_t CrossPointSettings::* ptr) {
-    return {name, SettingType::TOGGLE, ptr};
-  }
-
-  static SettingInfo Enum(const char* name, uint8_t CrossPointSettings::* ptr, std::vector<std::string> values) {
-    return {name, SettingType::ENUM, ptr, std::move(values)};
-  }
-
-  static SettingInfo Action(const char* name) { return {name, SettingType::ACTION, nullptr}; }
-
-  static SettingInfo Value(const char* name, uint8_t CrossPointSettings::* ptr, const ValueRange valueRange) {
-    return {name, SettingType::VALUE, ptr, {}, valueRange};
-  }
+  enum class Type { KOREADER_SYNC, CALIBRE_SETTINGS, CLEAR_CACHE, CHECK_UPDATES };
+  Type type;
 };
 
 class CategorySettingsActivity final : public ActivityWithSubactivity {
@@ -47,8 +23,8 @@ class CategorySettingsActivity final : public ActivityWithSubactivity {
   bool updateRequired = false;
   int selectedSettingIndex = 0;
   const char* categoryName;
-  const SettingInfo* settingsList;
-  int settingsCount;
+  const std::vector<const SettingDescriptor*> descriptors;
+  const std::vector<ActionItem> actionItems;
   const std::function<void()> onGoBack;
 
   static void taskTrampoline(void* param);
@@ -58,11 +34,12 @@ class CategorySettingsActivity final : public ActivityWithSubactivity {
 
  public:
   CategorySettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const char* categoryName,
-                           const SettingInfo* settingsList, int settingsCount, const std::function<void()>& onGoBack)
+                           const std::vector<const SettingDescriptor*>& descriptors,
+                           const std::vector<ActionItem>& actionItems, const std::function<void()>& onGoBack)
       : ActivityWithSubactivity("CategorySettings", renderer, mappedInput),
         categoryName(categoryName),
-        settingsList(settingsList),
-        settingsCount(settingsCount),
+        descriptors(descriptors),
+        actionItems(actionItems),
         onGoBack(onGoBack) {}
   void onEnter() override;
   void onExit() override;

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -9,9 +9,6 @@
 
 #include "activities/ActivityWithSubactivity.h"
 
-class CrossPointSettings;
-struct SettingInfo;
-
 class SettingsActivity final : public ActivityWithSubactivity {
   TaskHandle_t displayTaskHandle = nullptr;
   SemaphoreHandle_t renderingMutex = nullptr;


### PR DESCRIPTION
## Summary

Multiple goals are achieved with this change:

- make descriptions of settings close to their definitions: the labels are in the same file as the configuration declarations
- settings validation on loading with reset to default in case of bad value
- (de)serialization is based on a single list of descriptors: single point of truth
- possibly to have default values for the String configuration type
- more `constexpr` to reduce RAM usage
- less hardcoded values
- more maintainable

## RAM Usage:
 From
```
RAM:   [===       ]  32.5% (used 106516 bytes from 327680 bytes)
Flash: [========= ]  94.9% (used 6217240 bytes from 6553600 bytes)
```
 To
```
RAM:   [===       ]  32.3% (used 105844 bytes from 327680 bytes)
Flash: [========= ]  94.8% (used 6213636 bytes from 6553600 bytes)
```

## Boot config validation:
```
[1186] [SD] SD card detected
[1192] [CPS] Invalid value for Status Bar, resetting to default [1192] [CPS] Settings loaded from file
```

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_
