### PR TITLE
docs: Supported languages (old)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CrossPoint Reader aims to:
 * Support **customisable font, layout, and display** options.
 * Run purely on the **Xteink X4 hardware**.
 
-CrossPoint Reader supports EPUB files in at least these languages: English, Spanish, French, _____, Russian, Ukranian, ______. 
+CrossPoint Reader supports EPUB files in multiple languages, including English, Spanish, French, _____, _____, _____, Russian, Ukranian, ______. // TODO
 
 This project is **not affiliated with Xteink**; it's built as a community project.
 


### PR DESCRIPTION
## Summary

Update README with the list of supported languages for EPUB files.

## Additional Context

For weeks, I thought this firmware only supported English, because I remember you saying that full language support would only be possible after implementing proper font rendering. I also remember mentioning a separate Korean fork, and so on. 

All of this made it clear that this system doesn't support my languages. I was surprised when I saw a Reddit post with a photo of a book in my native language. Only then I did learn that such languages ​​are supported. Therefore, mentioning the supported languages ​​would help future buyers and new users.
