### PR TITLE
fix: line break

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -125,6 +125,20 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
   } else if (matches(name, BLOCK_TAGS, NUM_BLOCK_TAGS)) {
     if (strcmp(name, "br") == 0) {
+      // flush word preceding <br> to currentTextBlock before calling startNewTextBlock
+      EpdFontFamily::Style fontStyle = EpdFontFamily::REGULAR;
+      if (self->boldUntilDepth < self->depth && self->italicUntilDepth < self->depth) {
+        fontStyle = EpdFontFamily::BOLD_ITALIC;
+      } else if (self->boldUntilDepth < self->depth) {
+        fontStyle = EpdFontFamily::BOLD;
+      } else if (self->italicUntilDepth < self->depth) {
+        fontStyle = EpdFontFamily::ITALIC;
+      }
+
+      self->partWordBuffer[self->partWordBufferIndex] = '\0';
+      self->currentTextBlock->addWord(self->partWordBuffer, fontStyle);
+      self->partWordBufferIndex = 0;
+      
       self->startNewTextBlock(self->currentTextBlock->getStyle());
     } else {
       self->startNewTextBlock((TextBlock::Style)self->paragraphAlignment);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -142,8 +142,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
   } else if (matches(name, BLOCK_TAGS, NUM_BLOCK_TAGS)) {
     if (strcmp(name, "br") == 0) {
-      // flush word preceding <br/> to currentTextBlock before calling startNewTextBlock
-      self->flushPartWordBuffer();
+      if (self->partWordBufferIndex > 0) {
+        // flush word preceding <br/> to currentTextBlock before calling startNewTextBlock
+        self->flushPartWordBuffer();
+      }
       self->startNewTextBlock(self->currentTextBlock->getStyle());
     } else {
       self->startNewTextBlock((TextBlock::Style)self->paragraphAlignment);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -40,18 +40,18 @@ bool matches(const char* tag_name, const char* possible_tags[], const int possib
   return false;
 }
 
+// flush the contents of partWordBuffer to currentTextBlock
 void ChapterHtmlSlimParser::flushPartWordBuffer() {
+  // determine font style
   EpdFontFamily::Style fontStyle = EpdFontFamily::REGULAR;
-  if (boldUntilDepth < depth) {
-    if (italicUntilDepth < depth) {
-      fontStyle = EpdFontFamily::BOLD_ITALIC;
-    } else {
-      fontStyle = EpdFontFamily::BOLD;
-    }
+  if (boldUntilDepth < depth && italicUntilDepth < depth) {
+    fontStyle = EpdFontFamily::BOLD_ITALIC;
+  } else if (boldUntilDepth < depth) {
+    fontStyle = EpdFontFamily::BOLD;
   } else if (italicUntilDepth < depth) {
     fontStyle = EpdFontFamily::ITALIC;
   }
-
+  // flush the buffer
   partWordBuffer[partWordBufferIndex] = '\0';
   currentTextBlock->addWord(partWordBuffer, fontStyle);
   partWordBufferIndex = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -138,7 +138,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->partWordBuffer[self->partWordBufferIndex] = '\0';
       self->currentTextBlock->addWord(self->partWordBuffer, fontStyle);
       self->partWordBufferIndex = 0;
-      
+
       self->startNewTextBlock(self->currentTextBlock->getStyle());
     } else {
       self->startNewTextBlock((TextBlock::Style)self->paragraphAlignment);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -125,7 +125,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
   } else if (matches(name, BLOCK_TAGS, NUM_BLOCK_TAGS)) {
     if (strcmp(name, "br") == 0) {
-      // flush word preceding <br> to currentTextBlock before calling startNewTextBlock
+      // flush word preceding <br/> to currentTextBlock before calling startNewTextBlock
       EpdFontFamily::Style fontStyle = EpdFontFamily::REGULAR;
       if (self->boldUntilDepth < self->depth && self->italicUntilDepth < self->depth) {
         fontStyle = EpdFontFamily::BOLD_ITALIC;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -39,7 +39,7 @@ class ChapterHtmlSlimParser {
   bool hyphenationEnabled;
 
   void startNewTextBlock(TextBlock::Style style);
-  void flushPartWordBuffer(EpdFontFamily::Style fontStyle);
+  void flushPartWordBuffer();
   void makePages();
   // XML callbacks
   static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** atts);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -39,6 +39,7 @@ class ChapterHtmlSlimParser {
   bool hyphenationEnabled;
 
   void startNewTextBlock(TextBlock::Style style);
+  void flushPartWordBuffer(EpdFontFamily::Style fontStyle);
   void makePages();
   // XML callbacks
   static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** atts);


### PR DESCRIPTION
## Summary

* Fixes #519 
* Refactors repeated code into new function: `ChapterHtmlSlimParser::flushPartWordBuffer()`
    
## Additional Context 
  
* The `<br/>` tag is self closing and _in-line_, so the existing logic for closing block tags does not get applied to `<br/>` tags.
* This PR adds the _in-line_ logic to:
  * Flush the word preceding the `<br/>` tag from `partWordBuffer`  to `currentTextBlock` before calling `startNewTextBlock`  
* **New function**: `ChapterHtmlSlimParser::flushPartWordBuffer()`
  * **Purpose**: Consolidates the logic for flushing `partWordBuffer` to `currentTextBlock`
  * **Impact**: Simplifies `ChapterHtmlSlimParser::characterData(…)`, `ChapterHtmlSlimParser::startElement(…)`, and `ChapterHtmlSlimParser::endElement(…)` by integrating reused code into single function

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
