### PR TITLE
fix: Fix KOReader document md5 calculation for binary matching progress sync

### DIFF
--- a/lib/KOReaderSync/KOReaderDocumentId.cpp
+++ b/lib/KOReaderSync/KOReaderDocumentId.cpp
@@ -33,10 +33,10 @@ std::string KOReaderDocumentId::calculateFromFilename(const std::string& filePat
 
 size_t KOReaderDocumentId::getOffset(int i) {
   // Offset = 1024 << (2*i)
-  // For i = -1: 1024 >> 2 = 256
+  // For i = -1: KOReader uses a value of 0
   // For i >= 0: 1024 << (2*i)
   if (i < 0) {
-    return CHUNK_SIZE >> (-2 * i);
+    return 0;
   }
   return CHUNK_SIZE << (2 * i);
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Resolve [KoSync progress does not sync between Crosspoint-reader and KOReader (Kindle)](https://github.com/crosspoint-reader/crosspoint-reader/issues/502)

* **What changes are included?**
KOReaderDocumentId::getOffset() - Update the value for the md5 offset calculation to match KOReader.

## Additional Context

I've tested this with a couple of my ebooks and binary matching with KOReader sync seems to be working fine now for both pushing and pulling progress.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
