### PR TITLE
docs: Update README with supported languages for EPUB 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ This project is **not affiliated with Xteink**; it's built as a community projec
   - [ ] Full UTF support
 - [x] Screen rotation
 
-See [the user guide](./USER_GUIDE.md) for instructions on operating CrossPoint.
+Multi-language support: Read EPUBs in various languages, including English, Spanish, French, German, Italian, Portuguese, Russian, Ukrainian, Polish, Swedish, Norwegian, [and more](./USER_GUIDE.md#supported-languages).
+
+See [the user guide](./USER_GUIDE.md) for instructions on operating CrossPoint. 
 
 ## Installing
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -177,6 +177,15 @@ This feature can be disabled in **[Settings](#35-settings)** to help avoid chang
 * **Return to Home:** Press and **hold** the **Back** button to close the book and return to the **[Home](#31-home-screen)** screen.
 * **Chapter Menu:** Press **Confirm** to open the **[Table of Contents/Chapter Selection](#5-chapter-selection-screen)**.
 
+### Supported Languages
+
+CrossPoint renders text using the following Unicode character blocks, enabling support for a wide range of languages:
+
+*   **Latin Script (Basic, Supplement, Extended-A):** Covers English, German, French, Spanish, Portuguese, Italian, Dutch, Swedish, Norwegian, Danish, Finnish, Polish, Czech, Hungarian, Romanian, Slovak, Slovenian, Turkish, and others.
+*   **Cyrillic Script (Standard and Extended):** Covers Russian, Ukrainian, Belarusian, Bulgarian, Serbian, Macedonian, Kazakh, Kyrgyz, Mongolian, and others.
+
+What is not supported: Chinese, Japanese, Korean, Vietnamese, Hebrew, Arabic and Farsi.
+
 ---
 
 ## 5. Chapter Selection Screen


### PR DESCRIPTION
## Summary

- Update README with the list of supported languages for EPUB files.
- Update USER_GUIDE with an extended list of supported and unsupported languages. 

## Additional Context

For weeks, I thought this firmware only supported English, because I remember you saying that full language support would only be possible after implementing proper font rendering. I also remember mentioning a separate Korean fork, Vietnamese issues and so on.

All of this made it clear that this system doesn't support my languages. I was surprised when I saw a Reddit post with a photo of a book in my native language. Only then I did learn that such languages ​​are supported. Therefore, mentioning the supported languages ​​would help future buyers and new users.

---

### AI Usage

Did you use AI tools to help write this code? _**NO**_
