### PR TITLE
fix: generate sleep cover according to mode (FIT/CROP) to avoid artifacts. 

### DIFF
--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -565,3 +565,32 @@ bool JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(FsFile& jpegFile, Print
                                                          int targetMaxHeight) {
   return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetMaxWidth, targetMaxHeight, true);
 }
+
+// Get JPEG dimensions without full conversion
+bool JpegToBmpConverter::getJpegDimensions(FsFile& jpegFile, int& width, int& height) {
+  // Reset file position to beginning
+  if (!jpegFile.seek(0)) {
+    Serial.printf("[%lu] [JPG] Failed to seek to beginning of JPEG file\n", millis());
+    return false;
+  }
+
+  // Initialize JPEG decoder
+  pjpeg_image_info_t imageInfo = {};
+  JpegReadContext context{jpegFile, {}, 0, 0};
+
+  const int decodeStatus = pjpeg_decode_init(&imageInfo, jpegReadCallback, &context, false);
+  if (decodeStatus != 0) {
+    Serial.printf("[%lu] [JPG] pjpeg_decode_init failed with status %d\n", millis(), decodeStatus);
+    return false;
+  }
+
+  // Get dimensions from image info
+  width = imageInfo.m_width;
+  height = imageInfo.m_height;
+
+  Serial.printf("[%lu] [JPG] Read JPEG dimensions: %dx%d\n", millis(), width, height);
+
+  // Reset file position after reading
+  jpegFile.seek(0);
+  return true;
+}

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.h
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.h
@@ -16,4 +16,6 @@ class JpegToBmpConverter {
   static bool jpegFileToBmpStreamWithSize(FsFile& jpegFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   // Convert to 1-bit BMP (black and white only, no grays) for fast home screen rendering
   static bool jpegFileTo1BitBmpStreamWithSize(FsFile& jpegFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
+  // Get JPEG dimensions without full conversion
+  static bool getJpegDimensions(FsFile& jpegFile, int& width, int& height);
 };


### PR DESCRIPTION
Closes #348 

## Summary

* **What is the goal of this PR?**  
  Implement pre-calculated dimensions for EPUB cover image rendering in sleep screen modes (FIT and CROP) to eliminate runtime scaling artifacts and improve visual clarity.

* **What changes are included?**
  1. **JpegToBmpConverter::getJpegDimensions()** - Extract JPEG dimensions from header
  2. **Epub::getCoverBmpPath()** - Fix ternary operator precedence bug
  3. **Epub::generateCoverBmp()** - Pre-calculate exact dimensions per mode:
     - **FIT**: width=480px, height=(480×jpegHeight)/jpegWidth
     - **CROP**: height=800px, width=(800×jpegWidth)/jpegHeight
     - Convert JPEG to BMP with calculated dimensions (no runtime scaling)
     - Generate separate cache file per mode to avoid scaling artifacts

## Additional Context

* **Visual Improvements:**
  - Eliminates "grid-like" artifacts from aggressive runtime downsampling
  - Pre-scaled images are sharp and properly proportioned

* **Testing Completed:**
  - ✅ Verified with various JPEG aspect ratios (portrait, landscape, square)
  - ✅ Confirmed separate cache files (`cover_fit.bmp` vs `cover_crop.bmp`) are created per mode
  - ✅ Validated serial logs show correct calculated dimensions:
    ```
    [EBP] Calculated FIT dimensions: 480x720 (original JPEG: 600x900)
    [EBP] Calculated CROP dimensions: 533x800 (original JPEG: 600x900)
    ```
  - ✅ Validated sleep screen visual clarity improvement (no runtime scaling artifacts)

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_

- Used for code analysis and implementation validation
- Manual code review and testing performed
- All core algorithm decisions validated against requirements