### PR TITLE
chore: .gitignore: add compile_commands.json & .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ lib/EpdFont/fontsrc
 .vs
 build
 **/__pycache__/
+/compile_commands.json
+/.cache


### PR DESCRIPTION

## Summary

* **What is the goal of this PR?**
Quality of Life

* **What changes are included?**
Add compile_commands.json & .cache to .gitignore .

Both are use by clangd that can help IDE support.

Run `pio run --target compiledb` to generate `compile_commands.json`.


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
