### PR TITLE
PoC: introduce packed resources format

### DIFF
--- a/lib/ResourcesFS/ResourcesFS.cpp
+++ b/lib/ResourcesFS/ResourcesFS.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "ResourcesFS.h"
 
 #include <Arduino.h>
@@ -35,7 +33,6 @@ bool ResourcesFS::begin(bool remount) {
   spi_flash_mmap_handle_t map_handle;  // unused
   size_t len = impl->partition->size;
   if (len > MAX_ALLOC_SIZE) {
-    // FIXME: cannot mmap too large region at once, why?
     len = MAX_ALLOC_SIZE;
   }
 

--- a/lib/ResourcesFS/ResourcesFS.cpp
+++ b/lib/ResourcesFS/ResourcesFS.cpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "ResourcesFS.h"
+
+#include <Arduino.h>
+#include <esp_partition.h>
+
+#include <vector>
+
+ResourcesFS ResourcesFS::instance;
+
+class ResourcesFS::Impl {
+ public:
+  const esp_partition_t* partition = nullptr;
+  const Header* header = nullptr;
+  const uint8_t* mmap_data = nullptr;
+};
+
+bool ResourcesFS::begin(bool remount) {
+  if (!remount) {
+    assert(impl == nullptr && "begin called multiple times");
+    impl = new Impl();
+  } else {
+    assert(impl != nullptr && "remount called before initial begin");
+  }
+
+  impl->partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, nullptr);
+  if (!impl->partition) {
+    Serial.printf("[%lu] [FSS] SPIFFS partition not found, skipping\n", millis());
+    impl->header = nullptr;
+    impl->mmap_data = nullptr;
+    return false;
+  }
+
+  spi_flash_mmap_handle_t map_handle;  // unused
+  size_t len = impl->partition->size;
+  if (len > MAX_ALLOC_SIZE) {
+    // FIXME: cannot mmap too large region at once, why?
+    len = MAX_ALLOC_SIZE;
+  }
+
+  auto err =
+      esp_partition_mmap(impl->partition, 0, len, SPI_FLASH_MMAP_DATA, (const void**)&impl->mmap_data, &map_handle);
+  if (err != ESP_OK || impl->mmap_data == nullptr) {
+    Serial.printf("[%lu] [FSS] mmap failed, code: %d, skipping\n", millis(), err);
+    impl->header = nullptr;
+    impl->mmap_data = nullptr;
+    return false;
+  }
+
+  impl->header = (const Header*)impl->mmap_data;
+  if (impl->header->magic != MAGIC) {
+    Serial.printf("[%lu] [FSS] Invalid magic: 0x%08X, skipping\n", millis(), impl->header->magic);
+    impl->header = nullptr;
+    impl->mmap_data = nullptr;
+    return false;
+  }
+
+  Serial.printf("[%lu] [FSS] ResourcesFS initialized\n", millis());
+  return true;
+}
+
+const ResourcesFS::Header* ResourcesFS::getRoot() {
+  assert(impl != nullptr);
+  return impl->header;
+}
+
+const uint8_t* ResourcesFS::mmap(const ResourcesFS::FileEntry* entry) {
+  assert(impl != nullptr);
+  assert(impl->header != nullptr);
+  assert(impl->mmap_data != nullptr);
+
+  size_t offset = sizeof(Header);
+  for (size_t i = 0; i < MAX_FILES; i++) {
+    const FileEntry& e = impl->header->entries[i];
+    if (&e == entry) {
+      break;
+    }
+    offset += e.size;
+    offset += get_padding(e.size);
+  }
+  return impl->mmap_data + offset;
+}
+
+bool ResourcesFS::erase(size_t size) {
+  assert(impl != nullptr);
+  assert(impl->partition != nullptr);
+
+  // align size to sector size
+  static constexpr size_t sector_size = 4096;
+  size = (size + sector_size - 1) / sector_size * sector_size;
+
+  auto err = esp_partition_erase_range(impl->partition, 0, size);
+  if (err != ESP_OK) {
+    Serial.printf("[%lu] [FSS] erase failed, code %d\n", millis(), err);
+    return false;
+  }
+
+  return true;
+}
+
+bool ResourcesFS::write(uint32_t offset, const uint8_t* data, size_t len) {
+  assert(impl != nullptr);
+  assert(impl->partition != nullptr);
+  assert(offset + len <= impl->partition->size);
+
+  auto err = esp_partition_write(impl->partition, offset, data, len);
+  if (err != ESP_OK) {
+    Serial.printf("[%lu] [FSS] write failed, offset %u, len %u, code %d\n", millis(), offset, len, err);
+    return false;
+  }
+  return true;
+}

--- a/lib/ResourcesFS/ResourcesFS.h
+++ b/lib/ResourcesFS/ResourcesFS.h
@@ -11,11 +11,14 @@ class ResourcesFS {
   ResourcesFS() = default;
   ~ResourcesFS() = default;
 
+  // FIXME: true MAX_ALLOC_SIZE = ~3.5MB but not enough pages to do mmap
+  // See: spi_flash_mmap_get_free_pages() --> ~31 free pages on real device
+
   static constexpr size_t MAX_FILES = 32;
   static constexpr size_t MAX_FILE_NAME_LENGTH = 32;
-  static constexpr size_t MAX_ALLOC_SIZE = 3 * 1024 * 1024;  // 3 MB
-  static constexpr size_t ALIGNMENT = 4;                     // bytes
-  static constexpr uint32_t MAGIC = 0x46535631;              // "FSV1"
+  static constexpr size_t MAX_ALLOC_SIZE = 28 * 64 * 1024;  // 28 pages == ~1.8 MB
+  static constexpr size_t ALIGNMENT = 4;                    // bytes
+  static constexpr uint32_t MAGIC = 0x46535631;             // "FSV1"
 
   enum FileType {
     FILETYPE_INVALID = 0,

--- a/lib/ResourcesFS/ResourcesFS.h
+++ b/lib/ResourcesFS/ResourcesFS.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+// Simple implementation of read-only packed filesystem
+// Inspired by packed resources used by some STM32 smartwatch / smartband firmwares
+class ResourcesFS {
+ public:
+  ResourcesFS() = default;
+  ~ResourcesFS() = default;
+
+  static constexpr size_t MAX_FILES = 32;
+  static constexpr size_t MAX_FILE_NAME_LENGTH = 32;
+  static constexpr size_t MAX_ALLOC_SIZE = 3 * 1024 * 1024;  // 3 MB
+  static constexpr size_t ALIGNMENT = 4;                     // bytes
+  static constexpr uint32_t MAGIC = 0x46535631;              // "FSV1"
+
+  enum FileType {
+    FILETYPE_INVALID = 0,
+    FILETYPE_FONT_REGULAR = 1,
+  };
+
+  struct __attribute__((packed)) FileEntry {
+    uint32_t type;
+    uint32_t size;
+    char name[MAX_FILE_NAME_LENGTH];
+  };
+  static_assert(sizeof(FileEntry) == (4 + 4 + MAX_FILE_NAME_LENGTH));
+
+  struct __attribute__((packed)) Header {
+    uint32_t magic;
+    FileEntry entries[MAX_FILES];
+  };
+  static_assert(sizeof(Header) == 4 + MAX_FILES * sizeof(FileEntry));
+  static_assert(sizeof(Header) % ALIGNMENT == 0);
+
+  static size_t get_padding(size_t size) {
+    size_t remainder = size % ALIGNMENT;
+    return (remainder == 0) ? 0 : (ALIGNMENT - remainder);
+  }
+
+  // returns true if mounted successfully
+  // remount should only be used after write/erase operations
+  bool begin(bool remount = false);
+
+  // returns nullptr if not mounted
+  const Header* getRoot();
+
+  // always return a valid pointer; undefined behavior if entry is invalid
+  const uint8_t* mmap(const FileEntry* entry);
+
+  // flash writing
+  // (note: erase must be called before writing, otherwise write will result in corrupted data)
+  bool erase(size_t size);
+  bool write(uint32_t offset, const uint8_t* data, size_t len);
+
+#ifdef CREATE_RESOURCES
+  // to be used by host CLI tool that creates the packed filesystem
+  uint8_t writeData[MAX_ALLOC_SIZE];
+  size_t writeDataSize = 0;
+
+  void beginCreate() {
+    Header* header = (Header*)writeData;
+    header->magic = MAGIC;
+    for (size_t i = 0; i < MAX_FILES; i++) {
+      header->entries[i].type = FILETYPE_INVALID;
+      header->entries[i].size = 0;
+      header->entries[i].name[0] = '\0';
+    }
+    writeDataSize = sizeof(Header);
+  }
+
+  uint8_t* getWriteData() { return writeData; }
+
+  size_t getWriteSize() { return writeDataSize; }
+
+  // return error message or nullptr if successful
+  const char* addFileEntry(const FileEntry& entry, const uint8_t* data) {
+    Header* header = (Header*)writeData;
+    if (entry.size % ALIGNMENT != 0) {
+      return "File size must be multiple of alignment";
+    }
+    if (writeDataSize + entry.size > MAX_ALLOC_SIZE) {
+      return "Not enough space in ResourcesFS image";
+    }
+    if (entry.size == 0 || entry.name[0] == '\0') {
+      return "Invalid file entry";
+    }
+    // find empty slot
+    for (size_t i = 0; i < MAX_FILES; i++) {
+      if (header->entries[i].type == FILETYPE_INVALID) {
+        header->entries[i] = entry;
+        // copy data
+        size_t offset = writeDataSize;
+        for (size_t j = 0; j < entry.size; j++) {
+          writeData[offset + j] = data[j];
+        }
+        writeDataSize += entry.size;  // (no need padding here as size is already aligned)
+        return nullptr;               // success
+      } else if (strncmp(header->entries[i].name, entry.name, MAX_FILE_NAME_LENGTH) == 0) {
+        return "File with the same name already exists";
+      }
+    }
+    return "No empty slot available";
+  }
+#endif
+
+  static ResourcesFS& getInstance() { return instance; }
+
+ private:
+  // using pimpl to allow re-using this header on host system without Arduino dependencies
+  class Impl;
+  Impl* impl = nullptr;
+
+  static ResourcesFS instance;
+};
+
+#define Resources ResourcesFS::getInstance()

--- a/scripts/make_resources.py
+++ b/scripts/make_resources.py
@@ -1,0 +1,110 @@
+import argparse
+import struct
+import sys
+import os
+
+# TODO: sync with ResourcesFS.h
+
+MAX_FILES = 32
+MAX_FILE_NAME_LENGTH = 32
+ALIGNMENT = 4
+MAGIC = 0x46535631
+MAX_ALLOC_SIZE = 3 * 1024 * 1024
+
+filetype_map = {
+  'INVALID': 0,
+  'FONT_REGULAR': 1,
+}
+
+def main():
+  parser = argparse.ArgumentParser(description='Generate resources.bin')
+  parser.add_argument('-o', default='resources.bin', help='specify output binary file (default: resources.bin)')
+  parser.add_argument('inputs', nargs='*', help='file1:type1 file2:type2 ... (note: if file name contains extension, it will be stripped; example: my_font.bin:FONT_REGULAR will be stored as "my_font")')
+  args = parser.parse_args()
+
+  write_data = bytearray()
+  write_data += struct.pack('<I', MAGIC)
+  for _ in range(MAX_FILES):
+    write_data += struct.pack('<II32s', 0, 0, b'\x00' * 32)
+  current_size = len(write_data)
+
+  for inp in args.inputs:
+    try:
+      file_path, type_str = inp.split(':')
+    except ValueError:
+      print(f"Invalid input format: {inp}. Expected file:type")
+      sys.exit(1)
+
+    basename = os.path.basename(file_path)
+    name = os.path.splitext(basename)[0]
+    name_len = len(name.encode('ascii'))
+    if name_len > MAX_FILE_NAME_LENGTH - 1:
+      print(f"File name too long: {name} (max {MAX_FILE_NAME_LENGTH - 1} chars)")
+      sys.exit(1)
+    name_bytes = name.encode('ascii') + b'\x00' * (MAX_FILE_NAME_LENGTH - name_len)
+
+    if type_str.isdigit():
+      type_int = int(type_str)
+    else:
+      upper_type = type_str.upper()
+      if upper_type in filetype_map:
+        type_int = filetype_map[upper_type]
+      else:
+        print(f"Unknown file type: {type_str}")
+        sys.exit(1)
+
+    try:
+      with open(file_path, 'rb') as f:
+        data = f.read()
+    except IOError as e:
+      print(f"Error reading file {file_path}: {e}")
+      sys.exit(1)
+
+    size = len(data)
+    if size == 0:
+      print(f"Invalid file entry: empty file {file_path}")
+      sys.exit(1)
+    if size % ALIGNMENT != 0:
+      print(f"File size must be multiple of alignment ({ALIGNMENT}): {file_path} size={size}")
+      sys.exit(1)
+    if current_size + size > MAX_ALLOC_SIZE:
+      print(f"Not enough space in ResourcesFS image for {file_path}")
+      sys.exit(1)
+
+    # Find empty slot and check for duplicates
+    found = -1
+    for i in range(MAX_FILES):
+      offset = 4 + i * 40
+      t, s, n = struct.unpack_from('<II32s', write_data, offset)
+      name_existing = n.split(b'\x00', 1)[0].decode('ascii', errors='ignore')
+      if t == 0:
+        if found == -1:
+          found = i
+      elif name_existing == name:
+        print(f"File with the same name already exists: {name}")
+        sys.exit(1)
+
+    if found == -1:
+      print("No empty slot available")
+      sys.exit(1)
+
+    # Set entry
+    offset = 4 + found * 40
+    write_data[offset:offset + 8] = struct.pack('<II', type_int, size)
+    write_data[offset + 8:offset + 40] = name_bytes
+
+    # Append data
+    write_data += data
+    current_size += size
+
+    print(f"Added file: {name}, type={type_int}, size={size}")
+
+  try:
+    with open(args.o, 'wb') as f:
+      f.write(write_data)
+  except IOError as e:
+    print(f"Error writing output file {args.o}: {e}")
+    sys.exit(1)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
## Summary

Currently, some features like custom fonts cannot be implemented via SD card because the read speed will be quite slow.

This PR introduce packed resources format that is inspired by some STM32 smartwatch / smartband firmwares. One of my past (hobby) work was also based around this idea: https://github.com/ngxson/amazfit-bip-web

Instead of having a fully functional FS like spiffs or littlefs, we simply pack the resources into one big binary, then have a header table to tell where to find the resource.

Memory layout is simple:

```
--- header section ---
magic number
file0: name, type, size
file1: name, type, size
...
fileN: name, type, size
--- file1 data ---
...
--- file2 data ---
...
...
--- fileN data ---
...
```

The key benefit is that it allows using [esp_partition_mmap](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/storage/partition.html#_CPPv418esp_partition_mmapPK15esp_partition_t6size_t6size_t27esp_partition_mmap_memory_tPPKvP27esp_partition_mmap_handle_t) to read the data, eliminate the need of copying it onto system RAM.

## Included in this PR

- The implementation of `ResourcesFS`
- A python script to pack multiple files into `resources.bin`
- A minimal demo of automatically flashing `resources.bin` into device's flash, then read a file from it

The expected user flow will be:
1. The project can provide a list of pre-made resources, similar to https://amazfitbip.ngxson.com
2. User choose the resources to be packed, and download it to SD card (file name: `resources.bin`)
3. Upon boot, resource will automatically be flashed

Alternatively, we can also leverage the web flasher to flash it directly to spiffs partition.

## Caveats

The biggest caveat is that the ESP32's MMU only has a limited number of pages to be used for mmap'ing. There are a total of 256 pages (= 16MB), but some are data-only some are instruction-only:

- Data page can be accessed with byte-aligned access (meaning you can read from everywhere)
- Instruction page must be accessed with 4-byte alignment, so you cannot access, for example `basePtr + 0x1`

Currently, with the version on `master` branch, we have (31 app + 31 inst) = 62 pages available (= ~3.9MB, each page is 64KB). This PR uses an addition of 28 data pages, leaving 3 pages left. This is currently hard-coded, but we can modify such that the number of pages can be control more dynamically.

## Additional Context

Please note that I open this PR mostly for discussion (CC @daveallie )

Demo:
- Create a file named `test.txt`
- Run `python scripts/make_resources.py -o resources.bin test.txt:FONT_REGULAR`
- Copy `resources.bin` to SD card
- Power on the device, observe Serial logs

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **--> Only for writing python code**
