### PR TITLE
feat: Double shift to turn on caps mode

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -71,6 +71,10 @@ class KeyboardEntryActivity : public Activity {
   int selectedRow = 0;
   int selectedCol = 0;
   bool shiftActive = false;
+  bool capsLockActive = false;
+  unsigned long lastShiftTapMs = 0;
+
+  static constexpr unsigned long SHIFT_DOUBLE_TAP_MS = 500;
 
   // Callbacks
   OnCompleteCallback onComplete;


### PR DESCRIPTION
## Summary

While typing in the passwords for wifi etc. I realized that it is very cumbersome to keep hititng shift for consecutive capital letter characters. This PR adds a common feature that is available on all modern devices i.e., double shift to turn on caps. 

## Additional Context

The changes are minimal, the hardcoded value is the double-tap window (currently it is 500ms, happy to change it as seen fit). 


https://github.com/user-attachments/assets/35d34acc-f9ea-40f0-98b7-4d9b6d2e9a9e




---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Partially. I used codex to understand the codebase. Additionally, I verified any tab completion changes before pushing. 
