### PR TITLE
fix: custom sleep not showing image at index 0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,7 +317,6 @@ void setup() {
     // Clear app state to avoid getting into a boot loop if the epub doesn't load
     const auto path = APP_STATE.openEpubPath;
     APP_STATE.openEpubPath = "";
-    APP_STATE.lastSleepImage = 0;
     APP_STATE.saveToFile();
     onGoToReader(path, MyLibraryActivity::Tab::Recent);
   }


### PR DESCRIPTION
## Summary

* Fixing custom sleep behaviour where the first image in the /sleep directory is not shown
  * image at index 0 is not being rendered when more than 1 image is stored in /sleep directory, because `APP_STATE.lastSleepImage` is always 0.

## Additional Context

* `APP_STATE.lastSleepImage` is reset to 0 when a epub is open, this value is only used to compare it to the randomly selected one in `renderCustomSleepScreen()` that should always be a valid index, since the list of valid bmp images is colected from scratch. -> no need to reset it and block image @ index 0 from being rendered

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
