### PR TITLE
fix: webserver folder creation regex change

### DIFF
--- a/docs/webserver.md
+++ b/docs/webserver.md
@@ -153,7 +153,7 @@ Click **File Manager** to access file management features.
 
 1. Click the **+ Add** button in the top-right corner
 2. Select **New Folder** from the dropdown menu
-3. Enter a folder name (letters, numbers, underscores, and hyphens only)
+3. Enter a folder name (must not contain characters \" * : < > ? / \\ | and must not be . or ..)
 4. Click **Create Folder**
 
 This is useful for organizing your ebooks by genre, author, or series.

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1146,10 +1146,10 @@ function retryAllFailedUploads() {
       return;
     }
 
-    // Validate folder name (no special characters except underscore and hyphen)
-    const validName = /^[a-zA-Z0-9_\-]+$/.test(folderName);
+    // Validate folder name
+    const validName = /^(?!\.{1,2}$)[^"*:<>?\/\\|]+$/.test(folderName);
     if (!validName) {
-      alert('Folder name can only contain letters, numbers, underscores, and hyphens.');
+      alert('Folder name cannot contain \" * : < > ? / \\ | and must not be . or ..');
       return;
     }
 


### PR DESCRIPTION
## Summary

Resolves #562 

Implements regex change to support valid characters discussed by @daveallie in issue [here](https://github.com/crosspoint-reader/crosspoint-reader/issues/562#issuecomment-3830809156). 

Also rejects `.` and `..` as folder names which are invalid in FAT32 and exFAT filesystems

## Additional Context
- Unsure on the wording for the alert, it feels overly explicit, but that might be a good thing. Happy to change.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
