### PR TITLE
feat: Add inverse display setting

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -33,6 +33,8 @@ class GfxRenderer {
   RenderMode renderMode;
   Orientation orientation;
   bool fadingFix;
+  bool inverseDisplay;
+  mutable bool fullRefreshPending = false;
   uint8_t* frameBuffer = nullptr;
   uint8_t* bwBufferChunks[BW_BUFFER_NUM_CHUNKS] = {nullptr};
   std::map<int, EpdFontFamily> fontMap;
@@ -46,7 +48,7 @@ class GfxRenderer {
 
  public:
   explicit GfxRenderer(HalDisplay& halDisplay)
-      : display(halDisplay), renderMode(BW), orientation(Portrait), fadingFix(false) {}
+      : display(halDisplay), renderMode(BW), orientation(Portrait), fadingFix(false), inverseDisplay(false) {}
   ~GfxRenderer() { freeBwBufferChunks(); }
 
   static constexpr int VIEWABLE_MARGIN_TOP = 9;
@@ -64,6 +66,14 @@ class GfxRenderer {
 
   // Fading fix control
   void setFadingFix(const bool enabled) { fadingFix = enabled; }
+
+  // Inverse display: auto-inverts drawPixel and clearScreen in BW render mode
+  void setInverseDisplay(const bool enabled) {
+    if (inverseDisplay != enabled) {
+      fullRefreshPending = true;
+    }
+    inverseDisplay = enabled;
+  }
 
   // Screen ops
   int getScreenWidth() const;

--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -118,6 +118,7 @@ bool CrossPointSettings::saveToFile() const {
   serialization::writePod(outputFile, frontButtonRight);
   serialization::writePod(outputFile, fadingFix);
   serialization::writePod(outputFile, embeddedStyle);
+  serialization::writePod(outputFile, inverseDisplay);
   // New fields added at end for backward compatibility
   outputFile.close();
 
@@ -222,6 +223,8 @@ bool CrossPointSettings::loadFromFile() {
     serialization::readPod(inputFile, fadingFix);
     if (++settingsRead >= fileSettingsCount) break;
     serialization::readPod(inputFile, embeddedStyle);
+    if (++settingsRead >= fileSettingsCount) break;
+    serialization::readPod(inputFile, inverseDisplay);
     if (++settingsRead >= fileSettingsCount) break;
     // New fields added at end for backward compatibility
   } while (false);

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -171,6 +171,8 @@ class CrossPointSettings {
   uint8_t fadingFix = 0;
   // Use book's embedded CSS styles for EPUB rendering (1 = enabled, 0 = disabled)
   uint8_t embeddedStyle = 1;
+  // Inverse display (white text on black background)
+  uint8_t inverseDisplay = 0;
 
   ~CrossPointSettings() = default;
 

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -46,6 +46,7 @@ inline std::vector<SettingInfo> getSettingsList() {
       SettingInfo::Toggle("Extra Paragraph Spacing", &CrossPointSettings::extraParagraphSpacing,
                           "extraParagraphSpacing", "Reader"),
       SettingInfo::Toggle("Text Anti-Aliasing", &CrossPointSettings::textAntiAliasing, "textAntiAliasing", "Reader"),
+      SettingInfo::Toggle("Inverse Display", &CrossPointSettings::inverseDisplay, "inverseDisplay", "Display"),
 
       // --- Controls ---
       SettingInfo::Enum("Side Button Layout (reader)", &CrossPointSettings::sideButtonLayout,

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -688,14 +688,14 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   // grayscale rendering
   // TODO: Only do this if font supports it
   if (SETTINGS.textAntiAliasing) {
-    renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    renderer.clearScreen(0x00);
     page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
     renderer.copyGrayscaleLsbBuffers();
 
     // Render and copy to MSB buffer
-    renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    renderer.clearScreen(0x00);
     page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
     renderer.copyGrayscaleMsbBuffers();
 

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -471,13 +471,13 @@ void TxtReaderActivity::renderPage() {
     // Save BW buffer for restoration after grayscale pass
     renderer.storeBwBuffer();
 
-    renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    renderer.clearScreen(0x00);
     renderLines();
     renderer.copyGrayscaleLsbBuffers();
 
-    renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    renderer.clearScreen(0x00);
     renderLines();
     renderer.copyGrayscaleMsbBuffers();
 

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -288,6 +288,7 @@ void XtcReaderActivity::renderPage() {
 
     // Pass 2: LSB buffer - mark DARK gray only (XTH value 1)
     // In LUT: 0 bit = apply gray effect, 1 bit = untouched
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
     renderer.clearScreen(0x00);
     for (uint16_t y = 0; y < pageHeight; y++) {
       for (uint16_t x = 0; x < pageWidth; x++) {
@@ -300,6 +301,7 @@ void XtcReaderActivity::renderPage() {
 
     // Pass 3: MSB buffer - mark LIGHT AND DARK gray (XTH value 1 or 2)
     // In LUT: 0 bit = apply gray effect, 1 bit = untouched
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
     renderer.clearScreen(0x00);
     for (uint16_t y = 0; y < pageHeight; y++) {
       for (uint16_t x = 0; x < pageWidth; x++) {
@@ -313,6 +315,7 @@ void XtcReaderActivity::renderPage() {
 
     // Display grayscale overlay
     renderer.displayGrayBuffer();
+    renderer.setRenderMode(GfxRenderer::BW);
 
     // Pass 4: Re-render BW to framebuffer (restore for next frame, instead of restoreBwBuffer)
     renderer.clearScreen();

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -227,6 +227,9 @@ void SettingsActivity::toggleCurrentSetting() {
     return;
   }
 
+  // Sync renderer state immediately so the next render uses the new values
+  renderer.setInverseDisplay(SETTINGS.inverseDisplay);
+
   SETTINGS.saveToFile();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,6 +360,7 @@ void loop() {
   gpio.update();
 
   renderer.setFadingFix(SETTINGS.fadingFix);
+  renderer.setInverseDisplay(SETTINGS.inverseDisplay);
 
   if (Serial && millis() - lastMemPrint >= 10000) {
     Serial.printf("[%lu] [MEM] Free: %d bytes, Total: %d bytes, Min Free: %d bytes\n", millis(), ESP.getFreeHeap(),


### PR DESCRIPTION
Adds an "Inverse Display" toggle under Display settings that renders white text/UI on a black background across the entire UI — home screen, settings, file browser, readers, and all other activities.

## Approach

Rather than threading `!inverse` through every draw call and activity, this implements auto-inversion at the GfxRenderer level:

- **`drawPixel()`** flips pixel state when `inverseDisplay && renderMode == BW`
- **`clearScreen()`** flips the fill color under the same condition
- **`setInverseDisplay()`** on GfxRenderer triggers a full refresh when the value changes, so the transition between modes is clean

This means all activities get inverse display for free with zero per-activity changes. The setting is synced from `SETTINGS.inverseDisplay` every loop iteration in `main.cpp`, and also immediately on toggle in `SettingsActivity` to avoid a race with the render task.

### Grayscale anti-aliasing

The `renderMode == BW` guard ensures grayscale buffer setup (`clearScreen(0x00)` and `drawPixel` calls during `GRAYSCALE_LSB`/`GRAYSCALE_MSB` passes) is unaffected by auto-inversion. Reader activities reorder `setRenderMode()` before `clearScreen(0x00)` so the mode is already non-BW when the buffer is cleared.

For the grayscale LUT row selection in `renderChar`, the conditions now use `!inverseDisplay` directly (instead of relying on the caller's `pixelState` parameter):

- **GRAYSCALE_MSB**: `(bmpVal == 1 || (!inverseDisplay && bmpVal == 2))` — in inverse mode, only bmpVal=1 gets MSB marked
- **GRAYSCALE_LSB**: `bmpVal == (inverseDisplay ? 2 : 1)` — swaps which gray level gets LSB marked

This reassigns LUT rows so fringe pixels use waveforms that push FROM the physically-white starting state TOWARD black, producing visible gray transitions on the inverted background. (In normal mode, fringe pixels start black and get pulled toward white — the inverse needs the opposite direction.)

### Why not hardware inversion?

The SSD1677's command 0x21 bit 3 can invert BW source output, but this breaks differential fast refresh: the BW RAM gets inverted while RED RAM (previous frame) doesn't, so every pixel gets the wrong LUT transition applied, causing severe ghosting. Software-level inversion avoids this entirely.

## Files changed

- **GfxRenderer.h/.cpp** — `inverseDisplay` member, `setInverseDisplay()`, auto-inversion in `drawPixel`/`clearScreen`/`displayBuffer`, grayscale conditions in `renderChar`/`drawTextRotated90CW`
- **CrossPointSettings.h/.cpp** — `inverseDisplay` field with serialization
- **SettingsList.h** — Toggle in Display category
- **EpubReaderActivity.cpp / TxtReaderActivity.cpp** — Reorder `setRenderMode()` before `clearScreen(0x00)` in grayscale passes
- **XtcReaderActivity.cpp** — Add `setRenderMode()` calls around grayscale passes for consistency
- **SettingsActivity.cpp** — Sync `renderer.setInverseDisplay()` on toggle
- **main.cpp** — Sync `renderer.setInverseDisplay()` in main loop

---

### AI Usage

Designed and tested by me on a physical device. Implementation by Claude Opus 4.6 using Claude Code.