### PR TITLE
fix: Increase network SSID display length

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -546,8 +546,8 @@ void WifiSelectionActivity::renderNetworkList() const {
 
       // Draw network name (truncate if too long)
       std::string displayName = network.ssid;
-      if (displayName.length() > 16) {
-        displayName.replace(13, displayName.length() - 13, "...");
+      if (displayName.length() > 33) {
+        displayName.replace(30, displayName.length() - 30, "...");
       }
       renderer.drawText(UI_10_FONT_ID, 20, networkY, displayName.c_str());
 


### PR DESCRIPTION
## Rationale 

I have 2 wifi access points with almost identical names, just one has `_EXT` at the end of it. With the current display limit of 13 characters before adding ellipsis, I can't tell which is which.

Before device screenshot with masked SSIDs:
<img src="https://github.com/user-attachments/assets/3c5cbbaa-b2f6-412f-b5a8-6278963bd0f2" width="300">


## Summary

Adjusted displayed length from 13 characters to 30 in the Wifi selection screen - I've left some space for potential proportional font changes in the future

After image with masked SSIDs:
<img src="https://github.com/user-attachments/assets/c5f0712b-bbd3-4eec-9820-4693fae90c9f" width="300">

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
