### PR TITLE
perf: Enable Link Time Optimization (LTO)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,9 @@ board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_upload.offset_address = 0x10000
 
+build_unflags = -fno-lto
 build_flags =
+  -flto
   -DARDUINO_USB_MODE=1
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DMINIZ_NO_ZLIB_COMPATIBLE_NAMES=1


### PR DESCRIPTION
Add `build_unflags = -fno-lto` to remove ESP-IDF's default LTO-off flag, and add `-flto` to build_flags.

| Metric        | Without LTO          | With LTO             | Delta        | % Change |
|---------------|----------------------|----------------------|--------------|----------|
| firmware.bin  | 6,371,440 B          | 6,241,072 B          | -130,368 B   | -2.0%    |
| firmware.elf  | 39,599,948 B         | 22,893,308 B         | -16,706,640 B| -42.2%   |
| Flash used    | 6,218,928 B (94.9%)  | 6,117,722 B (93.3%)  | -101,206 B   | -1.6%    |
| RAM used      | 106,508 B (32.5%)    | 105,964 B (32.3%)    | -544 B       | -0.5%    |

## Summary

Enable link-time optimization for slightly more efficient flash usage. 

**I believe this change is stable and beneficial, but I am new to the project. This should absolutely get a little bit of user testing before merge.**

## Additional Context

In #660 @osteotek mentioned that you folks are doing some Flash usage optimization. I asked if there was a reason that LTO wasn't enabled, it sounds like it's just something that nobody had tried before. I did a little bit of testing last night, and it didn't seem to have an impact on system stability and does save us a fair number of bytes of flash. 

---

### AI Usage

Did you use AI tools to help write this code? **YES**

This was implemented by Claude Opus 4.5 using the Claude code 2.1.25 harness. 

Just for kicks, this is the relevant part of my conversation with the agent:
```
                                                                                                                              
❯ This is Crosspoint, an ESP32 e-reader firmware. I'd like us to build, check the sizes of the built artifacts, enable        
  LTO, and check the sizes of the built artifacts again. Have you reported to me?                                             
  ⎿  Async hook SessionStart completed:                                                                                       
                                                                                                                              
                                                                                                                              
∴ Thinking…                                                                                                                   
                                                                                                                              
  Jesse wants me to:                                                                                                          
  1. Build the project                                                                                                        
  2. Check sizes of built artifacts                                                                                           
  3. Enable LTO (Link-Time Optimization)                                                                                      
  4. Check sizes again                                                                                                        

[...]
     ld/default/firmware.elf                                                                                                  
                                                                                                                              
⏺ Baseline (no LTO):                                                                                                          
  - firmware.bin: 6,371,440 bytes (6.07 MB)                                                                                   
  - firmware.elf: 39,599,948 bytes (37.77 MB)                                                                                 
  - RAM: 32.5% (106,508 / 327,680 bytes)                                                                                      
  - Flash: 94.9% (6,218,928 / 6,553,600 bytes)                                                                                
                                                                                                                              
  Now enabling LTO. I need to add build_unflags = -fno-lto and -flto to the [base] section.                                   
                                                                                                                              
⏺ Update(/Users/jesse/Documents/GitHub/crosspoint/crosspoint-reader/platformio.ini)                                           
  ⎿  Added 2 lines                                                                                                            
      18  board_upload.maximum_size = 16777216                                                                                
      19  board_upload.offset_address = 0x10000                                                                               
      20                                                                                                                      
      21 +build_unflags = -fno-lto                                                                                            
      22  build_flags =                                                                                                       
      23 +  -flto                                                                                                             
      24    -DARDUINO_USB_MODE=1                                                                                              
      25    -DARDUINO_USB_CDC_ON_BOOT=1                                                                                       
      26    -DMINIZ_NO_ZLIB_COMPATIBLE_NAMES=1                                                                                
                                                                                                                              
⏺ Now rebuilding with LTO. This will need a full rebuild since LTO changes compilation.                                       
                                                                                                                              

[...]
⏺ Build with LTO also succeeded. Let me get the sizes.                                                                        
                                                                                                                              
⏺ Bash(ls -la /Users/jesse/Documents/GitHub/crosspoint/crosspoint-reader/.pio/build/default/firmware.bin                      
      /Users/jesse/Documents/GitHub/crosspoint/crosspoint-reader/.pi…)                                                        
  ⎿  -rw-r--r--@ 1 jesse  staff   6241072 Feb  2 15:48 /Users/jesse/Documents/GitHub/crosspoint/crosspoint-reader/.pio/bui    
     ld/default/firmware.bin                                                                                                  
     -rwxr-xr-x@ 1 jesse  staff  22893308 Feb  2 15:48 /Users/jesse/Documents/GitHub/crosspoint/crosspoint-reader/.pio/bui    
     ld/default/firmware.elf                                                                                                  
                                                                                                                              
⏺ Done. Here are the results, Jesse:                                                                                          
                                                                                                                              
  LTO Impact on Crosspoint Reader                                                                                             
  ┌──────────────┬─────────────────────┬─────────────────────┬───────────────┬──────────┐                                     
  │    Metric    │     Without LTO     │      With LTO       │     Delta     │ % Change │                                     
  ├──────────────┼─────────────────────┼─────────────────────┼───────────────┼──────────┤                                     
  │ firmware.bin │ 6,371,440 B         │ 6,241,072 B         │ -130,368 B    │ -2.0%    │                                     
  ├──────────────┼─────────────────────┼─────────────────────┼───────────────┼──────────┤                                     
  │ firmware.elf │ 39,599,948 B        │ 22,893,308 B        │ -16,706,640 B │ -42.2%   │                                     
  ├──────────────┼─────────────────────┼─────────────────────┼───────────────┼──────────┤                                     
  │ Flash used   │ 6,218,928 B (94.9%) │ 6,117,722 B (93.3%) │ -101,206 B    │ -1.6%    │                                     
  ├──────────────┼─────────────────────┼─────────────────────┼───────────────┼──────────┤                                     
  │ RAM used     │ 106,508 B (32.5%)   │ 105,964 B (32.3%)   │ -544 B        │ -0.5%    │                                     
  └──────────────┴─────────────────────┴─────────────────────┴───────────────┴──────────┘                                     
  LTO shaved ~101 KB off flash usage (1.6% reduction) and ~127 KB off the firmware.bin. The ELF file dropped dramatically     
  because LTO eliminates dead code and debug info more aggressively. RAM is essentially unchanged.                            
                                                                                                                              
  The change to platformio.ini adds build_unflags = -fno-lto (to remove ESP-IDF's default LTO-off flag) and -flto to          
  build_flags.                                                                                                                
                                                                                                                              
✻ Crunched for 3m 43s                                                                                                         
                                                                                                                              
❯ I would like you to commit this change with all of those details in the commit message.                                     
                                                                                                                              
```
