### PR TITLE
fix: dynamic continue reading card sizing based on cover image

### DIFF
--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -567,5 +567,5 @@ bool JpegToBmpConverter::jpegFileToBmpStreamWithSize(FsFile& jpegFile, Print& bm
 // Convert to 1-bit BMP (black and white only, no grays) for fast home screen rendering
 bool JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(FsFile& jpegFile, Print& bmpOut, int targetMaxWidth,
                                                          int targetMaxHeight) {
-  return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetMaxWidth, targetMaxHeight, true);
+  return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetMaxWidth, targetMaxHeight, true, false);
 }


### PR DESCRIPTION
Original Issue: #348

## Summary

* **What is the goal of this PR?**
- Adapt card width to cover image aspect ratio when available
- Maintain fixed 400px height for consistent layout
- Use actual image dimensions instead of hardcoded 240px width for EPUBs
- Add fallback to half-screen size when no cover image exists
- Parameter correction to avoid rendering artifacts

* **What changes are included?**
- HomeActivity.cpp: Dynamic logic to adapt the card width according to the cover's aspect ratio
- Epub.cpp: Calculation of dynamic dimensions based on the actual dimensions of the JPG image
- JpegToBmpConverter.cpp: Parameter correction to avoid rendering artifacts based on fix #662


## Additional Context

**Continue Reading Card**

v0.16.0 artifacts / fixed size card:
![IMG20260203122332](https://github.com/user-attachments/assets/4bbdce56-d9ef-4220-b99c-43e0eceb41fa)

Fix #662 without artifacts / fixed size card:
![IMG20260203120651](https://github.com/user-attachments/assets/694a1263-fedd-435e-be62-d3ec093e023b)

This PR without artifacts / dinamic card width:
![IMG20260203120959](https://github.com/user-attachments/assets/ac4a1f02-45ef-40b4-8536-5663f62b1188)

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
