### PR TITLE
fix: Scrolling page items calculation

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -268,7 +268,6 @@ void HomeActivity::render() {
     menuItems.insert(menuItems.begin() + 2, "OPDS Browser");
   }
 
-  Serial.printf("Home menu items count: %d\n", static_cast<int>(menuItems.size()));
   GUI.drawButtonMenu(
       renderer,
       Rect{0, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.verticalSpacing, pageWidth,

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -3,6 +3,8 @@
 #include <GfxRenderer.h>
 #include <SDCardManager.h>
 
+#include <algorithm>
+
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -157,14 +159,14 @@ void MyLibraryActivity::loop() {
   int listSize = static_cast<int>(files.size());
   if (upReleased) {
     if (skipPage) {
-      selectorIndex = max(((selectorIndex / pageItems - 1) * pageItems), 0);
+      selectorIndex = std::max(static_cast<int>((selectorIndex / pageItems - 1) * pageItems), 0);
     } else {
       selectorIndex = (selectorIndex + listSize - 1) % listSize;
     }
     updateRequired = true;
   } else if (downReleased) {
     if (skipPage) {
-      selectorIndex = min(((selectorIndex / pageItems + 1) * pageItems), listSize - 1);
+      selectorIndex = std::min(static_cast<int>((selectorIndex / pageItems + 1) * pageItems), listSize - 1);
     } else {
       selectorIndex = (selectorIndex + 1) % listSize;
     }

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -3,6 +3,8 @@
 #include <GfxRenderer.h>
 #include <SDCardManager.h>
 
+#include <algorithm>
+
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
@@ -92,14 +94,14 @@ void RecentBooksActivity::loop() {
   int listSize = static_cast<int>(recentBooks.size());
   if (upReleased) {
     if (skipPage) {
-      selectorIndex = max(((selectorIndex / pageItems - 1) * pageItems), 0);
+      selectorIndex = std::max(static_cast<int>((selectorIndex / pageItems - 1) * pageItems), 0);
     } else {
       selectorIndex = (selectorIndex + listSize - 1) % listSize;
     }
     updateRequired = true;
   } else if (downReleased) {
     if (skipPage) {
-      selectorIndex = min(((selectorIndex / pageItems + 1) * pageItems), listSize - 1);
+      selectorIndex = std::min(static_cast<int>((selectorIndex / pageItems + 1) * pageItems), listSize - 1);
     } else {
       selectorIndex = (selectorIndex + 1) % listSize;
     }

--- a/src/components/UITheme.h
+++ b/src/components/UITheme.h
@@ -6,9 +6,6 @@
 #include "CrossPointSettings.h"
 #include "components/themes/BaseTheme.h"
 
-inline int min(const int a, const int b) { return a < b ? a : b; }
-inline int max(const int a, const int b) { return a > b ? a : b; }
-
 class UITheme {
   // Static instance
   static UITheme instance;


### PR DESCRIPTION
## Summary

Fix for the page skip issue detected https://github.com/crosspoint-reader/crosspoint-reader/pull/700#issuecomment-3856374323 by user @whyte-j 

Skipping down on the last page now skips to the last item, and up on the first page to the first item, rather than wrapping around the list in a weird way.

## Additional Context

The calculation was outdated after several changes were added afterwards

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
