### PR TITLE
fix: increase lyra sideButtonHintsWidth to 30

### DIFF
--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -26,7 +26,7 @@ constexpr ThemeMetrics values = {.batteryWidth = 16,
                                  .homeCoverTileHeight = 287,
                                  .homeRecentBooksCount = 3,
                                  .buttonHintsHeight = 40,
-                                 .sideButtonHintsWidth = 19,
+                                 .sideButtonHintsWidth = 30,
                                  .versionTextRightX = 20,
                                  .versionTextY = 55,
                                  .bookProgressBarHeight = 4};


### PR DESCRIPTION
## Summary

Increase the width of Lyra's side button hints. It has been set to 30, the same width as the classic theme.


Before:
<img width="457" height="742" alt="image" src="https://github.com/user-attachments/assets/316e4679-fbf0-4f6e-b117-413075da1be2" />

After:
<img width="512" height="849" alt="image" src="https://github.com/user-attachments/assets/3b0cf069-55ad-4d5a-a93c-4aeca3ff67f8" />



## Additional Context

Resolves https://github.com/crosspoint-reader/crosspoint-reader/pull/700#issuecomment-3856983832

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code?
No
