### PR TITLE
fix: issue if book href are absolute url and not relative to server

### DIFF
--- a/src/util/UrlUtils.cpp
+++ b/src/util/UrlUtils.cpp
@@ -25,6 +25,10 @@ std::string extractHost(const std::string& url) {
 }
 
 std::string buildUrl(const std::string& serverUrl, const std::string& path) {
+  // If path is already an absolute URL (has protocol), use it directly
+  if (path.find("://") != std::string::npos) {
+    return path;
+  }
   const std::string urlWithProtocol = ensureProtocol(serverUrl);
   if (path.empty()) {
     return urlWithProtocol;


### PR DESCRIPTION
## Summary

fixing issue if book href are absolute url and not relative to the server

## Additional Context

* Fixes https://github.com/crosspoint-reader/crosspoint-reader/issues/632
* https://github.com/harshit181/RSSPub/issues/43

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**<  PARTIALLY>**_

