### PR TITLE
fix: Account for nbsp; character as whitespace

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -360,8 +360,6 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     }
 
     // Treat Non-Breaking Space (U+00A0) = 0xC2 0xA0 as a word separator
-    // EPUBs use &nbsp; between short prepositions and following words (e.g. Polish "w domu")
-    // The nbsp should render as a visible space, not merge words together (issue #743)
     const XML_Char NBSP_BYTE_1 = static_cast<XML_Char>(0xC2);
     const XML_Char NBSP_BYTE_2 = static_cast<XML_Char>(0xA0);
     if (s[i] == NBSP_BYTE_1 && (i + 1 < len) && s[i + 1] == NBSP_BYTE_2) {


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**
- Fixed an issue with `nbsp;` not being counted as whitespace, which caused words to incorrectly join together

**What changes are included?**
- Added separate handling for `nbsp;` characters similar to how we already handle BOM characters

## Additional Context

- Closes #743 
- Updated my test EPUB [here](https://github.com/jdk2pq/css-test-epub) with examples of this at the end of the book

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES*_, Claude Code
