### PR TITLE
feat: Add FB2 format support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 **/__pycache__/
 /compile_commands.json
 /.cache
+CLAUDE.md

--- a/lib/Fb2/Fb2.cpp
+++ b/lib/Fb2/Fb2.cpp
@@ -1,0 +1,306 @@
+#include "Fb2.h"
+
+#include <HalStorage.h>
+#include <HardwareSerial.h>
+#include <Serialization.h>
+
+#include "Fb2/Fb2CoverExtractor.h"
+#include "Fb2/Fb2MetadataParser.h"
+
+namespace {
+constexpr uint8_t FB2_CACHE_VERSION = 1;
+}  // namespace
+
+Fb2::Fb2(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {
+  cachePath = cacheDir + "/fb2_" + std::to_string(std::hash<std::string>{}(this->filepath));
+}
+
+bool Fb2::loadMetadataCache() {
+  const auto cacheFile = cachePath + "/book.bin";
+  FsFile file;
+  if (!Storage.openFileForRead("FB2", cacheFile, file)) {
+    return false;
+  }
+
+  uint8_t version;
+  serialization::readPod(file, version);
+  if (version != FB2_CACHE_VERSION) {
+    file.close();
+    Serial.printf("[%lu] [FB2] Cache version mismatch: %u vs %u\n", millis(), version, FB2_CACHE_VERSION);
+    return false;
+  }
+
+  serialization::readString(file, title);
+  serialization::readString(file, author);
+  serialization::readString(file, language);
+  serialization::readString(file, coverBinaryId);
+
+  uint16_t sectionCount;
+  serialization::readPod(file, sectionCount);
+  sections.clear();
+  sections.reserve(sectionCount);
+  for (uint16_t i = 0; i < sectionCount; i++) {
+    SectionInfo info;
+    serialization::readString(file, info.title);
+    uint32_t offset, length;
+    serialization::readPod(file, offset);
+    serialization::readPod(file, length);
+    info.fileOffset = offset;
+    info.length = length;
+    sections.push_back(std::move(info));
+  }
+
+  uint16_t tocCount;
+  serialization::readPod(file, tocCount);
+  tocEntries.clear();
+  tocEntries.reserve(tocCount);
+  for (uint16_t i = 0; i < tocCount; i++) {
+    TocEntry entry;
+    serialization::readString(file, entry.title);
+    int16_t idx;
+    serialization::readPod(file, idx);
+    entry.sectionIndex = idx;
+    tocEntries.push_back(std::move(entry));
+  }
+
+  file.close();
+  Serial.printf("[%lu] [FB2] Loaded metadata cache: %d sections, %d TOC entries\n", millis(), sectionCount, tocCount);
+  return true;
+}
+
+bool Fb2::saveMetadataCache() const {
+  const auto cacheFile = cachePath + "/book.bin";
+  FsFile file;
+  if (!Storage.openFileForWrite("FB2", cacheFile, file)) {
+    return false;
+  }
+
+  serialization::writePod(file, FB2_CACHE_VERSION);
+  serialization::writeString(file, title);
+  serialization::writeString(file, author);
+  serialization::writeString(file, language);
+  serialization::writeString(file, coverBinaryId);
+
+  const uint16_t sectionCount = static_cast<uint16_t>(sections.size());
+  serialization::writePod(file, sectionCount);
+  for (const auto& info : sections) {
+    serialization::writeString(file, info.title);
+    serialization::writePod(file, static_cast<uint32_t>(info.fileOffset));
+    serialization::writePod(file, static_cast<uint32_t>(info.length));
+  }
+
+  const uint16_t tocCount = static_cast<uint16_t>(tocEntries.size());
+  serialization::writePod(file, tocCount);
+  for (const auto& entry : tocEntries) {
+    serialization::writeString(file, entry.title);
+    serialization::writePod(file, static_cast<int16_t>(entry.sectionIndex));
+  }
+
+  file.close();
+  Serial.printf("[%lu] [FB2] Saved metadata cache\n", millis());
+  return true;
+}
+
+bool Fb2::parseMetadata() {
+  Fb2MetadataParser parser(filepath);
+  if (!parser.parse()) {
+    Serial.printf("[%lu] [FB2] Failed to parse metadata\n", millis());
+    return false;
+  }
+
+  title = parser.getTitle();
+  author = parser.getAuthor();
+  language = parser.getLanguage();
+  coverBinaryId = parser.getCoverBinaryId();
+  sections = parser.getSections();
+  tocEntries = parser.getTocEntries();
+
+  Serial.printf("[%lu] [FB2] Parsed: title=%s, author=%s, sections=%d\n", millis(), title.c_str(), author.c_str(),
+                static_cast<int>(sections.size()));
+  return true;
+}
+
+bool Fb2::load(const bool buildIfMissing) {
+  Serial.printf("[%lu] [FB2] Loading FB2: %s\n", millis(), filepath.c_str());
+
+  // Try cache first
+  if (loadMetadataCache()) {
+    loaded = true;
+    Serial.printf("[%lu] [FB2] Loaded from cache\n", millis());
+    return true;
+  }
+
+  if (!buildIfMissing) {
+    return false;
+  }
+
+  // Parse from scratch
+  Serial.printf("[%lu] [FB2] Cache not found, parsing...\n", millis());
+  setupCacheDir();
+
+  if (!parseMetadata()) {
+    return false;
+  }
+
+  if (!saveMetadataCache()) {
+    Serial.printf("[%lu] [FB2] Warning: Could not save metadata cache\n", millis());
+  }
+
+  loaded = true;
+  return true;
+}
+
+bool Fb2::clearCache() const {
+  if (!Storage.exists(cachePath.c_str())) {
+    Serial.printf("[%lu] [FB2] Cache does not exist, no action needed\n", millis());
+    return true;
+  }
+
+  if (!Storage.removeDir(cachePath.c_str())) {
+    Serial.printf("[%lu] [FB2] Failed to clear cache\n", millis());
+    return false;
+  }
+
+  Serial.printf("[%lu] [FB2] Cache cleared successfully\n", millis());
+  return true;
+}
+
+void Fb2::setupCacheDir() const {
+  if (Storage.exists(cachePath.c_str())) {
+    return;
+  }
+  Storage.mkdir(cachePath.c_str());
+}
+
+const std::string& Fb2::getCachePath() const { return cachePath; }
+
+const std::string& Fb2::getPath() const { return filepath; }
+
+const std::string& Fb2::getTitle() const {
+  static std::string blank;
+  return loaded ? title : blank;
+}
+
+const std::string& Fb2::getAuthor() const {
+  static std::string blank;
+  return loaded ? author : blank;
+}
+
+const std::string& Fb2::getLanguage() const {
+  static std::string blank;
+  return loaded ? language : blank;
+}
+
+std::string Fb2::getCoverBmpPath() const { return cachePath + "/cover.bmp"; }
+
+bool Fb2::generateCoverBmp() const {
+  if (Storage.exists(getCoverBmpPath().c_str())) {
+    return true;
+  }
+
+  if (!loaded || coverBinaryId.empty()) {
+    Serial.printf("[%lu] [FB2] No cover image available\n", millis());
+    return false;
+  }
+
+  setupCacheDir();
+  Fb2CoverExtractor extractor(filepath, coverBinaryId, getCoverBmpPath());
+  return extractor.extract();
+}
+
+std::string Fb2::getThumbBmpPath() const { return cachePath + "/thumb_[HEIGHT].bmp"; }
+
+std::string Fb2::getThumbBmpPath(int height) const { return cachePath + "/thumb_" + std::to_string(height) + ".bmp"; }
+
+bool Fb2::generateThumbBmp(int height) const {
+  if (Storage.exists(getThumbBmpPath(height).c_str())) {
+    return true;
+  }
+
+  if (!loaded || coverBinaryId.empty()) {
+    Serial.printf("[%lu] [FB2] No cover image for thumbnail\n", millis());
+    // Write empty file to avoid future attempts
+    FsFile thumbBmp;
+    setupCacheDir();
+    Storage.openFileForWrite("FB2", getThumbBmpPath(height), thumbBmp);
+    thumbBmp.close();
+    return false;
+  }
+
+  setupCacheDir();
+  Fb2CoverExtractor extractor(filepath, coverBinaryId, "");
+  return extractor.extractThumb(getThumbBmpPath(height), height);
+}
+
+int Fb2::getSectionCount() const { return static_cast<int>(sections.size()); }
+
+const Fb2::SectionInfo& Fb2::getSectionInfo(int index) const {
+  static SectionInfo empty = {"", 0, 0};
+  if (index < 0 || index >= static_cast<int>(sections.size())) {
+    return empty;
+  }
+  return sections[index];
+}
+
+size_t Fb2::getBookSize() const {
+  if (sections.empty()) {
+    return 0;
+  }
+  return getCumulativeSectionSize(static_cast<int>(sections.size()) - 1);
+}
+
+size_t Fb2::getCumulativeSectionSize(int index) const {
+  if (index < 0 || index >= static_cast<int>(sections.size())) {
+    return 0;
+  }
+  size_t cumulative = 0;
+  for (int i = 0; i <= index; i++) {
+    cumulative += sections[i].length;
+  }
+  return cumulative;
+}
+
+float Fb2::calculateProgress(int currentSectionIndex, float currentSectionRead) const {
+  const size_t bookSize = getBookSize();
+  if (bookSize == 0) {
+    return 0.0f;
+  }
+  const size_t prevSize = (currentSectionIndex >= 1) ? getCumulativeSectionSize(currentSectionIndex - 1) : 0;
+  const size_t curSize = getCumulativeSectionSize(currentSectionIndex) - prevSize;
+  const float sectionProgSize = currentSectionRead * static_cast<float>(curSize);
+  const float totalProgress = static_cast<float>(prevSize) + sectionProgSize;
+  return totalProgress / static_cast<float>(bookSize);
+}
+
+int Fb2::getTocCount() const { return static_cast<int>(tocEntries.size()); }
+
+const Fb2::TocEntry& Fb2::getTocEntry(int index) const {
+  static TocEntry empty = {"", -1};
+  if (index < 0 || index >= static_cast<int>(tocEntries.size())) {
+    return empty;
+  }
+  return tocEntries[index];
+}
+
+int Fb2::getTocIndexForSectionIndex(int sectionIndex) const {
+  for (int i = 0; i < static_cast<int>(tocEntries.size()); i++) {
+    if (tocEntries[i].sectionIndex == sectionIndex) {
+      return i;
+    }
+  }
+  // Return closest lower TOC entry
+  int best = -1;
+  for (int i = 0; i < static_cast<int>(tocEntries.size()); i++) {
+    if (tocEntries[i].sectionIndex <= sectionIndex) {
+      best = i;
+    }
+  }
+  return best;
+}
+
+int Fb2::getSectionIndexForTocIndex(int tocIndex) const {
+  if (tocIndex < 0 || tocIndex >= static_cast<int>(tocEntries.size())) {
+    return 0;
+  }
+  return tocEntries[tocIndex].sectionIndex;
+}

--- a/lib/Fb2/Fb2.h
+++ b/lib/Fb2/Fb2.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Fb2 {
+ public:
+  struct SectionInfo {
+    std::string title;
+    size_t fileOffset;
+    size_t length;
+  };
+
+  struct TocEntry {
+    std::string title;
+    int sectionIndex;
+  };
+
+ private:
+  std::string filepath;
+  std::string cachePath;
+  std::string title;
+  std::string author;
+  std::string language;
+  std::string coverBinaryId;
+  std::vector<SectionInfo> sections;
+  std::vector<TocEntry> tocEntries;
+  bool loaded = false;
+
+  bool parseMetadata();
+  bool loadMetadataCache();
+  bool saveMetadataCache() const;
+
+ public:
+  explicit Fb2(std::string filepath, const std::string& cacheDir);
+  ~Fb2() = default;
+
+  bool load(bool buildIfMissing = true);
+  bool clearCache() const;
+  void setupCacheDir() const;
+  const std::string& getCachePath() const;
+  const std::string& getPath() const;
+  const std::string& getTitle() const;
+  const std::string& getAuthor() const;
+  const std::string& getLanguage() const;
+
+  // Cover/thumbnail
+  std::string getCoverBmpPath() const;
+  bool generateCoverBmp() const;
+  std::string getThumbBmpPath() const;
+  std::string getThumbBmpPath(int height) const;
+  bool generateThumbBmp(int height) const;
+
+  // Sections (spine-like navigation)
+  int getSectionCount() const;
+  const SectionInfo& getSectionInfo(int index) const;
+  size_t getBookSize() const;
+  size_t getCumulativeSectionSize(int index) const;
+  float calculateProgress(int currentSectionIndex, float currentSectionRead) const;
+
+  // TOC
+  int getTocCount() const;
+  const TocEntry& getTocEntry(int index) const;
+  int getTocIndexForSectionIndex(int sectionIndex) const;
+  int getSectionIndexForTocIndex(int tocIndex) const;
+
+  // Cover binary ID (for cover extractor)
+  const std::string& getCoverBinaryId() const { return coverBinaryId; }
+};

--- a/lib/Fb2/Fb2/Fb2CoverExtractor.cpp
+++ b/lib/Fb2/Fb2/Fb2CoverExtractor.cpp
@@ -1,0 +1,261 @@
+#include "Fb2CoverExtractor.h"
+
+#include <HalStorage.h>
+#include <HardwareSerial.h>
+#include <JpegToBmpConverter.h>
+#include <expat.h>
+
+#include <cstring>
+
+namespace {
+// Base64 decoding table
+constexpr int8_t B64_INVALID = -1;
+
+int8_t base64DecodeChar(char c) {
+  if (c >= 'A' && c <= 'Z') return c - 'A';
+  if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+  if (c >= '0' && c <= '9') return c - '0' + 52;
+  if (c == '+') return 62;
+  if (c == '/') return 63;
+  return B64_INVALID;
+}
+
+struct ExtractState {
+  const std::string& targetId;
+  FsFile* outputFile;
+  bool foundTarget;
+  bool inBinary;
+  bool done;
+  // Base64 streaming state
+  uint8_t b64Buf[3];
+  int b64Pending;
+
+  explicit ExtractState(const std::string& id, FsFile* out)
+      : targetId(id), outputFile(out), foundTarget(false), inBinary(false), done(false), b64Pending(0) {}
+
+  void decodeBase64Chunk(const char* data, int len) {
+    for (int i = 0; i < len; i++) {
+      char c = data[i];
+      if (c == '\n' || c == '\r' || c == ' ' || c == '\t') continue;
+      if (c == '=') {
+        // Padding - flush remaining
+        if (b64Pending == 2) {
+          outputFile->write(b64Buf, 1);
+        } else if (b64Pending == 3) {
+          outputFile->write(b64Buf, 2);
+        }
+        b64Pending = 0;
+        continue;
+      }
+
+      int8_t val = base64DecodeChar(c);
+      if (val == B64_INVALID) continue;
+
+      switch (b64Pending) {
+        case 0:
+          b64Buf[0] = static_cast<uint8_t>(val << 2);
+          b64Pending = 1;
+          break;
+        case 1:
+          b64Buf[0] |= static_cast<uint8_t>(val >> 4);
+          b64Buf[1] = static_cast<uint8_t>((val & 0x0F) << 4);
+          b64Pending = 2;
+          break;
+        case 2:
+          b64Buf[1] |= static_cast<uint8_t>(val >> 2);
+          b64Buf[2] = static_cast<uint8_t>((val & 0x03) << 6);
+          b64Pending = 3;
+          break;
+        case 3:
+          b64Buf[2] |= static_cast<uint8_t>(val);
+          outputFile->write(b64Buf, 3);
+          b64Pending = 0;
+          break;
+      }
+    }
+  }
+};
+
+const char* stripNs(const char* name) {
+  const char* colon = strchr(name, ':');
+  return colon ? colon + 1 : name;
+}
+
+void XMLCALL onStart(void* userData, const char* name, const char** atts) {
+  auto* state = static_cast<ExtractState*>(userData);
+  if (state->done) return;
+
+  const char* tag = stripNs(name);
+  if (strcmp(tag, "binary") == 0 && atts) {
+    for (int i = 0; atts[i]; i += 2) {
+      if (strcmp(atts[i], "id") == 0 && state->targetId == atts[i + 1]) {
+        state->foundTarget = true;
+        state->inBinary = true;
+        state->b64Pending = 0;
+        return;
+      }
+    }
+  }
+}
+
+void XMLCALL onEnd(void* userData, const char* name) {
+  auto* state = static_cast<ExtractState*>(userData);
+  const char* tag = stripNs(name);
+  if (state->inBinary && strcmp(tag, "binary") == 0) {
+    // Flush any remaining base64 data
+    if (state->b64Pending == 2) {
+      state->outputFile->write(state->b64Buf, 1);
+    } else if (state->b64Pending == 3) {
+      state->outputFile->write(state->b64Buf, 2);
+    }
+    state->inBinary = false;
+    state->done = true;
+  }
+}
+
+void XMLCALL onCharData(void* userData, const char* s, int len) {
+  auto* state = static_cast<ExtractState*>(userData);
+  if (state->inBinary) {
+    state->decodeBase64Chunk(s, len);
+  }
+}
+}  // namespace
+
+bool Fb2CoverExtractor::extractBinaryToJpeg(const std::string& tempJpegPath) const {
+  FsFile jpegFile;
+  if (!Storage.openFileForWrite("FB2", tempJpegPath, jpegFile)) {
+    return false;
+  }
+
+  ExtractState state(binaryId, &jpegFile);
+
+  XML_Parser xmlParser = XML_ParserCreate(nullptr);
+  if (!xmlParser) {
+    jpegFile.close();
+    return false;
+  }
+
+  XML_SetUserData(xmlParser, &state);
+  XML_SetElementHandler(xmlParser, onStart, onEnd);
+  XML_SetCharacterDataHandler(xmlParser, onCharData);
+
+  FsFile fb2File;
+  if (!Storage.openFileForRead("FB2", filepath, fb2File)) {
+    XML_ParserFree(xmlParser);
+    jpegFile.close();
+    return false;
+  }
+
+  bool success = true;
+  int done;
+  do {
+    void* buf = XML_GetBuffer(xmlParser, 1024);
+    if (!buf) {
+      success = false;
+      break;
+    }
+
+    size_t len = fb2File.read(buf, 1024);
+    if (len == 0 && fb2File.available() > 0) {
+      success = false;
+      break;
+    }
+
+    done = fb2File.available() == 0;
+
+    if (XML_ParseBuffer(xmlParser, static_cast<int>(len), done) == XML_STATUS_ERROR) {
+      // Parse errors in binary extraction are common due to entity issues; check if we got data
+      if (state.foundTarget && jpegFile.size() > 0) {
+        break;  // We got enough data
+      }
+      success = false;
+      break;
+    }
+
+    // Early exit once we've extracted the binary
+    if (state.done) break;
+  } while (!done);
+
+  XML_ParserFree(xmlParser);
+  fb2File.close();
+  jpegFile.close();
+
+  if (!state.foundTarget || !success) {
+    Storage.remove(tempJpegPath.c_str());
+    return false;
+  }
+
+  return true;
+}
+
+bool Fb2CoverExtractor::extract() const {
+  const auto tempJpegPath = outputBmpPath.substr(0, outputBmpPath.rfind('/')) + "/.cover.jpg";
+
+  if (!extractBinaryToJpeg(tempJpegPath)) {
+    Serial.printf("[%lu] [FB2] Failed to extract cover binary\n", millis());
+    return false;
+  }
+
+  FsFile coverJpg;
+  if (!Storage.openFileForRead("FB2", tempJpegPath, coverJpg)) {
+    Storage.remove(tempJpegPath.c_str());
+    return false;
+  }
+
+  FsFile coverBmp;
+  if (!Storage.openFileForWrite("FB2", outputBmpPath, coverBmp)) {
+    coverJpg.close();
+    Storage.remove(tempJpegPath.c_str());
+    return false;
+  }
+
+  const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp);
+  coverJpg.close();
+  coverBmp.close();
+  Storage.remove(tempJpegPath.c_str());
+
+  if (!success) {
+    Serial.printf("[%lu] [FB2] Failed to convert cover JPEG to BMP\n", millis());
+    Storage.remove(outputBmpPath.c_str());
+  } else {
+    Serial.printf("[%lu] [FB2] Generated cover BMP\n", millis());
+  }
+  return success;
+}
+
+bool Fb2CoverExtractor::extractThumb(const std::string& thumbPath, int height) const {
+  const auto cacheDir = thumbPath.substr(0, thumbPath.rfind('/'));
+  const auto tempJpegPath = cacheDir + "/.cover.jpg";
+
+  if (!extractBinaryToJpeg(tempJpegPath)) {
+    Serial.printf("[%lu] [FB2] Failed to extract cover binary for thumbnail\n", millis());
+    return false;
+  }
+
+  FsFile coverJpg;
+  if (!Storage.openFileForRead("FB2", tempJpegPath, coverJpg)) {
+    Storage.remove(tempJpegPath.c_str());
+    return false;
+  }
+
+  FsFile thumbBmp;
+  if (!Storage.openFileForWrite("FB2", thumbPath, thumbBmp)) {
+    coverJpg.close();
+    Storage.remove(tempJpegPath.c_str());
+    return false;
+  }
+
+  int thumbWidth = static_cast<int>(height * 0.6);
+  const bool success = JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(coverJpg, thumbBmp, thumbWidth, height);
+  coverJpg.close();
+  thumbBmp.close();
+  Storage.remove(tempJpegPath.c_str());
+
+  if (!success) {
+    Serial.printf("[%lu] [FB2] Failed to generate thumbnail BMP\n", millis());
+    Storage.remove(thumbPath.c_str());
+  } else {
+    Serial.printf("[%lu] [FB2] Generated thumbnail BMP\n", millis());
+  }
+  return success;
+}

--- a/lib/Fb2/Fb2/Fb2CoverExtractor.h
+++ b/lib/Fb2/Fb2/Fb2CoverExtractor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+// Extracts and converts cover images from FB2 files.
+// FB2 stores images as base64-encoded data in <binary> elements.
+class Fb2CoverExtractor {
+  std::string filepath;
+  std::string binaryId;
+  std::string outputBmpPath;
+
+  // Extract base64 data for the specified binary ID to a temp JPEG file
+  bool extractBinaryToJpeg(const std::string& tempJpegPath) const;
+
+ public:
+  explicit Fb2CoverExtractor(const std::string& filepath, const std::string& binaryId, const std::string& outputBmpPath)
+      : filepath(filepath), binaryId(binaryId), outputBmpPath(outputBmpPath) {}
+
+  // Extract cover and convert to BMP at outputBmpPath
+  bool extract() const;
+
+  // Extract cover and convert to 1-bit thumbnail BMP
+  bool extractThumb(const std::string& thumbPath, int height) const;
+};

--- a/lib/Fb2/Fb2/Fb2MetadataParser.cpp
+++ b/lib/Fb2/Fb2/Fb2MetadataParser.cpp
@@ -1,0 +1,273 @@
+#include "Fb2MetadataParser.h"
+
+#include <HalStorage.h>
+#include <HardwareSerial.h>
+#include <expat.h>
+
+#include <cstring>
+
+namespace {
+// Strip namespace prefix from tag name (e.g., "l:title" -> "title")
+const char* stripNs(const char* name) {
+  const char* colon = strchr(name, ':');
+  return colon ? colon + 1 : name;
+}
+
+// Extract attribute value from xlink:href="#id" -> "id"
+std::string getXlinkHref(const char** atts) {
+  if (!atts) return "";
+  for (int i = 0; atts[i]; i += 2) {
+    const char* attrName = stripNs(atts[i]);
+    if (strcmp(attrName, "href") == 0) {
+      const char* val = atts[i + 1];
+      if (val[0] == '#') return std::string(val + 1);
+      return std::string(val);
+    }
+  }
+  return "";
+}
+}  // namespace
+
+void Fb2MetadataParser::startElement(void* userData, const char* name, const char** atts) {
+  auto* self = static_cast<Fb2MetadataParser*>(userData);
+  const char* tag = stripNs(name);
+
+  if (strcmp(tag, "title-info") == 0 && !self->inBody) {
+    self->inTitleInfo = true;
+    return;
+  }
+
+  if (self->inTitleInfo) {
+    if (strcmp(tag, "book-title") == 0) {
+      self->context = Context::BOOK_TITLE;
+      self->charBuffer.clear();
+    } else if (strcmp(tag, "author") == 0) {
+      self->inAuthor = true;
+      self->authorFirstName.clear();
+      self->authorMiddleName.clear();
+      self->authorLastName.clear();
+    } else if (self->inAuthor && strcmp(tag, "first-name") == 0) {
+      self->context = Context::AUTHOR_FIRST_NAME;
+      self->charBuffer.clear();
+    } else if (self->inAuthor && strcmp(tag, "middle-name") == 0) {
+      self->context = Context::AUTHOR_MIDDLE_NAME;
+      self->charBuffer.clear();
+    } else if (self->inAuthor && strcmp(tag, "last-name") == 0) {
+      self->context = Context::AUTHOR_LAST_NAME;
+      self->charBuffer.clear();
+    } else if (strcmp(tag, "lang") == 0) {
+      self->context = Context::LANG;
+      self->charBuffer.clear();
+    } else if (strcmp(tag, "coverpage") == 0) {
+      self->context = Context::COVERPAGE;
+    } else if (self->context == Context::COVERPAGE && strcmp(tag, "image") == 0) {
+      self->coverBinaryId = getXlinkHref(atts);
+    }
+    return;
+  }
+
+  if (strcmp(tag, "body") == 0 && !self->inBody) {
+    self->inBody = true;
+    self->bodyDepth = 0;
+    // Record byte offset of body start
+    self->previousSectionEnd = XML_GetCurrentByteIndex(static_cast<XML_Parser>(self->parser));
+    return;
+  }
+
+  if (self->inBody) {
+    if (strcmp(tag, "section") == 0) {
+      self->sectionDepth++;
+      // Only track top-level sections (depth 1 within body)
+      if (self->sectionDepth == 1) {
+        self->currentSectionOffset = XML_GetCurrentByteIndex(static_cast<XML_Parser>(self->parser));
+        self->currentSectionTitle.clear();
+        self->inSectionTitle = false;
+      }
+    } else if (strcmp(tag, "title") == 0 && self->sectionDepth == 1) {
+      self->inSectionTitle = true;
+      self->charBuffer.clear();
+    } else if (strcmp(tag, "p") == 0 && self->inSectionTitle) {
+      self->context = Context::SECTION_TITLE_P;
+      self->charBuffer.clear();
+    }
+  }
+}
+
+void Fb2MetadataParser::endElement(void* userData, const char* name) {
+  auto* self = static_cast<Fb2MetadataParser*>(userData);
+  const char* tag = stripNs(name);
+
+  if (strcmp(tag, "title-info") == 0 && self->inTitleInfo) {
+    self->inTitleInfo = false;
+    self->context = Context::NONE;
+    return;
+  }
+
+  if (self->inTitleInfo) {
+    if (strcmp(tag, "book-title") == 0 && self->context == Context::BOOK_TITLE) {
+      self->title = self->charBuffer;
+      self->context = Context::NONE;
+    } else if (strcmp(tag, "author") == 0 && self->inAuthor) {
+      self->inAuthor = false;
+      // Build author string: "First Middle Last"
+      std::string fullAuthor;
+      if (!self->authorFirstName.empty()) {
+        fullAuthor = self->authorFirstName;
+      }
+      if (!self->authorMiddleName.empty()) {
+        if (!fullAuthor.empty()) fullAuthor += " ";
+        fullAuthor += self->authorMiddleName;
+      }
+      if (!self->authorLastName.empty()) {
+        if (!fullAuthor.empty()) fullAuthor += " ";
+        fullAuthor += self->authorLastName;
+      }
+      if (!fullAuthor.empty() && self->author.empty()) {
+        self->author = fullAuthor;
+      }
+      self->context = Context::NONE;
+    } else if (self->inAuthor && strcmp(tag, "first-name") == 0 && self->context == Context::AUTHOR_FIRST_NAME) {
+      self->authorFirstName = self->charBuffer;
+      self->context = Context::NONE;
+    } else if (self->inAuthor && strcmp(tag, "middle-name") == 0 && self->context == Context::AUTHOR_MIDDLE_NAME) {
+      self->authorMiddleName = self->charBuffer;
+      self->context = Context::NONE;
+    } else if (self->inAuthor && strcmp(tag, "last-name") == 0 && self->context == Context::AUTHOR_LAST_NAME) {
+      self->authorLastName = self->charBuffer;
+      self->context = Context::NONE;
+    } else if (strcmp(tag, "lang") == 0 && self->context == Context::LANG) {
+      self->language = self->charBuffer;
+      self->context = Context::NONE;
+    } else if (strcmp(tag, "coverpage") == 0) {
+      self->context = Context::NONE;
+    }
+    return;
+  }
+
+  if (self->inBody) {
+    if (strcmp(tag, "title") == 0 && self->inSectionTitle && self->sectionDepth == 1) {
+      self->inSectionTitle = false;
+      self->context = Context::NONE;
+    } else if (strcmp(tag, "p") == 0 && self->context == Context::SECTION_TITLE_P) {
+      // Append paragraph text to section title
+      if (!self->currentSectionTitle.empty() && !self->charBuffer.empty()) {
+        self->currentSectionTitle += " ";
+      }
+      self->currentSectionTitle += self->charBuffer;
+      self->charBuffer.clear();
+      self->context = Context::NONE;
+    } else if (strcmp(tag, "section") == 0) {
+      if (self->sectionDepth == 1) {
+        // Finalize the previous section's length
+        size_t endOffset = XML_GetCurrentByteIndex(static_cast<XML_Parser>(self->parser));
+        // Estimate end position (expat gives us the start of the end tag)
+        // Add a reasonable estimate for the closing tag length
+        endOffset += strlen(name) + 3;  // "</section>" roughly
+
+        Fb2::SectionInfo info;
+        info.title = self->currentSectionTitle;
+        info.fileOffset = self->currentSectionOffset;
+        info.length = endOffset - self->currentSectionOffset;
+        self->sections.push_back(std::move(info));
+
+        // Add TOC entry
+        Fb2::TocEntry tocEntry;
+        tocEntry.title = self->sections.back().title.empty()
+                             ? ("Section " + std::to_string(self->currentSectionIndex + 1))
+                             : self->sections.back().title;
+        tocEntry.sectionIndex = self->currentSectionIndex;
+        self->tocEntries.push_back(std::move(tocEntry));
+
+        self->currentSectionIndex++;
+        self->previousSectionEnd = endOffset;
+      }
+      self->sectionDepth--;
+    } else if (strcmp(tag, "body") == 0) {
+      self->inBody = false;
+    }
+  }
+}
+
+void Fb2MetadataParser::characterData(void* userData, const char* s, int len) {
+  auto* self = static_cast<Fb2MetadataParser*>(userData);
+
+  if (self->context == Context::BOOK_TITLE || self->context == Context::AUTHOR_FIRST_NAME ||
+      self->context == Context::AUTHOR_MIDDLE_NAME || self->context == Context::AUTHOR_LAST_NAME ||
+      self->context == Context::LANG || self->context == Context::SECTION_TITLE_P) {
+    self->charBuffer.append(s, len);
+  }
+}
+
+bool Fb2MetadataParser::parse() {
+  XML_Parser xmlParser = XML_ParserCreate(nullptr);
+  if (!xmlParser) {
+    Serial.printf("[%lu] [FB2] Could not create XML parser\n", millis());
+    return false;
+  }
+
+  parser = xmlParser;
+
+  XML_SetUserData(xmlParser, this);
+  XML_SetElementHandler(xmlParser, startElement, endElement);
+  XML_SetCharacterDataHandler(xmlParser, characterData);
+
+  FsFile file;
+  if (!Storage.openFileForRead("FB2", filepath, file)) {
+    XML_ParserFree(xmlParser);
+    parser = nullptr;
+    return false;
+  }
+
+  bool success = true;
+  int done;
+  do {
+    void* const buf = XML_GetBuffer(xmlParser, 1024);
+    if (!buf) {
+      Serial.printf("[%lu] [FB2] Could not allocate parser buffer\n", millis());
+      success = false;
+      break;
+    }
+
+    const size_t len = file.read(buf, 1024);
+    if (len == 0 && file.available() > 0) {
+      Serial.printf("[%lu] [FB2] File read error\n", millis());
+      success = false;
+      break;
+    }
+
+    done = file.available() == 0;
+
+    if (XML_ParseBuffer(xmlParser, static_cast<int>(len), done) == XML_STATUS_ERROR) {
+      Serial.printf("[%lu] [FB2] Parse error at line %lu: %s\n", millis(), XML_GetCurrentLineNumber(xmlParser),
+                    XML_ErrorString(XML_GetErrorCode(xmlParser)));
+      success = false;
+      break;
+    }
+  } while (!done);
+
+  XML_ParserFree(xmlParser);
+  parser = nullptr;
+  file.close();
+
+  // If no sections found, treat entire body as one section
+  if (success && sections.empty()) {
+    Serial.printf("[%lu] [FB2] No sections found, treating entire file as one section\n", millis());
+    // Re-parse is too expensive; create a dummy section covering the whole file
+    FsFile sizeFile;
+    if (Storage.openFileForRead("FB2", filepath, sizeFile)) {
+      Fb2::SectionInfo info;
+      info.title = title.empty() ? "Content" : title;
+      info.fileOffset = 0;
+      info.length = sizeFile.size();
+      sections.push_back(std::move(info));
+      sizeFile.close();
+
+      Fb2::TocEntry tocEntry;
+      tocEntry.title = sections.back().title;
+      tocEntry.sectionIndex = 0;
+      tocEntries.push_back(std::move(tocEntry));
+    }
+  }
+
+  return success;
+}

--- a/lib/Fb2/Fb2/Fb2MetadataParser.h
+++ b/lib/Fb2/Fb2/Fb2MetadataParser.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Fb2.h"
+
+// Streaming expat-based parser for FB2 metadata.
+// First pass: extracts title, author, language, cover ID from <description>,
+// and scans <body> to identify section boundaries and titles with file offsets.
+class Fb2MetadataParser {
+  std::string filepath;
+
+  // Metadata
+  std::string title;
+  std::string author;
+  std::string language;
+  std::string coverBinaryId;
+
+  // Section scanning
+  std::vector<Fb2::SectionInfo> sections;
+  std::vector<Fb2::TocEntry> tocEntries;
+
+  // Parser state
+  enum class Context {
+    NONE,
+    TITLE_INFO,
+    BOOK_TITLE,
+    AUTHOR_FIRST_NAME,
+    AUTHOR_MIDDLE_NAME,
+    AUTHOR_LAST_NAME,
+    LANG,
+    COVERPAGE,
+    BODY,
+    SECTION_TITLE,
+    SECTION_TITLE_P,
+    BINARY_SCAN
+  };
+  Context context = Context::NONE;
+  int bodyDepth = 0;
+  int sectionDepth = 0;
+  bool inBody = false;
+  bool inTitleInfo = false;
+  bool inAuthor = false;
+  std::string charBuffer;
+  std::string authorFirstName;
+  std::string authorMiddleName;
+  std::string authorLastName;
+  std::string currentSectionTitle;
+  bool inSectionTitle = false;
+  size_t currentSectionOffset = 0;
+  size_t previousSectionEnd = 0;
+  int currentSectionIndex = 0;
+
+  // Track byte offset from expat
+  void* parser = nullptr;
+
+  static void startElement(void* userData, const char* name, const char** atts);
+  static void endElement(void* userData, const char* name);
+  static void characterData(void* userData, const char* s, int len);
+
+ public:
+  explicit Fb2MetadataParser(const std::string& filepath) : filepath(filepath) {}
+  bool parse();
+
+  const std::string& getTitle() const { return title; }
+  const std::string& getAuthor() const { return author; }
+  const std::string& getLanguage() const { return language; }
+  const std::string& getCoverBinaryId() const { return coverBinaryId; }
+  const std::vector<Fb2::SectionInfo>& getSections() const { return sections; }
+  const std::vector<Fb2::TocEntry>& getTocEntries() const { return tocEntries; }
+};

--- a/lib/Fb2/Fb2/Fb2Section.cpp
+++ b/lib/Fb2/Fb2/Fb2Section.cpp
@@ -1,0 +1,194 @@
+#include "Fb2Section.h"
+
+#include <Epub/Page.h>
+#include <Epub/hyphenation/Hyphenator.h>
+#include <HalStorage.h>
+#include <Serialization.h>
+
+#include "Fb2SectionParser.h"
+
+namespace {
+// FB2 section files don't track embeddedStyle (no CSS in FB2).
+// We use a separate version from EPUB sections.
+constexpr uint8_t FB2_SECTION_FILE_VERSION = 1;
+constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
+                                 sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) +
+                                 sizeof(uint32_t);
+}  // namespace
+
+uint32_t Fb2Section::onPageComplete(std::unique_ptr<Page> page) {
+  if (!file) {
+    Serial.printf("[%lu] [FBS] File not open for writing page %d\n", millis(), pageCount);
+    return 0;
+  }
+
+  const uint32_t position = file.position();
+  if (!page->serialize(file)) {
+    Serial.printf("[%lu] [FBS] Failed to serialize page %d\n", millis(), pageCount);
+    return 0;
+  }
+  Serial.printf("[%lu] [FBS] Page %d processed\n", millis(), pageCount);
+
+  pageCount++;
+  return position;
+}
+
+void Fb2Section::writeSectionFileHeader(const int fontId, const float lineCompression, const bool extraParagraphSpacing,
+                                        const uint8_t paragraphAlignment, const uint16_t viewportWidth,
+                                        const uint16_t viewportHeight, const bool hyphenationEnabled) {
+  if (!file) {
+    Serial.printf("[%lu] [FBS] File not open for writing header\n", millis());
+    return;
+  }
+  serialization::writePod(file, FB2_SECTION_FILE_VERSION);
+  serialization::writePod(file, fontId);
+  serialization::writePod(file, lineCompression);
+  serialization::writePod(file, extraParagraphSpacing);
+  serialization::writePod(file, paragraphAlignment);
+  serialization::writePod(file, viewportWidth);
+  serialization::writePod(file, viewportHeight);
+  serialization::writePod(file, hyphenationEnabled);
+  serialization::writePod(file, pageCount);                 // Placeholder
+  serialization::writePod(file, static_cast<uint32_t>(0));  // LUT offset placeholder
+}
+
+bool Fb2Section::loadSectionFile(const int fontId, const float lineCompression, const bool extraParagraphSpacing,
+                                 const uint8_t paragraphAlignment, const uint16_t viewportWidth,
+                                 const uint16_t viewportHeight, const bool hyphenationEnabled) {
+  if (!Storage.openFileForRead("FBS", filePath, file)) {
+    return false;
+  }
+
+  {
+    uint8_t version;
+    serialization::readPod(file, version);
+    if (version != FB2_SECTION_FILE_VERSION) {
+      file.close();
+      Serial.printf("[%lu] [FBS] Version mismatch: %u\n", millis(), version);
+      clearCache();
+      return false;
+    }
+
+    int fileFontId;
+    uint16_t fileViewportWidth, fileViewportHeight;
+    float fileLineCompression;
+    bool fileExtraParagraphSpacing;
+    uint8_t fileParagraphAlignment;
+    bool fileHyphenationEnabled;
+    serialization::readPod(file, fileFontId);
+    serialization::readPod(file, fileLineCompression);
+    serialization::readPod(file, fileExtraParagraphSpacing);
+    serialization::readPod(file, fileParagraphAlignment);
+    serialization::readPod(file, fileViewportWidth);
+    serialization::readPod(file, fileViewportHeight);
+    serialization::readPod(file, fileHyphenationEnabled);
+
+    if (fontId != fileFontId || lineCompression != fileLineCompression ||
+        extraParagraphSpacing != fileExtraParagraphSpacing || paragraphAlignment != fileParagraphAlignment ||
+        viewportWidth != fileViewportWidth || viewportHeight != fileViewportHeight ||
+        hyphenationEnabled != fileHyphenationEnabled) {
+      file.close();
+      Serial.printf("[%lu] [FBS] Parameters do not match\n", millis());
+      clearCache();
+      return false;
+    }
+  }
+
+  serialization::readPod(file, pageCount);
+  file.close();
+  Serial.printf("[%lu] [FBS] Loaded section: %d pages\n", millis(), pageCount);
+  return true;
+}
+
+bool Fb2Section::clearCache() const {
+  if (!Storage.exists(filePath.c_str())) {
+    return true;
+  }
+
+  if (!Storage.remove(filePath.c_str())) {
+    Serial.printf("[%lu] [FBS] Failed to clear cache\n", millis());
+    return false;
+  }
+
+  Serial.printf("[%lu] [FBS] Cache cleared\n", millis());
+  return true;
+}
+
+bool Fb2Section::createSectionFile(const int fontId, const float lineCompression, const bool extraParagraphSpacing,
+                                   const uint8_t paragraphAlignment, const uint16_t viewportWidth,
+                                   const uint16_t viewportHeight, const bool hyphenationEnabled,
+                                   const std::function<void()>& popupFn) {
+  const auto& sectionInfo = fb2->getSectionInfo(sectionIndex);
+
+  // Create cache directory
+  {
+    const auto sectionsDir = fb2->getCachePath() + "/sections";
+    Storage.mkdir(sectionsDir.c_str());
+  }
+
+  if (!Storage.openFileForWrite("FBS", filePath, file)) {
+    return false;
+  }
+  writeSectionFileHeader(fontId, lineCompression, extraParagraphSpacing, paragraphAlignment, viewportWidth,
+                         viewportHeight, hyphenationEnabled);
+  std::vector<uint32_t> lut = {};
+
+  // If there's only one section with fileOffset 0, the metadata parser found no real <section> tags.
+  // Pass -1 to tell the parser to process all body content instead of filtering by section index.
+  const int targetIndex = (fb2->getSectionCount() == 1 && sectionInfo.fileOffset == 0) ? -1 : sectionIndex;
+  Fb2SectionParser visitor(
+      fb2->getPath(), sectionInfo.fileOffset, sectionInfo.length, targetIndex, renderer, fontId, lineCompression,
+      extraParagraphSpacing, paragraphAlignment, viewportWidth, viewportHeight, hyphenationEnabled,
+      [this, &lut](std::unique_ptr<Page> page) { lut.emplace_back(this->onPageComplete(std::move(page))); }, popupFn);
+  Hyphenator::setPreferredLanguage(fb2->getLanguage());
+  bool success = visitor.parseAndBuildPages();
+
+  if (!success) {
+    Serial.printf("[%lu] [FBS] Failed to parse and build pages\n", millis());
+    file.close();
+    Storage.remove(filePath.c_str());
+    return false;
+  }
+
+  const uint32_t lutOffset = file.position();
+  bool hasFailedLutRecords = false;
+  for (const uint32_t& pos : lut) {
+    if (pos == 0) {
+      hasFailedLutRecords = true;
+      break;
+    }
+    serialization::writePod(file, pos);
+  }
+
+  if (hasFailedLutRecords) {
+    Serial.printf("[%lu] [FBS] Failed LUT records\n", millis());
+    file.close();
+    Storage.remove(filePath.c_str());
+    return false;
+  }
+
+  // Write final page count and LUT offset
+  file.seek(HEADER_SIZE - sizeof(uint32_t) - sizeof(pageCount));
+  serialization::writePod(file, pageCount);
+  serialization::writePod(file, lutOffset);
+  file.close();
+  return true;
+}
+
+std::unique_ptr<Page> Fb2Section::loadPageFromSectionFile() {
+  if (!Storage.openFileForRead("FBS", filePath, file)) {
+    return nullptr;
+  }
+
+  file.seek(HEADER_SIZE - sizeof(uint32_t));
+  uint32_t lutOffset;
+  serialization::readPod(file, lutOffset);
+  file.seek(lutOffset + sizeof(uint32_t) * currentPage);
+  uint32_t pagePos;
+  serialization::readPod(file, pagePos);
+  file.seek(pagePos);
+
+  auto page = Page::deserialize(file);
+  file.close();
+  return page;
+}

--- a/lib/Fb2/Fb2/Fb2Section.h
+++ b/lib/Fb2/Fb2/Fb2Section.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <SdFat.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "Fb2.h"
+
+class Page;
+class GfxRenderer;
+
+class Fb2Section {
+  std::shared_ptr<Fb2> fb2;
+  const int sectionIndex;
+  GfxRenderer& renderer;
+  std::string filePath;
+  FsFile file;
+
+  void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
+                              uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled);
+  uint32_t onPageComplete(std::unique_ptr<Page> page);
+
+ public:
+  uint16_t pageCount = 0;
+  int currentPage = 0;
+
+  explicit Fb2Section(const std::shared_ptr<Fb2>& fb2, const int sectionIndex, GfxRenderer& renderer)
+      : fb2(fb2),
+        sectionIndex(sectionIndex),
+        renderer(renderer),
+        filePath(fb2->getCachePath() + "/sections/" + std::to_string(sectionIndex) + ".bin") {}
+  ~Fb2Section() = default;
+  bool loadSectionFile(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
+                       uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled);
+  bool clearCache() const;
+  bool createSectionFile(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
+                         uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
+                         const std::function<void()>& popupFn = nullptr);
+  std::unique_ptr<Page> loadPageFromSectionFile();
+};

--- a/lib/Fb2/Fb2/Fb2SectionParser.cpp
+++ b/lib/Fb2/Fb2/Fb2SectionParser.cpp
@@ -1,0 +1,415 @@
+#include "Fb2SectionParser.h"
+
+#include <Epub/hyphenation/Hyphenator.h>
+#include <GfxRenderer.h>
+#include <HalStorage.h>
+#include <HardwareSerial.h>
+#include <expat.h>
+
+#include <cstring>
+
+namespace {
+constexpr size_t MIN_SIZE_FOR_POPUP = 50 * 1024;
+
+bool isWhitespace(const char c) { return c == ' ' || c == '\r' || c == '\n' || c == '\t'; }
+
+const char* stripNs(const char* name) {
+  const char* colon = strchr(name, ':');
+  return colon ? colon + 1 : name;
+}
+}  // namespace
+
+void Fb2SectionParser::flushPartWordBuffer() {
+  const bool isBold = boldUntilDepth < depth;
+  const bool isItalic = italicUntilDepth < depth;
+
+  EpdFontFamily::Style fontStyle = EpdFontFamily::REGULAR;
+  if (isBold) {
+    fontStyle = static_cast<EpdFontFamily::Style>(fontStyle | EpdFontFamily::BOLD);
+  }
+  if (isItalic) {
+    fontStyle = static_cast<EpdFontFamily::Style>(fontStyle | EpdFontFamily::ITALIC);
+  }
+
+  partWordBuffer[partWordBufferIndex] = '\0';
+  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues);
+  partWordBufferIndex = 0;
+  nextWordContinues = false;
+}
+
+void Fb2SectionParser::startNewTextBlock(const BlockStyle& blockStyle) {
+  nextWordContinues = false;
+  if (currentTextBlock) {
+    if (currentTextBlock->isEmpty()) {
+      currentTextBlock->setBlockStyle(currentTextBlock->getBlockStyle().getCombinedBlockStyle(blockStyle));
+      return;
+    }
+    makePages();
+  }
+  currentTextBlock.reset(new ParsedText(extraParagraphSpacing, hyphenationEnabled, blockStyle));
+}
+
+void XMLCALL Fb2SectionParser::startElement(void* userData, const char* name, const char** /* atts */) {
+  auto* self = static_cast<Fb2SectionParser*>(userData);
+  const char* tag = stripNs(name);
+
+  // If we've already passed our target section, skip everything
+  if (self->pastTargetSection) {
+    self->depth++;
+    return;
+  }
+
+  if (self->skipUntilDepth < self->depth) {
+    self->depth++;
+    return;
+  }
+
+  // Skip <description> and <binary> blocks during section parsing
+  if (strcmp(tag, "description") == 0 || strcmp(tag, "binary") == 0) {
+    self->skipUntilDepth = self->depth;
+    self->depth++;
+    return;
+  }
+
+  // Track body element
+  if (strcmp(tag, "body") == 0) {
+    self->inBody = true;
+    self->depth++;
+    return;
+  }
+
+  // Track top-level sections within body
+  if (strcmp(tag, "section") == 0 && self->inBody) {
+    // Only count top-level sections (direct children of body)
+    // A top-level section is one that starts when we're not inside any target section
+    if (!self->inTargetSection) {
+      if (self->topLevelSectionCount == self->targetSectionIndex) {
+        self->inTargetSection = true;
+        self->targetSectionDepth = self->depth;
+      }
+      self->topLevelSectionCount++;
+    }
+    // Nested sections inside target section are just processed normally
+    self->depth++;
+    return;
+  }
+
+  // If targetSectionIndex is -1, process everything in body (single-section fallback)
+  // Otherwise, only process content when inside the target section
+  if (self->targetSectionIndex >= 0 && !self->inTargetSection) {
+    self->depth++;
+    return;
+  }
+
+  auto centeredBlockStyle = BlockStyle();
+  centeredBlockStyle.textAlignDefined = true;
+  centeredBlockStyle.alignment = CssTextAlign::Center;
+
+  auto indentedBlockStyle = BlockStyle();
+  indentedBlockStyle.marginLeft = 20;
+
+  // FB2 content tags
+  if (strcmp(tag, "p") == 0) {
+    auto paragraphBlockStyle = BlockStyle();
+    paragraphBlockStyle.textAlignDefined = true;
+    const auto align = (self->paragraphAlignment == static_cast<uint8_t>(CssTextAlign::None))
+                           ? CssTextAlign::Justify
+                           : static_cast<CssTextAlign>(self->paragraphAlignment);
+    paragraphBlockStyle.alignment = align;
+    self->startNewTextBlock(paragraphBlockStyle);
+  } else if (strcmp(tag, "title") == 0) {
+    self->startNewTextBlock(centeredBlockStyle);
+    self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
+  } else if (strcmp(tag, "subtitle") == 0) {
+    self->startNewTextBlock(centeredBlockStyle);
+    self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
+  } else if (strcmp(tag, "epigraph") == 0) {
+    auto epigraphStyle = BlockStyle();
+    epigraphStyle.marginLeft = 30;
+    epigraphStyle.textAlignDefined = true;
+    epigraphStyle.alignment = CssTextAlign::Right;
+    self->startNewTextBlock(epigraphStyle);
+    self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
+  } else if (strcmp(tag, "poem") == 0 || strcmp(tag, "stanza") == 0) {
+    self->startNewTextBlock(centeredBlockStyle);
+  } else if (strcmp(tag, "v") == 0) {
+    // Verse line - start new text block for each line
+    self->startNewTextBlock(centeredBlockStyle);
+  } else if (strcmp(tag, "cite") == 0) {
+    self->startNewTextBlock(indentedBlockStyle);
+  } else if (strcmp(tag, "empty-line") == 0) {
+    // Force a blank line
+    auto emptyBlockStyle = BlockStyle();
+    emptyBlockStyle.marginTop =
+        static_cast<int16_t>(self->renderer.getLineHeight(self->fontId) * self->lineCompression);
+    self->startNewTextBlock(emptyBlockStyle);
+  } else if (strcmp(tag, "strong") == 0) {
+    if (self->partWordBufferIndex > 0) {
+      self->flushPartWordBuffer();
+      self->nextWordContinues = true;
+    }
+    self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
+  } else if (strcmp(tag, "emphasis") == 0) {
+    if (self->partWordBufferIndex > 0) {
+      self->flushPartWordBuffer();
+      self->nextWordContinues = true;
+    }
+    self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
+  } else if (strcmp(tag, "strikethrough") == 0) {
+    // No strikethrough rendering support, treat as regular text
+  } else if (strcmp(tag, "image") == 0) {
+    self->startNewTextBlock(centeredBlockStyle);
+    self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
+    self->depth++;
+    self->characterData(userData, "[Image]", 7);
+    self->skipUntilDepth = self->depth - 1;
+    return;
+  } else if (strcmp(tag, "table") == 0) {
+    self->startNewTextBlock(centeredBlockStyle);
+    self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
+    self->depth++;
+    self->characterData(userData, "[Table omitted]", 15);
+    self->skipUntilDepth = self->depth - 1;
+    return;
+  } else if (strcmp(tag, "a") == 0) {
+    // Hyperlinks - just render the text content
+  } else if (strcmp(tag, "sup") == 0 || strcmp(tag, "sub") == 0) {
+    // Superscript/subscript - render as regular text
+  } else if (strcmp(tag, "code") == 0) {
+    // Code blocks - render as regular text
+  }
+
+  self->depth++;
+}
+
+void XMLCALL Fb2SectionParser::characterData(void* userData, const char* s, const int len) {
+  auto* self = static_cast<Fb2SectionParser*>(userData);
+
+  if (self->pastTargetSection) {
+    return;
+  }
+
+  if (self->skipUntilDepth < self->depth) {
+    return;
+  }
+
+  // Only process text when inside the target section (or processing all body content)
+  if (self->targetSectionIndex >= 0 && !self->inTargetSection) {
+    return;
+  }
+
+  for (int i = 0; i < len; i++) {
+    if (isWhitespace(s[i])) {
+      if (self->partWordBufferIndex > 0) {
+        self->flushPartWordBuffer();
+      }
+      self->nextWordContinues = false;
+      continue;
+    }
+
+    // Skip BOM
+    const char FEFF_BYTE_1 = static_cast<char>(0xEF);
+    const char FEFF_BYTE_2 = static_cast<char>(0xBB);
+    const char FEFF_BYTE_3 = static_cast<char>(0xBF);
+    if (s[i] == FEFF_BYTE_1 && (i + 2 < len) && s[i + 1] == FEFF_BYTE_2 && s[i + 2] == FEFF_BYTE_3) {
+      i += 2;
+      continue;
+    }
+
+    if (self->partWordBufferIndex >= FB2_MAX_WORD_SIZE) {
+      self->flushPartWordBuffer();
+    }
+
+    self->partWordBuffer[self->partWordBufferIndex++] = s[i];
+  }
+
+  // Split long text blocks to prevent memory issues
+  if (self->currentTextBlock && self->currentTextBlock->size() > 750) {
+    self->currentTextBlock->layoutAndExtractLines(
+        self->renderer, self->fontId, self->viewportWidth,
+        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
+  }
+}
+
+void XMLCALL Fb2SectionParser::endElement(void* userData, const char* name) {
+  auto* self = static_cast<Fb2SectionParser*>(userData);
+  const char* tag = stripNs(name);
+
+  if (self->pastTargetSection) {
+    self->depth--;
+    return;
+  }
+
+  // Flush buffer before style changes on block-closing tags
+  const bool processingContent = self->inTargetSection || self->targetSectionIndex < 0;
+  if (processingContent && self->partWordBufferIndex > 0) {
+    bool isBlock = strcmp(tag, "p") == 0 || strcmp(tag, "title") == 0 || strcmp(tag, "subtitle") == 0 ||
+                   strcmp(tag, "epigraph") == 0 || strcmp(tag, "v") == 0 || strcmp(tag, "cite") == 0 ||
+                   strcmp(tag, "poem") == 0 || strcmp(tag, "stanza") == 0 || strcmp(tag, "section") == 0;
+    bool isInline = strcmp(tag, "strong") == 0 || strcmp(tag, "emphasis") == 0 || strcmp(tag, "a") == 0;
+
+    if (isBlock || isInline || self->depth == 1) {
+      self->flushPartWordBuffer();
+      if (isInline) {
+        self->nextWordContinues = true;
+      }
+    }
+  }
+
+  self->depth--;
+
+  if (self->skipUntilDepth == self->depth) {
+    self->skipUntilDepth = INT_MAX;
+  }
+
+  if (self->boldUntilDepth == self->depth) {
+    self->boldUntilDepth = INT_MAX;
+  }
+
+  if (self->italicUntilDepth == self->depth) {
+    self->italicUntilDepth = INT_MAX;
+  }
+
+  // Track closing of sections — check if we're leaving the target top-level section
+  if (strcmp(tag, "section") == 0 && self->inBody && self->inTargetSection) {
+    // depth has already been decremented above; compare with the depth at which the target section opened
+    if (self->depth == self->targetSectionDepth) {
+      self->inTargetSection = false;
+      self->pastTargetSection = true;
+    }
+  }
+
+  if (strcmp(tag, "body") == 0) {
+    self->inBody = false;
+  }
+}
+
+void Fb2SectionParser::addLineToPage(std::shared_ptr<TextBlock> line) {
+  const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
+
+  if (currentPageNextY + lineHeight > viewportHeight) {
+    completePageFn(std::move(currentPage));
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  const int16_t xOffset = line->getBlockStyle().leftInset();
+  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
+  currentPageNextY += lineHeight;
+}
+
+void Fb2SectionParser::makePages() {
+  if (!currentTextBlock) {
+    return;
+  }
+
+  if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
+  const BlockStyle& blockStyle = currentTextBlock->getBlockStyle();
+
+  if (blockStyle.marginTop > 0) {
+    currentPageNextY += blockStyle.marginTop;
+  }
+  if (blockStyle.paddingTop > 0) {
+    currentPageNextY += blockStyle.paddingTop;
+  }
+
+  const int horizontalInset = blockStyle.totalHorizontalInset();
+  const uint16_t effectiveWidth =
+      (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+
+  currentTextBlock->layoutAndExtractLines(
+      renderer, fontId, effectiveWidth,
+      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); });
+
+  if (blockStyle.marginBottom > 0) {
+    currentPageNextY += blockStyle.marginBottom;
+  }
+  if (blockStyle.paddingBottom > 0) {
+    currentPageNextY += blockStyle.paddingBottom;
+  }
+
+  if (extraParagraphSpacing) {
+    currentPageNextY += lineHeight / 2;
+  }
+}
+
+bool Fb2SectionParser::parseAndBuildPages() {
+  auto paragraphBlockStyle = BlockStyle();
+  paragraphBlockStyle.textAlignDefined = true;
+  const auto align = (paragraphAlignment == static_cast<uint8_t>(CssTextAlign::None))
+                         ? CssTextAlign::Justify
+                         : static_cast<CssTextAlign>(paragraphAlignment);
+  paragraphBlockStyle.alignment = align;
+  startNewTextBlock(paragraphBlockStyle);
+
+  XML_Parser xmlParser = XML_ParserCreate(nullptr);
+  if (!xmlParser) {
+    Serial.printf("[%lu] [FB2] Could not create parser for section\n", millis());
+    return false;
+  }
+
+  FsFile file;
+  if (!Storage.openFileForRead("FB2", filepath, file)) {
+    XML_ParserFree(xmlParser);
+    return false;
+  }
+
+  if (popupFn && sectionLength >= MIN_SIZE_FOR_POPUP) {
+    popupFn();
+  }
+
+  // For FB2, we parse the entire file but the section offsets help us identify content.
+  // Since expat requires well-formed XML from the start, we parse the whole file.
+  XML_SetUserData(xmlParser, this);
+  XML_SetElementHandler(xmlParser, startElement, endElement);
+  XML_SetCharacterDataHandler(xmlParser, characterData);
+
+  bool success = true;
+  int done;
+  do {
+    void* const buf = XML_GetBuffer(xmlParser, 1024);
+    if (!buf) {
+      success = false;
+      break;
+    }
+
+    const size_t len = file.read(buf, 1024);
+    if (len == 0 && file.available() > 0) {
+      success = false;
+      break;
+    }
+
+    done = file.available() == 0;
+
+    if (XML_ParseBuffer(xmlParser, static_cast<int>(len), done) == XML_STATUS_ERROR) {
+      Serial.printf("[%lu] [FB2] Section parse error: %s\n", millis(), XML_ErrorString(XML_GetErrorCode(xmlParser)));
+      success = false;
+      break;
+    }
+
+    // Stop early if we've finished parsing the target section
+    if (pastTargetSection) {
+      break;
+    }
+  } while (!done);
+
+  XML_ParserFree(xmlParser);
+  file.close();
+
+  // Flush remaining content
+  if (success && currentTextBlock) {
+    makePages();
+    if (currentPage) {
+      completePageFn(std::move(currentPage));
+      currentPage.reset();
+    }
+    currentTextBlock.reset();
+  }
+
+  return success;
+}

--- a/lib/Fb2/Fb2/Fb2SectionParser.h
+++ b/lib/Fb2/Fb2/Fb2SectionParser.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <Epub/Page.h>
+#include <Epub/ParsedText.h>
+#include <Epub/blocks/BlockStyle.h>
+#include <Epub/blocks/TextBlock.h>
+#include <expat.h>
+
+#include <climits>
+#include <functional>
+#include <memory>
+#include <string>
+
+class GfxRenderer;
+
+#define FB2_MAX_WORD_SIZE 200
+
+// Expat-based parser for FB2 section content.
+// Converts FB2 tags into Pages using the same rendering pipeline as EPUB.
+class Fb2SectionParser {
+  const std::string& filepath;
+  size_t fileOffset;
+  size_t sectionLength;
+  GfxRenderer& renderer;
+  std::function<void(std::unique_ptr<Page>)> completePageFn;
+  std::function<void()> popupFn;
+
+  int targetSectionIndex;
+  int depth = 0;
+  int skipUntilDepth = INT_MAX;
+  int boldUntilDepth = INT_MAX;
+  int italicUntilDepth = INT_MAX;
+  int topLevelSectionCount = 0;
+  int targetSectionDepth = -1;  // depth at which the target section was entered
+  bool inTargetSection = false;
+  bool pastTargetSection = false;
+  bool inBody = false;
+
+  char partWordBuffer[FB2_MAX_WORD_SIZE + 1] = {};
+  int partWordBufferIndex = 0;
+  bool nextWordContinues = false;
+  std::unique_ptr<ParsedText> currentTextBlock = nullptr;
+  std::unique_ptr<Page> currentPage = nullptr;
+  int16_t currentPageNextY = 0;
+
+  int fontId;
+  float lineCompression;
+  bool extraParagraphSpacing;
+  uint8_t paragraphAlignment;
+  uint16_t viewportWidth;
+  uint16_t viewportHeight;
+  bool hyphenationEnabled;
+
+  void flushPartWordBuffer();
+  void startNewTextBlock(const BlockStyle& blockStyle);
+  void makePages();
+  void addLineToPage(std::shared_ptr<TextBlock> line);
+
+  static void XMLCALL startElement(void* userData, const char* name, const char** atts);
+  static void XMLCALL characterData(void* userData, const char* s, int len);
+  static void XMLCALL endElement(void* userData, const char* name);
+
+ public:
+  explicit Fb2SectionParser(const std::string& filepath, size_t fileOffset, size_t sectionLength,
+                            int targetSectionIndex, GfxRenderer& renderer, int fontId, float lineCompression,
+                            bool extraParagraphSpacing, uint8_t paragraphAlignment, uint16_t viewportWidth,
+                            uint16_t viewportHeight, bool hyphenationEnabled,
+                            const std::function<void(std::unique_ptr<Page>)>& completePageFn,
+                            const std::function<void()>& popupFn = nullptr)
+      : filepath(filepath),
+        fileOffset(fileOffset),
+        sectionLength(sectionLength),
+        targetSectionIndex(targetSectionIndex),
+        renderer(renderer),
+        fontId(fontId),
+        lineCompression(lineCompression),
+        extraParagraphSpacing(extraParagraphSpacing),
+        paragraphAlignment(paragraphAlignment),
+        viewportWidth(viewportWidth),
+        viewportHeight(viewportHeight),
+        hyphenationEnabled(hyphenationEnabled),
+        completePageFn(completePageFn),
+        popupFn(popupFn) {}
+
+  bool parseAndBuildPages();
+};

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -1,6 +1,7 @@
 #include "RecentBooksStore.h"
 
 #include <Epub.h>
+#include <Fb2.h>
 #include <HalStorage.h>
 #include <HardwareSerial.h>
 #include <Serialization.h>
@@ -90,6 +91,11 @@ RecentBook RecentBooksStore::getDataFromBook(std::string path) const {
     Epub epub(path, "/.crosspoint");
     epub.load(false);
     return RecentBook{path, epub.getTitle(), epub.getAuthor(), epub.getThumbBmpPath()};
+  } else if (StringUtils::checkFileExtension(lastBookFileName, ".fb2")) {
+    Fb2 fb2(path, "/.crosspoint");
+    if (fb2.load(false)) {
+      return RecentBook{path, fb2.getTitle(), fb2.getAuthor(), fb2.getThumbBmpPath()};
+    }
   } else if (StringUtils::checkFileExtension(lastBookFileName, ".xtch") ||
              StringUtils::checkFileExtension(lastBookFileName, ".xtc")) {
     // Handle XTC file

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -1,6 +1,7 @@
 #include "SleepActivity.h"
 
 #include <Epub.h>
+#include <Fb2.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Txt.h>
@@ -228,6 +229,19 @@ void SleepActivity::renderCoverSleepScreen() const {
     }
 
     coverBmpPath = lastXtc.getCoverBmpPath();
+  } else if (StringUtils::checkFileExtension(APP_STATE.openEpubPath, ".fb2")) {
+    Fb2 lastFb2(APP_STATE.openEpubPath, "/.crosspoint");
+    if (!lastFb2.load(true)) {
+      Serial.println("[SLP] Failed to load last FB2");
+      return (this->*renderNoCoverSleepScreen)();
+    }
+
+    if (!lastFb2.generateCoverBmp()) {
+      Serial.println("[SLP] Failed to generate FB2 cover bmp");
+      return (this->*renderNoCoverSleepScreen)();
+    }
+
+    coverBmpPath = lastFb2.getCoverBmpPath();
   } else if (StringUtils::checkFileExtension(APP_STATE.openEpubPath, ".txt")) {
     // Handle TXT file - looks for cover image in the same folder
     Txt lastTxt(APP_STATE.openEpubPath, "/.crosspoint");

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <Bitmap.h>
 #include <Epub.h>
+#include <Fb2.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Utf8.h>
@@ -84,6 +85,22 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
           }
           coverRendered = false;
           updateRequired = true;
+        } else if (StringUtils::checkFileExtension(book.path, ".fb2")) {
+          Fb2 fb2(book.path, "/.crosspoint");
+          if (fb2.load(false)) {
+            if (!showingLoading) {
+              showingLoading = true;
+              popupRect = GUI.drawPopup(renderer, "Loading...");
+            }
+            GUI.fillPopupProgress(renderer, popupRect, 10 + progress * (90 / recentBooks.size()));
+            bool success = fb2.generateThumbBmp(coverHeight);
+            if (!success) {
+              RECENT_BOOKS.updateBook(book.path, book.title, book.author, "");
+              book.coverBmpPath = "";
+            }
+            coverRendered = false;
+            updateRequired = true;
+          }
         } else if (StringUtils::checkFileExtension(book.path, ".xtch") ||
                    StringUtils::checkFileExtension(book.path, ".xtc")) {
           // Handle XTC file

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -52,9 +52,9 @@ void MyLibraryActivity::loadFiles() {
       files.emplace_back(std::string(name) + "/");
     } else {
       auto filename = std::string(name);
-      if (StringUtils::checkFileExtension(filename, ".epub") || StringUtils::checkFileExtension(filename, ".xtch") ||
-          StringUtils::checkFileExtension(filename, ".xtc") || StringUtils::checkFileExtension(filename, ".txt") ||
-          StringUtils::checkFileExtension(filename, ".md")) {
+      if (StringUtils::checkFileExtension(filename, ".epub") || StringUtils::checkFileExtension(filename, ".fb2") ||
+          StringUtils::checkFileExtension(filename, ".xtch") || StringUtils::checkFileExtension(filename, ".xtc") ||
+          StringUtils::checkFileExtension(filename, ".txt") || StringUtils::checkFileExtension(filename, ".md")) {
         files.emplace_back(filename);
       }
     }

--- a/src/activities/reader/Fb2ReaderActivity.cpp
+++ b/src/activities/reader/Fb2ReaderActivity.cpp
@@ -1,0 +1,637 @@
+#include "Fb2ReaderActivity.h"
+
+#include <Epub/Page.h>
+#include <GfxRenderer.h>
+#include <HalStorage.h>
+
+#include "CrossPointSettings.h"
+#include "CrossPointState.h"
+#include "EpubReaderPercentSelectionActivity.h"
+#include "Fb2ReaderChapterSelectionActivity.h"
+#include "MappedInputManager.h"
+#include "RecentBooksStore.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
+
+namespace {
+constexpr unsigned long skipChapterMs = 700;
+constexpr unsigned long goHomeMs = 1000;
+constexpr int statusBarMargin = 19;
+constexpr int progressBarMarginTop = 1;
+
+int clampPercent(int percent) {
+  if (percent < 0) return 0;
+  if (percent > 100) return 100;
+  return percent;
+}
+
+void applyReaderOrientation(GfxRenderer& renderer, const uint8_t orientation) {
+  switch (orientation) {
+    case CrossPointSettings::ORIENTATION::PORTRAIT:
+      renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+      break;
+    case CrossPointSettings::ORIENTATION::LANDSCAPE_CW:
+      renderer.setOrientation(GfxRenderer::Orientation::LandscapeClockwise);
+      break;
+    case CrossPointSettings::ORIENTATION::INVERTED:
+      renderer.setOrientation(GfxRenderer::Orientation::PortraitInverted);
+      break;
+    case CrossPointSettings::ORIENTATION::LANDSCAPE_CCW:
+      renderer.setOrientation(GfxRenderer::Orientation::LandscapeCounterClockwise);
+      break;
+    default:
+      break;
+  }
+}
+}  // namespace
+
+void Fb2ReaderActivity::taskTrampoline(void* param) {
+  auto* self = static_cast<Fb2ReaderActivity*>(param);
+  self->displayTaskLoop();
+}
+
+void Fb2ReaderActivity::onEnter() {
+  ActivityWithSubactivity::onEnter();
+
+  if (!fb2) return;
+
+  applyReaderOrientation(renderer, SETTINGS.orientation);
+  renderingMutex = xSemaphoreCreateMutex();
+  fb2->setupCacheDir();
+
+  // Load progress
+  FsFile f;
+  if (Storage.openFileForRead("FBR", fb2->getCachePath() + "/progress.bin", f)) {
+    uint8_t data[6];
+    int dataSize = f.read(data, 6);
+    if (dataSize == 4 || dataSize == 6) {
+      currentSectionIndex = data[0] + (data[1] << 8);
+      nextPageNumber = data[2] + (data[3] << 8);
+      cachedSectionIndex = currentSectionIndex;
+    }
+    if (dataSize == 6) {
+      cachedSectionTotalPageCount = data[4] + (data[5] << 8);
+    }
+    f.close();
+  }
+
+  APP_STATE.openEpubPath = fb2->getPath();
+  APP_STATE.saveToFile();
+  RECENT_BOOKS.addBook(fb2->getPath(), fb2->getTitle(), fb2->getAuthor(), fb2->getThumbBmpPath());
+
+  updateRequired = true;
+  xTaskCreate(&Fb2ReaderActivity::taskTrampoline, "Fb2ReaderTask", 8192, this, 1, &displayTaskHandle);
+}
+
+void Fb2ReaderActivity::onExit() {
+  ActivityWithSubactivity::onExit();
+  renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+
+  xSemaphoreTake(renderingMutex, portMAX_DELAY);
+  if (displayTaskHandle) {
+    vTaskDelete(displayTaskHandle);
+    displayTaskHandle = nullptr;
+  }
+  vSemaphoreDelete(renderingMutex);
+  renderingMutex = nullptr;
+  APP_STATE.readerActivityLoadCount = 0;
+  APP_STATE.saveToFile();
+  section.reset();
+  fb2.reset();
+}
+
+void Fb2ReaderActivity::loop() {
+  if (subActivity) {
+    subActivity->loop();
+    if (pendingSubactivityExit) {
+      pendingSubactivityExit = false;
+      exitActivity();
+      updateRequired = true;
+      skipNextButtonCheck = true;
+    }
+    if (pendingGoHome) {
+      pendingGoHome = false;
+      exitActivity();
+      if (onGoHome) onGoHome();
+      return;
+    }
+    return;
+  }
+
+  if (pendingGoHome) {
+    pendingGoHome = false;
+    if (onGoHome) onGoHome();
+    return;
+  }
+
+  if (skipNextButtonCheck) {
+    const bool confirmCleared = !mappedInput.isPressed(MappedInputManager::Button::Confirm) &&
+                                !mappedInput.wasReleased(MappedInputManager::Button::Confirm);
+    const bool backCleared = !mappedInput.isPressed(MappedInputManager::Button::Back) &&
+                             !mappedInput.wasReleased(MappedInputManager::Button::Back);
+    if (confirmCleared && backCleared) {
+      skipNextButtonCheck = false;
+    }
+    return;
+  }
+
+  // Menu
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    xSemaphoreTake(renderingMutex, portMAX_DELAY);
+    const int currentPage = section ? section->currentPage + 1 : 0;
+    const int totalPages = section ? section->pageCount : 0;
+    float bookProgress = 0.0f;
+    if (fb2 && fb2->getBookSize() > 0 && section && section->pageCount > 0) {
+      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+      bookProgress = fb2->calculateProgress(currentSectionIndex, chapterProgress) * 100.0f;
+    }
+    const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
+    exitActivity();
+    enterNewActivity(new EpubReaderMenuActivity(
+        this->renderer, this->mappedInput, fb2->getTitle(), currentPage, totalPages, bookProgressPercent,
+        SETTINGS.orientation, [this](const uint8_t orientation) { onReaderMenuBack(orientation); },
+        [this](EpubReaderMenuActivity::MenuAction action) { onReaderMenuConfirm(action); }));
+    xSemaphoreGive(renderingMutex);
+  }
+
+  // Long press BACK (1s+) goes to file selection
+  if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= goHomeMs) {
+    onGoBack();
+    return;
+  }
+
+  // Short press BACK goes home
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) && mappedInput.getHeldTime() < goHomeMs) {
+    onGoHome();
+    return;
+  }
+
+  const bool usePressForPageTurn = !SETTINGS.longPressChapterSkip;
+  const bool prevTriggered = usePressForPageTurn ? (mappedInput.wasPressed(MappedInputManager::Button::PageBack) ||
+                                                    mappedInput.wasPressed(MappedInputManager::Button::Left))
+                                                 : (mappedInput.wasReleased(MappedInputManager::Button::PageBack) ||
+                                                    mappedInput.wasReleased(MappedInputManager::Button::Left));
+  const bool powerPageTurn = SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::PAGE_TURN &&
+                             mappedInput.wasReleased(MappedInputManager::Button::Power);
+  const bool nextTriggered = usePressForPageTurn
+                                 ? (mappedInput.wasPressed(MappedInputManager::Button::PageForward) || powerPageTurn ||
+                                    mappedInput.wasPressed(MappedInputManager::Button::Right))
+                                 : (mappedInput.wasReleased(MappedInputManager::Button::PageForward) || powerPageTurn ||
+                                    mappedInput.wasReleased(MappedInputManager::Button::Right));
+
+  if (!prevTriggered && !nextTriggered) return;
+
+  // End of book handling
+  if (currentSectionIndex > 0 && currentSectionIndex >= fb2->getSectionCount()) {
+    currentSectionIndex = fb2->getSectionCount() - 1;
+    nextPageNumber = UINT16_MAX;
+    updateRequired = true;
+    return;
+  }
+
+  const bool skipChapter = SETTINGS.longPressChapterSkip && mappedInput.getHeldTime() > skipChapterMs;
+
+  if (skipChapter) {
+    const int nextIndex = nextTriggered ? currentSectionIndex + 1 : currentSectionIndex - 1;
+    if (nextIndex < 0) return;  // Already at the beginning of the book
+    xSemaphoreTake(renderingMutex, portMAX_DELAY);
+    nextPageNumber = 0;
+    currentSectionIndex = nextIndex;
+    section.reset();
+    xSemaphoreGive(renderingMutex);
+    updateRequired = true;
+    return;
+  }
+
+  if (!section) {
+    updateRequired = true;
+    return;
+  }
+
+  if (prevTriggered) {
+    if (section->currentPage > 0) {
+      section->currentPage--;
+    } else if (currentSectionIndex > 0) {
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      nextPageNumber = UINT16_MAX;
+      currentSectionIndex--;
+      section.reset();
+      xSemaphoreGive(renderingMutex);
+    }
+    updateRequired = true;
+  } else {
+    if (section->currentPage < section->pageCount - 1) {
+      section->currentPage++;
+    } else {
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      nextPageNumber = 0;
+      currentSectionIndex++;
+      section.reset();
+      xSemaphoreGive(renderingMutex);
+    }
+    updateRequired = true;
+  }
+}
+
+void Fb2ReaderActivity::onReaderMenuBack(const uint8_t orientation) {
+  exitActivity();
+  applyOrientation(orientation);
+  updateRequired = true;
+}
+
+void Fb2ReaderActivity::jumpToPercent(int percent) {
+  if (!fb2) return;
+
+  const size_t bookSize = fb2->getBookSize();
+  if (bookSize == 0) return;
+
+  percent = clampPercent(percent);
+  size_t targetSize =
+      (bookSize / 100) * static_cast<size_t>(percent) + (bookSize % 100) * static_cast<size_t>(percent) / 100;
+  if (percent >= 100) targetSize = bookSize - 1;
+
+  const int sectionCount = fb2->getSectionCount();
+  if (sectionCount == 0) return;
+
+  int targetIdx = sectionCount - 1;
+  size_t prevCumulative = 0;
+
+  for (int i = 0; i < sectionCount; i++) {
+    const size_t cumulative = fb2->getCumulativeSectionSize(i);
+    if (targetSize <= cumulative) {
+      targetIdx = i;
+      prevCumulative = (i > 0) ? fb2->getCumulativeSectionSize(i - 1) : 0;
+      break;
+    }
+  }
+
+  const size_t cumulative = fb2->getCumulativeSectionSize(targetIdx);
+  const size_t sectionSize = (cumulative > prevCumulative) ? (cumulative - prevCumulative) : 0;
+  pendingSpineProgress =
+      (sectionSize == 0) ? 0.0f : static_cast<float>(targetSize - prevCumulative) / static_cast<float>(sectionSize);
+  if (pendingSpineProgress < 0.0f) pendingSpineProgress = 0.0f;
+  if (pendingSpineProgress > 1.0f) pendingSpineProgress = 1.0f;
+
+  xSemaphoreTake(renderingMutex, portMAX_DELAY);
+  currentSectionIndex = targetIdx;
+  nextPageNumber = 0;
+  pendingPercentJump = true;
+  section.reset();
+  xSemaphoreGive(renderingMutex);
+}
+
+void Fb2ReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action) {
+  switch (action) {
+    case EpubReaderMenuActivity::MenuAction::SELECT_CHAPTER: {
+      const int currentP = section ? section->currentPage : 0;
+      const int totalP = section ? section->pageCount : 0;
+      const int secIdx = currentSectionIndex;
+
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      exitActivity();
+      enterNewActivity(new Fb2ReaderChapterSelectionActivity(
+          this->renderer, this->mappedInput, fb2, secIdx, currentP, totalP,
+          [this] {
+            exitActivity();
+            updateRequired = true;
+          },
+          [this](const int newSectionIndex) {
+            if (currentSectionIndex != newSectionIndex) {
+              currentSectionIndex = newSectionIndex;
+              nextPageNumber = 0;
+              section.reset();
+            }
+            exitActivity();
+            updateRequired = true;
+          }));
+      xSemaphoreGive(renderingMutex);
+      break;
+    }
+    case EpubReaderMenuActivity::MenuAction::GO_TO_PERCENT: {
+      float bookProgress = 0.0f;
+      if (fb2 && fb2->getBookSize() > 0 && section && section->pageCount > 0) {
+        const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+        bookProgress = fb2->calculateProgress(currentSectionIndex, chapterProgress) * 100.0f;
+      }
+      const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      exitActivity();
+      enterNewActivity(new EpubReaderPercentSelectionActivity(
+          renderer, mappedInput, initialPercent,
+          [this](const int percent) {
+            jumpToPercent(percent);
+            exitActivity();
+            updateRequired = true;
+          },
+          [this]() {
+            exitActivity();
+            updateRequired = true;
+          }));
+      xSemaphoreGive(renderingMutex);
+      break;
+    }
+    case EpubReaderMenuActivity::MenuAction::GO_HOME: {
+      pendingGoHome = true;
+      break;
+    }
+    case EpubReaderMenuActivity::MenuAction::DELETE_CACHE: {
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      if (fb2) {
+        uint16_t backupSection = currentSectionIndex;
+        uint16_t backupPage = section ? section->currentPage : 0;
+        uint16_t backupPageCount = section ? section->pageCount : 0;
+
+        section.reset();
+        fb2->clearCache();
+        fb2->setupCacheDir();
+        saveProgress(backupSection, backupPage, backupPageCount);
+      }
+      xSemaphoreGive(renderingMutex);
+      pendingGoHome = true;
+      break;
+    }
+    case EpubReaderMenuActivity::MenuAction::SYNC: {
+      // KOReader sync not supported for FB2
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void Fb2ReaderActivity::applyOrientation(const uint8_t orientation) {
+  if (SETTINGS.orientation == orientation) return;
+
+  xSemaphoreTake(renderingMutex, portMAX_DELAY);
+  if (section) {
+    cachedSectionIndex = currentSectionIndex;
+    cachedSectionTotalPageCount = section->pageCount;
+    nextPageNumber = section->currentPage;
+  }
+
+  SETTINGS.orientation = orientation;
+  SETTINGS.saveToFile();
+  applyReaderOrientation(renderer, SETTINGS.orientation);
+  section.reset();
+  xSemaphoreGive(renderingMutex);
+}
+
+void Fb2ReaderActivity::displayTaskLoop() {
+  while (true) {
+    if (updateRequired) {
+      updateRequired = false;
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      renderScreen();
+      xSemaphoreGive(renderingMutex);
+    }
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+  }
+}
+
+void Fb2ReaderActivity::renderScreen() {
+  if (!fb2) return;
+
+  if (currentSectionIndex < 0) currentSectionIndex = 0;
+  if (currentSectionIndex > fb2->getSectionCount()) currentSectionIndex = fb2->getSectionCount();
+
+  if (currentSectionIndex == fb2->getSectionCount()) {
+    renderer.clearScreen();
+    renderer.drawCenteredText(UI_12_FONT_ID, 300, "End of book", true, EpdFontFamily::BOLD);
+    renderer.displayBuffer();
+    return;
+  }
+
+  int orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft;
+  renderer.getOrientedViewableTRBL(&orientedMarginTop, &orientedMarginRight, &orientedMarginBottom,
+                                   &orientedMarginLeft);
+  orientedMarginTop += SETTINGS.screenMargin;
+  orientedMarginLeft += SETTINGS.screenMargin;
+  orientedMarginRight += SETTINGS.screenMargin;
+  orientedMarginBottom += SETTINGS.screenMargin;
+
+  auto metrics = UITheme::getInstance().getMetrics();
+
+  if (SETTINGS.statusBar != CrossPointSettings::STATUS_BAR_MODE::NONE) {
+    const bool showProgressBar = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::BOOK_PROGRESS_BAR ||
+                                 SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::ONLY_BOOK_PROGRESS_BAR ||
+                                 SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::CHAPTER_PROGRESS_BAR;
+    orientedMarginBottom += statusBarMargin - SETTINGS.screenMargin +
+                            (showProgressBar ? (metrics.bookProgressBarHeight + progressBarMarginTop) : 0);
+  }
+
+  if (!section) {
+    const auto& sectionInfo = fb2->getSectionInfo(currentSectionIndex);
+    Serial.printf("[%lu] [FBR] Loading section %d: %s\n", millis(), currentSectionIndex, sectionInfo.title.c_str());
+    section = std::unique_ptr<Fb2Section>(new Fb2Section(fb2, currentSectionIndex, renderer));
+
+    const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
+    const uint16_t viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;
+
+    if (!section->loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
+                                  SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,
+                                  viewportHeight, SETTINGS.hyphenationEnabled)) {
+      Serial.printf("[%lu] [FBR] Cache not found, building...\n", millis());
+      const auto popupFn = [this]() { GUI.drawPopup(renderer, "Indexing..."); };
+
+      if (!section->createSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
+                                      SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,
+                                      viewportHeight, SETTINGS.hyphenationEnabled, popupFn)) {
+        Serial.printf("[%lu] [FBR] Failed to build section\n", millis());
+        section.reset();
+        return;
+      }
+    }
+
+    if (nextPageNumber == UINT16_MAX) {
+      section->currentPage = section->pageCount - 1;
+    } else {
+      section->currentPage = nextPageNumber;
+    }
+
+    if (cachedSectionTotalPageCount > 0) {
+      if (currentSectionIndex == cachedSectionIndex && section->pageCount != cachedSectionTotalPageCount) {
+        float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedSectionTotalPageCount);
+        section->currentPage = static_cast<int>(progress * section->pageCount);
+      }
+      cachedSectionTotalPageCount = 0;
+    }
+
+    if (pendingPercentJump && section->pageCount > 0) {
+      int newPage = static_cast<int>(pendingSpineProgress * static_cast<float>(section->pageCount));
+      if (newPage >= section->pageCount) newPage = section->pageCount - 1;
+      section->currentPage = newPage;
+      pendingPercentJump = false;
+    }
+  }
+
+  renderer.clearScreen();
+
+  if (section->pageCount == 0) {
+    renderer.drawCenteredText(UI_12_FONT_ID, 300, "Empty chapter", true, EpdFontFamily::BOLD);
+    renderStatusBar(orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
+    renderer.displayBuffer();
+    return;
+  }
+
+  if (section->currentPage < 0 || section->currentPage >= section->pageCount) {
+    renderer.drawCenteredText(UI_12_FONT_ID, 300, "Out of bounds", true, EpdFontFamily::BOLD);
+    renderStatusBar(orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
+    renderer.displayBuffer();
+    return;
+  }
+
+  {
+    auto p = section->loadPageFromSectionFile();
+    if (!p) {
+      section->clearCache();
+      section.reset();
+      return renderScreen();
+    }
+    renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
+  }
+  saveProgress(currentSectionIndex, section->currentPage, section->pageCount);
+}
+
+void Fb2ReaderActivity::saveProgress(int sectionIndex, int currentPage, int pageCount) {
+  FsFile f;
+  if (Storage.openFileForWrite("FBR", fb2->getCachePath() + "/progress.bin", f)) {
+    uint8_t data[6];
+    data[0] = sectionIndex & 0xFF;
+    data[1] = (sectionIndex >> 8) & 0xFF;
+    data[2] = currentPage & 0xFF;
+    data[3] = (currentPage >> 8) & 0xFF;
+    data[4] = pageCount & 0xFF;
+    data[5] = (pageCount >> 8) & 0xFF;
+    f.write(data, 6);
+    f.close();
+  }
+}
+
+void Fb2ReaderActivity::renderContents(std::unique_ptr<Page> page, const int orientedMarginTop,
+                                       const int orientedMarginRight, const int orientedMarginBottom,
+                                       const int orientedMarginLeft) {
+  page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
+  renderStatusBar(orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
+  if (pagesUntilFullRefresh <= 1) {
+    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+    pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
+  } else {
+    renderer.displayBuffer();
+    pagesUntilFullRefresh--;
+  }
+
+  renderer.storeBwBuffer();
+
+  if (SETTINGS.textAntiAliasing) {
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayGrayBuffer();
+    renderer.setRenderMode(GfxRenderer::BW);
+  }
+
+  renderer.restoreBwBuffer();
+}
+
+void Fb2ReaderActivity::renderStatusBar(const int orientedMarginRight, const int orientedMarginBottom,
+                                        const int orientedMarginLeft) const {
+  auto metrics = UITheme::getInstance().getMetrics();
+
+  const bool showProgressPercentage = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::FULL;
+  const bool showBookProgressBar = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::BOOK_PROGRESS_BAR ||
+                                   SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::ONLY_BOOK_PROGRESS_BAR;
+  const bool showChapterProgressBar = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::CHAPTER_PROGRESS_BAR;
+  const bool showProgressText = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::FULL ||
+                                SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::CHAPTER_PROGRESS_BAR;
+  const bool showBookPercentage = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::BOOK_PROGRESS_BAR;
+  const bool showBattery = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::NO_PROGRESS ||
+                           SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::FULL ||
+                           SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::BOOK_PROGRESS_BAR ||
+                           SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::CHAPTER_PROGRESS_BAR;
+  const bool showChapterTitle = SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::NO_PROGRESS ||
+                                SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::FULL ||
+                                SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::BOOK_PROGRESS_BAR ||
+                                SETTINGS.statusBar == CrossPointSettings::STATUS_BAR_MODE::CHAPTER_PROGRESS_BAR;
+  const bool showBatteryPercentage =
+      SETTINGS.hideBatteryPercentage == CrossPointSettings::HIDE_BATTERY_PERCENTAGE::HIDE_NEVER;
+
+  const auto screenHeight = renderer.getScreenHeight();
+  const auto textY = screenHeight - orientedMarginBottom - 4;
+  int progressTextWidth = 0;
+
+  const float sectionChapterProg =
+      (section->pageCount > 0) ? static_cast<float>(section->currentPage + 1) / section->pageCount : 0;
+  const float bookProgress = fb2->calculateProgress(currentSectionIndex, sectionChapterProg) * 100;
+
+  if (showProgressText || showProgressPercentage || showBookPercentage) {
+    char progressStr[32];
+    if (showProgressPercentage) {
+      snprintf(progressStr, sizeof(progressStr), "%d/%d  %.0f%%", section->currentPage + 1, section->pageCount,
+               bookProgress);
+    } else if (showBookPercentage) {
+      snprintf(progressStr, sizeof(progressStr), "%.0f%%", bookProgress);
+    } else {
+      snprintf(progressStr, sizeof(progressStr), "%d/%d", section->currentPage + 1, section->pageCount);
+    }
+
+    progressTextWidth = renderer.getTextWidth(SMALL_FONT_ID, progressStr);
+    renderer.drawText(SMALL_FONT_ID, renderer.getScreenWidth() - orientedMarginRight - progressTextWidth, textY,
+                      progressStr);
+  }
+
+  if (showBookProgressBar) {
+    GUI.drawReadingProgressBar(renderer, static_cast<size_t>(bookProgress));
+  }
+
+  if (showChapterProgressBar) {
+    const float chapterProgress =
+        (section->pageCount > 0) ? (static_cast<float>(section->currentPage + 1) / section->pageCount) * 100 : 0;
+    GUI.drawReadingProgressBar(renderer, static_cast<size_t>(chapterProgress));
+  }
+
+  if (showBattery) {
+    GUI.drawBattery(renderer, Rect{orientedMarginLeft + 1, textY, metrics.batteryWidth, metrics.batteryHeight},
+                    showBatteryPercentage);
+  }
+
+  if (showChapterTitle) {
+    const int rendererableScreenWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
+    const int batterySize = showBattery ? (showBatteryPercentage ? 50 : 20) : 0;
+    const int titleMarginLeft = batterySize + 30;
+    const int titleMarginRight = progressTextWidth + 30;
+
+    int titleMarginLeftAdjusted = std::max(titleMarginLeft, titleMarginRight);
+    int availableTitleSpace = rendererableScreenWidth - 2 * titleMarginLeftAdjusted;
+    const int tocIndex = fb2->getTocIndexForSectionIndex(currentSectionIndex);
+
+    std::string sectionTitle;
+    int titleWidth;
+    if (tocIndex == -1) {
+      sectionTitle = "Unnamed";
+      titleWidth = renderer.getTextWidth(SMALL_FONT_ID, "Unnamed");
+    } else {
+      const auto& tocEntry = fb2->getTocEntry(tocIndex);
+      sectionTitle = tocEntry.title;
+      titleWidth = renderer.getTextWidth(SMALL_FONT_ID, sectionTitle.c_str());
+      if (titleWidth > availableTitleSpace) {
+        availableTitleSpace = rendererableScreenWidth - titleMarginLeft - titleMarginRight;
+        titleMarginLeftAdjusted = titleMarginLeft;
+      }
+      if (titleWidth > availableTitleSpace) {
+        sectionTitle = renderer.truncatedText(SMALL_FONT_ID, sectionTitle.c_str(), availableTitleSpace);
+        titleWidth = renderer.getTextWidth(SMALL_FONT_ID, sectionTitle.c_str());
+      }
+    }
+
+    renderer.drawText(SMALL_FONT_ID,
+                      titleMarginLeftAdjusted + orientedMarginLeft + (availableTitleSpace - titleWidth) / 2, textY,
+                      sectionTitle.c_str());
+  }
+}

--- a/src/activities/reader/Fb2ReaderActivity.h
+++ b/src/activities/reader/Fb2ReaderActivity.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <Fb2.h>
+#include <Fb2/Fb2Section.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+
+#include "EpubReaderMenuActivity.h"
+#include "activities/ActivityWithSubactivity.h"
+
+class Fb2ReaderActivity final : public ActivityWithSubactivity {
+  std::shared_ptr<Fb2> fb2;
+  std::unique_ptr<Fb2Section> section = nullptr;
+  TaskHandle_t displayTaskHandle = nullptr;
+  SemaphoreHandle_t renderingMutex = nullptr;
+  int currentSectionIndex = 0;
+  int nextPageNumber = 0;
+  int pagesUntilFullRefresh = 0;
+  int cachedSectionIndex = 0;
+  int cachedSectionTotalPageCount = 0;
+  bool pendingPercentJump = false;
+  float pendingSpineProgress = 0.0f;
+  bool updateRequired = false;
+  bool pendingSubactivityExit = false;
+  bool pendingGoHome = false;
+  bool skipNextButtonCheck = false;
+  const std::function<void()> onGoBack;
+  const std::function<void()> onGoHome;
+
+  static void taskTrampoline(void* param);
+  [[noreturn]] void displayTaskLoop();
+  void renderScreen();
+  void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,
+                      int orientedMarginBottom, int orientedMarginLeft);
+  void renderStatusBar(int orientedMarginRight, int orientedMarginBottom, int orientedMarginLeft) const;
+  void saveProgress(int sectionIndex, int currentPage, int pageCount);
+  void jumpToPercent(int percent);
+  void onReaderMenuBack(uint8_t orientation);
+  void onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action);
+  void applyOrientation(uint8_t orientation);
+
+ public:
+  explicit Fb2ReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Fb2> fb2,
+                             const std::function<void()>& onGoBack, const std::function<void()>& onGoHome)
+      : ActivityWithSubactivity("Fb2Reader", renderer, mappedInput),
+        fb2(std::move(fb2)),
+        onGoBack(onGoBack),
+        onGoHome(onGoHome) {}
+  void onEnter() override;
+  void onExit() override;
+  void loop() override;
+};

--- a/src/activities/reader/Fb2ReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/Fb2ReaderChapterSelectionActivity.cpp
@@ -1,0 +1,145 @@
+#include "Fb2ReaderChapterSelectionActivity.h"
+
+#include <GfxRenderer.h>
+
+#include "MappedInputManager.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
+
+namespace {
+constexpr int SKIP_PAGE_MS = 700;
+}  // namespace
+
+int Fb2ReaderChapterSelectionActivity::getTotalItems() const { return fb2->getTocCount(); }
+
+int Fb2ReaderChapterSelectionActivity::getPageItems() const {
+  constexpr int lineHeight = 30;
+  const int screenHeight = renderer.getScreenHeight();
+  const auto orientation = renderer.getOrientation();
+  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
+  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
+  const int startY = 60 + hintGutterHeight;
+  const int availableHeight = screenHeight - startY - lineHeight;
+  return std::max(1, availableHeight / lineHeight);
+}
+
+void Fb2ReaderChapterSelectionActivity::taskTrampoline(void* param) {
+  auto* self = static_cast<Fb2ReaderChapterSelectionActivity*>(param);
+  self->displayTaskLoop();
+}
+
+void Fb2ReaderChapterSelectionActivity::onEnter() {
+  ActivityWithSubactivity::onEnter();
+  if (!fb2) return;
+
+  renderingMutex = xSemaphoreCreateMutex();
+
+  selectorIndex = fb2->getTocIndexForSectionIndex(currentSectionIndex);
+  if (selectorIndex == -1) selectorIndex = 0;
+
+  updateRequired = true;
+  xTaskCreate(&Fb2ReaderChapterSelectionActivity::taskTrampoline, "Fb2ChapterTask", 4096, this, 1, &displayTaskHandle);
+}
+
+void Fb2ReaderChapterSelectionActivity::onExit() {
+  ActivityWithSubactivity::onExit();
+  xSemaphoreTake(renderingMutex, portMAX_DELAY);
+  if (displayTaskHandle) {
+    vTaskDelete(displayTaskHandle);
+    displayTaskHandle = nullptr;
+  }
+  vSemaphoreDelete(renderingMutex);
+  renderingMutex = nullptr;
+}
+
+void Fb2ReaderChapterSelectionActivity::loop() {
+  if (subActivity) {
+    subActivity->loop();
+    return;
+  }
+
+  const bool prevReleased = mappedInput.wasReleased(MappedInputManager::Button::Up) ||
+                            mappedInput.wasReleased(MappedInputManager::Button::Left);
+  const bool nextReleased = mappedInput.wasReleased(MappedInputManager::Button::Down) ||
+                            mappedInput.wasReleased(MappedInputManager::Button::Right);
+
+  const bool skipPage = mappedInput.getHeldTime() > SKIP_PAGE_MS;
+  const int pageItems = getPageItems();
+  const int totalItems = getTotalItems();
+
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    const auto newSectionIndex = fb2->getSectionIndexForTocIndex(selectorIndex);
+    onSelectSectionIndex(newSectionIndex);
+  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+    onGoBack();
+  } else if (prevReleased) {
+    if (skipPage) {
+      selectorIndex = ((selectorIndex / pageItems - 1) * pageItems + totalItems) % totalItems;
+    } else {
+      selectorIndex = (selectorIndex + totalItems - 1) % totalItems;
+    }
+    updateRequired = true;
+  } else if (nextReleased) {
+    if (skipPage) {
+      selectorIndex = ((selectorIndex / pageItems + 1) * pageItems) % totalItems;
+    } else {
+      selectorIndex = (selectorIndex + 1) % totalItems;
+    }
+    updateRequired = true;
+  }
+}
+
+void Fb2ReaderChapterSelectionActivity::displayTaskLoop() {
+  while (true) {
+    if (updateRequired && !subActivity) {
+      updateRequired = false;
+      xSemaphoreTake(renderingMutex, portMAX_DELAY);
+      renderScreen();
+      xSemaphoreGive(renderingMutex);
+    }
+    vTaskDelay(10 / portTICK_PERIOD_MS);
+  }
+}
+
+void Fb2ReaderChapterSelectionActivity::renderScreen() {
+  renderer.clearScreen();
+
+  const auto pageWidth = renderer.getScreenWidth();
+  const auto orientation = renderer.getOrientation();
+  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
+  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
+  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
+  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
+  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
+  const int contentWidth = pageWidth - hintGutterWidth;
+  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
+  const int contentY = hintGutterHeight;
+  const int pageItems = getPageItems();
+  const int totalItems = getTotalItems();
+
+  const int titleX =
+      contentX + (contentWidth - renderer.getTextWidth(UI_12_FONT_ID, "Go to Chapter", EpdFontFamily::BOLD)) / 2;
+  renderer.drawText(UI_12_FONT_ID, titleX, 15 + contentY, "Go to Chapter", true, EpdFontFamily::BOLD);
+
+  const auto pageStartIndex = selectorIndex / pageItems * pageItems;
+  renderer.fillRect(contentX, 60 + contentY + (selectorIndex % pageItems) * 30 - 2, contentWidth - 1, 30);
+
+  for (int i = 0; i < pageItems; i++) {
+    int itemIndex = pageStartIndex + i;
+    if (itemIndex >= totalItems) break;
+    const int displayY = 60 + contentY + i * 30;
+    const bool isSelected = (itemIndex == selectorIndex);
+
+    const auto& tocEntry = fb2->getTocEntry(itemIndex);
+    const int indentSize = contentX + 20;
+    const std::string chapterName =
+        renderer.truncatedText(UI_10_FONT_ID, tocEntry.title.c_str(), contentWidth - 40 - indentSize);
+
+    renderer.drawText(UI_10_FONT_ID, indentSize, displayY, chapterName.c_str(), !isSelected);
+  }
+
+  const auto labels = mappedInput.mapLabels("« Back", "Select", "Up", "Down");
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+
+  renderer.displayBuffer();
+}

--- a/src/activities/reader/Fb2ReaderChapterSelectionActivity.h
+++ b/src/activities/reader/Fb2ReaderChapterSelectionActivity.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <Fb2.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+
+#include <memory>
+
+#include "../ActivityWithSubactivity.h"
+
+class Fb2ReaderChapterSelectionActivity final : public ActivityWithSubactivity {
+  std::shared_ptr<Fb2> fb2;
+  TaskHandle_t displayTaskHandle = nullptr;
+  SemaphoreHandle_t renderingMutex = nullptr;
+  int currentSectionIndex = 0;
+  int currentPage = 0;
+  int totalPagesInSection = 0;
+  int selectorIndex = 0;
+  bool updateRequired = false;
+  const std::function<void()> onGoBack;
+  const std::function<void(int newSectionIndex)> onSelectSectionIndex;
+
+  int getPageItems() const;
+  int getTotalItems() const;
+
+  static void taskTrampoline(void* param);
+  [[noreturn]] void displayTaskLoop();
+  void renderScreen();
+
+ public:
+  explicit Fb2ReaderChapterSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                                             const std::shared_ptr<Fb2>& fb2, const int currentSectionIndex,
+                                             const int currentPage, const int totalPagesInSection,
+                                             const std::function<void()>& onGoBack,
+                                             const std::function<void(int newSectionIndex)>& onSelectSectionIndex)
+      : ActivityWithSubactivity("Fb2ChapterSelection", renderer, mappedInput),
+        fb2(fb2),
+        currentSectionIndex(currentSectionIndex),
+        currentPage(currentPage),
+        totalPagesInSection(totalPagesInSection),
+        onGoBack(onGoBack),
+        onSelectSectionIndex(onSelectSectionIndex) {}
+  void onEnter() override;
+  void onExit() override;
+  void loop() override;
+};

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -5,6 +5,7 @@
 #include "activities/home/MyLibraryActivity.h"
 
 class Epub;
+class Fb2;
 class Xtc;
 class Txt;
 
@@ -14,14 +15,17 @@ class ReaderActivity final : public ActivityWithSubactivity {
   const std::function<void()> onGoBack;
   const std::function<void(const std::string&)> onGoToLibrary;
   static std::unique_ptr<Epub> loadEpub(const std::string& path);
+  static std::unique_ptr<Fb2> loadFb2(const std::string& path);
   static std::unique_ptr<Xtc> loadXtc(const std::string& path);
   static std::unique_ptr<Txt> loadTxt(const std::string& path);
+  static bool isFb2File(const std::string& path);
   static bool isXtcFile(const std::string& path);
   static bool isTxtFile(const std::string& path);
 
   static std::string extractFolderPath(const std::string& filePath);
   void goToLibrary(const std::string& fromBookPath = "");
   void onGoToEpubReader(std::unique_ptr<Epub> epub);
+  void onGoToFb2Reader(std::unique_ptr<Fb2> fb2);
   void onGoToXtcReader(std::unique_ptr<Xtc> xtc);
   void onGoToTxtReader(std::unique_ptr<Txt> txt);
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -2,6 +2,7 @@
 
 #include <ArduinoJson.h>
 #include <Epub.h>
+#include <Fb2.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <WiFi.h>
@@ -40,11 +41,13 @@ size_t wsLastCompleteSize = 0;
 unsigned long wsLastCompleteAt = 0;
 
 // Helper function to clear epub cache after upload
-void clearEpubCacheIfNeeded(const String& filePath) {
-  // Only clear cache for .epub files
+void clearBookCacheIfNeeded(const String& filePath) {
   if (StringUtils::checkFileExtension(filePath, ".epub")) {
     Epub(filePath.c_str(), "/.crosspoint").clearCache();
     Serial.printf("[%lu] [WEB] Cleared epub cache for: %s\n", millis(), filePath.c_str());
+  } else if (StringUtils::checkFileExtension(filePath, ".fb2")) {
+    Fb2(filePath.c_str(), "/.crosspoint").clearCache();
+    Serial.printf("[%lu] [WEB] Cleared fb2 cache for: %s\n", millis(), filePath.c_str());
   }
 }
 
@@ -657,7 +660,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
         String filePath = state.path;
         if (!filePath.endsWith("/")) filePath += "/";
         filePath += state.fileName;
-        clearEpubCacheIfNeeded(filePath);
+        clearBookCacheIfNeeded(filePath);
       }
     }
   } else if (upload.status == UPLOAD_FILE_ABORTED) {
@@ -803,7 +806,7 @@ void CrossPointWebServer::handleRename() const {
     return;
   }
 
-  clearEpubCacheIfNeeded(itemPath);
+  clearBookCacheIfNeeded(itemPath);
   const bool success = file.rename(newPath.c_str());
   file.close();
 
@@ -896,7 +899,7 @@ void CrossPointWebServer::handleMove() const {
     return;
   }
 
-  clearEpubCacheIfNeeded(itemPath);
+  clearBookCacheIfNeeded(itemPath);
   const bool success = file.rename(newPath.c_str());
   file.close();
 
@@ -1290,7 +1293,7 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
         String filePath = wsUploadPath;
         if (!filePath.endsWith("/")) filePath += "/";
         filePath += wsUploadFileName;
-        clearEpubCacheIfNeeded(filePath);
+        clearBookCacheIfNeeded(filePath);
 
         wsServer->sendTXT(num, "DONE");
         lastProgressSent = 0;


### PR DESCRIPTION
Resolves #592

## Summary

- Add full reading support for FictionBook (`.fb2`) files — an XML-based ebook format popular in Russian-speaking countries
- New `lib/Fb2/` library with expat-based streaming parsers for metadata extraction, section content rendering, and base64 cover image extraction
- New `Fb2ReaderActivity` and `Fb2ReaderChapterSelectionActivity` for reading and chapter navigation
- Registered `.fb2` across all UI touchpoints: file browser, recent books, home screen covers, sleep screen, web server cache clearing

**Note:** Image support (inline images, ImageUtils, PngToBmpConverter) has been removed from this PR per reviewer feedback. Image rendering will be addressed in a separate follow-up PR.

## Details

**Library (`lib/Fb2/`)**
- `Fb2` — main class with binary metadata caching, section navigation, progress calculation
- `Fb2MetadataParser` — first-pass parser extracting title-info, author, language, cover ID, and section boundaries with file offsets
- `Fb2SectionParser` — content parser converting FB2 tags (`<p>`, `<title>`, `<emphasis>`, `<strong>`, `<poem>`, `<cite>`, `<epigraph>`, etc.) into Pages using the existing Epub rendering pipeline (ParsedText/TextBlock/Page)
- `Fb2CoverExtractor` — streams base64-encoded `<binary>` elements, decodes to JPEG, converts to BMP via JpegToBmpConverter
- `Fb2Section` — section cache manager with binary LUT for random page access

**Reader Activities**
- `Fb2ReaderActivity` — full reader with FreeRTOS display task, orientation support, progress save/restore, percent jump, status bar, text anti-aliasing. Reuses `EpubReaderMenuActivity` directly
- `Fb2ReaderChapterSelectionActivity` — TOC-based chapter selection from section titles

**Touchpoint Registration**
- `ReaderActivity` — FB2 file detection and dispatch
- `MyLibraryActivity` — `.fb2` in file browser filter
- `RecentBooksStore` — FB2 metadata extraction for recent books
- `HomeActivity` — FB2 cover thumbnail generation
- `SleepActivity` — FB2 cover for sleep screen
- `CrossPointWebServer` — FB2 cache clearing on upload/delete/rename

## AI Usage

YES — Code was generated with AI assistance (Claude). All code was reviewed and tested on device.

## Test plan

- [ ] Place `.fb2` files on SD card, verify they appear in Browse Files
- [ ] Open an FB2 file, verify reading with page navigation works
- [ ] Verify chapter selection shows section titles from the TOC
- [ ] Verify progress is saved and restored when reopening a book
- [ ] Verify cover thumbnails appear on home screen for FB2 books
- [ ] Verify sleep screen shows FB2 book cover when configured
- [ ] Verify "Go to %" navigation works correctly
- [ ] Verify cache deletion and rebuild works
- [ ] Verify FB2 files with no `<section>` tags render correctly as a single section
- [ ] Verify FB2 files with nested sections render each top-level section correctly
- [ ] Upload/delete FB2 via web server, verify cache is cleared