### PR TITLE
feat: Extend python debugging monitor functionality (keyword filter / suppress)

### DIFF
--- a/scripts/debugging_monitor.py
+++ b/scripts/debugging_monitor.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+"""
+ESP32 Serial Monitor with Memory Graph
+
+This script provides a real-time serial monitor for ESP32 devices with
+integrated memory usage graphing capabilities. It reads serial output,
+parses memory information, and displays it in both console and graphical form.
+"""
+
 import sys
 import argparse
 import re
@@ -6,7 +15,7 @@ from datetime import datetime
 from collections import deque
 
 # Try to import potentially missing packages
-PACKAGE_MAPPING = {
+PACKAGE_MAPPING: dict[str, str] = {
     "serial": "pyserial",
     "colorama": "colorama",
     "matplotlib": "matplotlib",
@@ -16,10 +25,10 @@ try:
     import serial
     from colorama import init, Fore, Style
     import matplotlib.pyplot as plt
-    import matplotlib.animation as animation
+    from matplotlib import animation
 except ImportError as e:
-    error_msg = str(e).lower()
-    missing_packages = [pkg for mod, pkg in PACKAGE_MAPPING.items() if mod in error_msg]
+    ERROR_MSG = str(e).lower()
+    missing_packages = [pkg for mod, pkg in PACKAGE_MAPPING.items() if mod in ERROR_MSG]
 
     if not missing_packages:
         # Fallback if mapping doesn't cover
@@ -30,8 +39,8 @@ except ImportError as e:
     print("!" * 50)
 
     print("\nTo fix this, please run the following command in your terminal:\n")
-    install_cmd = "pip install " if sys.platform.startswith("win") else "pip3 install "
-    print(f"    {install_cmd}{' '.join(missing_packages)}")
+    INSTALL_CMD = "pip install " if sys.platform.startswith("win") else "pip3 install "
+    print(f"    {INSTALL_CMD}{' '.join(missing_packages)}")
 
     print("\nExiting...")
     sys.exit(1)
@@ -39,16 +48,16 @@ except ImportError as e:
 # --- Global Variables for Data Sharing ---
 # Store last 50 data points
 MAX_POINTS = 50
-time_data = deque(maxlen=MAX_POINTS)
-free_mem_data = deque(maxlen=MAX_POINTS)
-total_mem_data = deque(maxlen=MAX_POINTS)
-data_lock = threading.Lock()  # Prevent reading while writing
+time_data: deque[str] = deque(maxlen=MAX_POINTS)
+free_mem_data: deque[float] = deque(maxlen=MAX_POINTS)
+total_mem_data: deque[float] = deque(maxlen=MAX_POINTS)
+data_lock: threading.Lock = threading.Lock()  # Prevent reading while writing
 
 # Initialize colors
 init(autoreset=True)
 
 # Color mapping for log lines
-COLOR_KEYWORDS = {
+COLOR_KEYWORDS: dict[str, list[str]] = {
     Fore.RED: ["ERROR", "[ERR]", "[SCT]", "FAILED", "WARNING"],
     Fore.CYAN: ["[MEM]", "FREE:"],
     Fore.MAGENTA: [
@@ -112,7 +121,8 @@ COLOR_KEYWORDS = {
 }
 
 
-def get_color_for_line(line):
+# pylint: disable=R0912
+def get_color_for_line(line: str) -> str:
     """
     Classify log lines by type and assign appropriate colors.
     """
@@ -123,7 +133,7 @@ def get_color_for_line(line):
     return Fore.WHITE
 
 
-def parse_memory_line(line):
+def parse_memory_line(line: str) -> tuple[int | None, int | None]:
     """
     Extracts Free and Total bytes from the specific log line.
     Format: [MEM] Free: 196344 bytes, Total: 226412 bytes, Min Free: 112620 bytes
@@ -140,21 +150,23 @@ def parse_memory_line(line):
     return None, None
 
 
-def serial_worker(port, baud, kwargs):
+def serial_worker(port: str, baud: int, kwargs: dict[str, str]) -> None:
     """
     Runs in a background thread. Handles reading serial, printing to console,
     and updating the data lists.
     """
     print(f"{Fore.CYAN}--- Opening {port} at {baud} baud ---{Style.RESET_ALL}")
-    filter = kwargs.get("filter", "").lower()
+    filter_keyword = kwargs.get("filter", "").lower()
     suppress = kwargs.get("suppress", "").lower()
-    if filter and suppress and filter == suppress:
+    if filter_keyword and suppress and filter_keyword == suppress:
         print(
-            f"{Fore.YELLOW}Warning: Filter and Suppress keywords are the same. This may result in no output.{Style.RESET_ALL}"
+            f"{Fore.YELLOW}Warning: Filter and Suppress keywords are the same. "
+            f"This may result in no output.{Style.RESET_ALL}"
         )
-    if filter:
+    if filter_keyword:
         print(
-            f"{Fore.YELLOW}Filtering lines to only show those containing: '{filter}'{Style.RESET_ALL}"
+            f"{Fore.YELLOW}Filtering lines to only show those containing: "
+            f"'{filter_keyword}'{Style.RESET_ALL}"
         )
     if suppress:
         print(
@@ -188,13 +200,13 @@ def serial_worker(port, baud, kwargs):
                 # Check for Memory Line
                 if "[MEM]" in formatted_line:
                     free_val, total_val = parse_memory_line(formatted_line)
-                    if free_val is not None:
+                    if free_val is not None and total_val is not None:
                         with data_lock:
                             time_data.append(pc_time)
                             free_mem_data.append(free_val / 1024)  # Convert to KB
                             total_mem_data.append(total_val / 1024)  # Convert to KB
                 # Apply filters
-                if filter and filter not in formatted_line.lower():
+                if filter_keyword and filter_keyword not in formatted_line.lower():
                     continue
                 if suppress and suppress in formatted_line.lower():
                     continue
@@ -202,10 +214,10 @@ def serial_worker(port, baud, kwargs):
                 line_color = get_color_for_line(formatted_line)
                 print(f"{line_color}{formatted_line}")
 
-            except OSError:
-                print(f"{Fore.RED}Device disconnected.{Style.RESET_ALL}")
+            except (OSError, UnicodeDecodeError):
+                print(f"{Fore.RED}Device disconnected or data error.{Style.RESET_ALL}")
                 break
-    except Exception:
+    except KeyboardInterrupt:
         # If thread is killed violently (e.g. main exit), silence errors
         pass
     finally:
@@ -213,13 +225,13 @@ def serial_worker(port, baud, kwargs):
             ser.close()
 
 
-def update_graph(frame):
+def update_graph(frame) -> list:  # pylint: disable=unused-argument
     """
     Called by Matplotlib animation to redraw the chart.
     """
     with data_lock:
         if not time_data:
-            return
+            return []
 
         # Convert deques to lists for plotting
         x = list(time_data)
@@ -247,17 +259,34 @@ def update_graph(frame):
     plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
 
+    return []
 
-def main():
+
+def main() -> None:
+    """
+    Main entry point for the ESP32 monitor application.
+    Sets up argument parsing, starts serial monitoring thread, and initializes the memory graph.
+    """
     parser = argparse.ArgumentParser(description="ESP32 Monitor with Graph")
     if sys.platform.startswith("win"):
         default_port = "COM8"
     elif sys.platform.startswith("darwin"):
-        default_port = "/dev/tty.usbmodem14101"
+        default_port = "/dev/cu.usbmodem101"
     else:
         default_port = "/dev/ttyACM0"
-    parser.add_argument("port", nargs="?", default=default_port, help="Serial port")
-    parser.add_argument("--baud", type=int, default=115200, help="Baud rate")
+    default_baudrate = 115200
+    parser.add_argument(
+        "port",
+        nargs="?",
+        default=default_port,
+        help=f"Serial port (default: {default_port})",
+    )
+    parser.add_argument(
+        "--baud",
+        type=int,
+        default=default_baudrate,
+        help=f"Baud rate (default: {default_baudrate})",
+    )
     parser.add_argument(
         "--filter",
         type=str,
@@ -275,22 +304,32 @@ def main():
     # 1. Start the Serial Reader in a separate thread
     # Daemon=True means this thread dies when the main program closes
     myargs = vars(args)  # Convert Namespace to dict for easier passing
-    a = {k: v for k, v in myargs.items()}  # all args
     t = threading.Thread(
-        target=serial_worker, args=(args.port, args.baud, a), daemon=True
+        target=serial_worker, args=(args.port, args.baud, myargs), daemon=True
     )
     t.start()
 
     # 2. Set up the Graph (Main Thread)
     try:
-        plt.style.use("light_background")
-    except Exception:
+        import matplotlib.style as mplstyle  # pylint: disable=import-outside-toplevel
+        default_styles = ("light_background", "ggplot", "seaborn", "dark_background", )
+        styles = list(mplstyle.available)
+        for default_style in default_styles:
+            if default_style in styles:
+                print(
+                    f"\n{Fore.CYAN}--- Using Matplotlib style: {default_style} ---{Style.RESET_ALL}"
+                )
+                mplstyle.use(default_style)
+                break
+    except (AttributeError, ValueError):
         pass
 
     fig = plt.figure(figsize=(10, 6))
 
     # Update graph every 1000ms
-    ani = animation.FuncAnimation(fig, update_graph, interval=1000)  # noqa: F841
+    _ = animation.FuncAnimation(
+        fig, update_graph, interval=1000, cache_frame_data=False
+    )
 
     try:
         print(


### PR DESCRIPTION
## Summary

* I needed the ability to filter and or suppress debug messages containig certain keywords (eg [GFX] for render related stuff)
* Update of debugging_monitor.py script for development work

## Additional Context
```
usage: debugging_monitor.py [-h] [--baud BAUD] [--filter FILTER] [--suppress SUPPRESS] [port]

ESP32 Monitor with Graph

positional arguments:
  port                 Serial port

options:
  -h, --help           show this help message and exit
  --baud BAUD          Baud rate
  --filter FILTER      Only display lines containing this keyword (case-insensitive)
  --suppress SUPPRESS  Suppress lines containing this keyword (case-insensitive)
```
* plus a couple of platform specific defaults (port, pip style)
---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? NO
