### PR TITLE
fix: Auto calculate the settings size on serialization

### DIFF
--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -6,7 +6,6 @@
 
 #include <cstring>
 #include <string>
-#include <vector>
 
 #include "fontIds.h"
 
@@ -78,6 +77,68 @@ void applyLegacyFrontButtonLayout(CrossPointSettings& settings) {
 }
 }  // namespace
 
+class SettingsWriter {
+ public:
+  bool is_counting = false;
+  uint8_t item_count = 0;
+  template <typename T>
+
+  void writeItem(FsFile& file, const T& value) {
+    if (is_counting) {
+      item_count++;
+    } else {
+      serialization::writePod(file, value);
+    }
+  }
+
+  void writeItemString(FsFile& file, const char* value) {
+    if (is_counting) {
+      item_count++;
+    } else {
+      serialization::writeString(file, std::string(value));
+    }
+  }
+};
+
+uint8_t CrossPointSettings::writeSettings(FsFile& file, bool count_only) const {
+  SettingsWriter writer;
+  writer.is_counting = count_only;
+
+  writer.writeItem(file, sleepScreen);
+  writer.writeItem(file, extraParagraphSpacing);
+  writer.writeItem(file, shortPwrBtn);
+  writer.writeItem(file, statusBar);
+  writer.writeItem(file, orientation);
+  writer.writeItem(file, frontButtonLayout);  // legacy
+  writer.writeItem(file, sideButtonLayout);
+  writer.writeItem(file, fontFamily);
+  writer.writeItem(file, fontSize);
+  writer.writeItem(file, lineSpacing);
+  writer.writeItem(file, paragraphAlignment);
+  writer.writeItem(file, sleepTimeout);
+  writer.writeItem(file, refreshFrequency);
+  writer.writeItem(file, screenMargin);
+  writer.writeItem(file, sleepScreenCoverMode);
+  writer.writeItemString(file, opdsServerUrl);
+  writer.writeItem(file, textAntiAliasing);
+  writer.writeItem(file, hideBatteryPercentage);
+  writer.writeItem(file, longPressChapterSkip);
+  writer.writeItem(file, hyphenationEnabled);
+  writer.writeItemString(file, opdsUsername);
+  writer.writeItemString(file, opdsPassword);
+  writer.writeItem(file, sleepScreenCoverFilter);
+  writer.writeItem(file, uiTheme);
+  writer.writeItem(file, frontButtonBack);
+  writer.writeItem(file, frontButtonConfirm);
+  writer.writeItem(file, frontButtonLeft);
+  writer.writeItem(file, frontButtonRight);
+  writer.writeItem(file, fadingFix);
+  writer.writeItem(file, embeddedStyle);
+  // New fields need to be added at end for backward compatibility
+
+  return writer.item_count;
+}
+
 bool CrossPointSettings::saveToFile() const {
   // Make sure the directory exists
   Storage.mkdir("/.crosspoint");
@@ -88,16 +149,12 @@ bool CrossPointSettings::saveToFile() const {
   }
 
   // First pass: count the items
-  is_counting = true;
-  item_count = 0;
-  writeSettings(outputFile);  // This will just count, not write
+  uint8_t item_count = writeSettings(outputFile, true);  // This will just count, not write
 
   // Write header
   serialization::writePod(outputFile, SETTINGS_FILE_VERSION);
   serialization::writePod(outputFile, static_cast<uint8_t>(item_count));
-
   // Second pass: actually write the settings
-  is_counting = false;
   writeSettings(outputFile);  // This will write the actual data
 
   outputFile.close();

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -175,61 +175,6 @@ class CrossPointSettings {
   // Use book's embedded CSS styles for EPUB rendering (1 = enabled, 0 = disabled)
   uint8_t embeddedStyle = 1;
 
-  // Serialization helpers
-  mutable bool is_counting = false;
-  mutable int item_count = 0;
-
-  template <typename T>
-  void writeItem(FsFile& file, const T& value) const {
-    if (is_counting) {
-      item_count++;
-    } else {
-      serialization::writePod(file, value);
-    }
-  }
-
-  void writeItemString(FsFile& file, const char* value) const {
-    if (is_counting) {
-      item_count++;
-    } else {
-      serialization::writeString(file, std::string(value));
-    }
-  }
-
-  void writeSettings(FsFile& file) const {
-    writeItem(file, sleepScreen);
-    writeItem(file, extraParagraphSpacing);
-    writeItem(file, shortPwrBtn);
-    writeItem(file, statusBar);
-    writeItem(file, orientation);
-    writeItem(file, frontButtonLayout);  // legacy
-    writeItem(file, sideButtonLayout);
-    writeItem(file, fontFamily);
-    writeItem(file, fontSize);
-    writeItem(file, lineSpacing);
-    writeItem(file, paragraphAlignment);
-    writeItem(file, sleepTimeout);
-    writeItem(file, refreshFrequency);
-    writeItem(file, screenMargin);
-    writeItem(file, sleepScreenCoverMode);
-    writeItemString(file, opdsServerUrl);
-    writeItem(file, textAntiAliasing);
-    writeItem(file, hideBatteryPercentage);
-    writeItem(file, longPressChapterSkip);
-    writeItem(file, hyphenationEnabled);
-    writeItemString(file, opdsUsername);
-    writeItemString(file, opdsPassword);
-    writeItem(file, sleepScreenCoverFilter);
-    writeItem(file, uiTheme);
-    writeItem(file, frontButtonBack);
-    writeItem(file, frontButtonConfirm);
-    writeItem(file, frontButtonLeft);
-    writeItem(file, frontButtonRight);
-    writeItem(file, fadingFix);
-    writeItem(file, embeddedStyle);
-    // New fields need to be added at end for backward compatibility
-  }
-
   ~CrossPointSettings() = default;
 
   // Get singleton instance
@@ -239,6 +184,9 @@ class CrossPointSettings {
     return (shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP) ? 10 : 400;
   }
   int getReaderFontId() const;
+
+  // If count_only is true, returns the number of settings items that would be written.
+  uint8_t writeSettings(FsFile& file, bool count_only = false) const;
 
   bool saveToFile() const;
   bool loadFromFile();


### PR DESCRIPTION
## Summary

* The constant SETTINGS_CONST was hardcoded and needed to be updated whenever an additional setting was added
* This is no longer necessary as the settings size will be determined automatically on settings persistence

## Additional Context

* New settings need to be added (as previously) in saveToFile - that's it

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? YES
