### PR TITLE
fix: Correct multiple author display

### DIFF
--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -334,6 +334,9 @@ void XMLCALL ContentOpfParser::characterData(void* userData, const XML_Char* s, 
   }
 
   if (self->state == IN_BOOK_AUTHOR) {
+    if (!self->author.empty()) {
+      self->author.append(", ");  // Add separator for multiple authors
+    }
     self->author.append(s, len);
     return;
   }


### PR DESCRIPTION
## Summary

* If an EPUB has:
```
<dc:creator>J.R.R. Tolkien</dc:creator>
<dc:creator>Christopher Tolkien</dc:creator>
```
the current result for epub.author would provide : "J.R.R. TolkienChristopher Tolkien" (no separator!)
* The fix will seperate multiple authors: "J.R.R. Tolkien, Christopher Tolkien"

## Additional Context

* Simple fix in ContentOpfParser - I am not seeing any dependence on the wrong concatenated result.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? NO
