### PR TITLE
fix: URL-decode filenames in file browser and HTTP uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ lib/EpdFont/fontsrc
 .vs
 build
 **/__pycache__/
+.venv
 /compile_commands.json
 /.cache

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -242,7 +242,7 @@ void MyLibraryActivity::render() const {
   } else {
     GUI.drawList(
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, files.size(), selectorIndex,
-        [this](int index) { return files[index]; }, nullptr, nullptr, nullptr);
+        [this](int index) { return StringUtils::urlDecode(files[index]); }, nullptr, nullptr, nullptr);
   }
 
   // Help text

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -542,7 +542,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
     // Reset watchdog - this is the critical 1% crash point
     esp_task_wdt_reset();
 
-    state.fileName = upload.filename;
+    state.fileName = StringUtils::urlDecode(std::string(upload.filename.c_str())).c_str();
     state.size = 0;
     state.success = false;
     state.error = "";

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -61,4 +61,28 @@ bool checkFileExtension(const String& fileName, const char* extension) {
   return localFile.endsWith(localExtension);
 }
 
+std::string urlDecode(const std::string& encoded) {
+  std::string decoded;
+  decoded.reserve(encoded.size());
+  for (size_t i = 0; i < encoded.size(); i++) {
+    if (encoded[i] == '%' && i + 2 < encoded.size()) {
+      auto hexVal = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        return -1;
+      };
+      int hi = hexVal(encoded[i + 1]);
+      int lo = hexVal(encoded[i + 2]);
+      if (hi >= 0 && lo >= 0) {
+        decoded += static_cast<char>((hi << 4) | lo);
+        i += 2;
+        continue;
+      }
+    }
+    decoded += (encoded[i] == '+') ? ' ' : encoded[i];
+  }
+  return decoded;
+}
+
 }  // namespace StringUtils

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -19,4 +19,10 @@ std::string sanitizeFilename(const std::string& name, size_t maxLength = 100);
 bool checkFileExtension(const std::string& fileName, const char* extension);
 bool checkFileExtension(const String& fileName, const char* extension);
 
+/**
+ * Decode a URL/percent-encoded string (e.g., "My%20Book" -> "My Book").
+ * Handles %XX hex sequences and '+' as space.
+ */
+std::string urlDecode(const std::string& encoded);
+
 }  // namespace StringUtils


### PR DESCRIPTION
## Summary

- Files uploaded via the web interface's HTTP multipart upload path are saved to the SD card with URL-encoded names (e.g., `My%20Book%20%E2%80%94%20Title.epub` instead of `My Book — Title.epub`), because the ESP32 WebServer library does not decode the `Content-Disposition` filename header
- This PR adds a `urlDecode()` utility to `StringUtils` and applies it in two places:
  1. **File browser display** — filenames are URL-decoded for display only (the raw filename is preserved for filesystem access)
  2. **HTTP upload** — filenames are URL-decoded at upload time so new uploads are saved with clean names on the SD card

## Changes

- **`src/util/StringUtils.h` / `.cpp`** — Add `StringUtils::urlDecode()` that decodes `%XX` hex sequences and `+` as space
- **`src/activities/home/MyLibraryActivity.cpp`** — URL-decode filenames in the `render()` display lambda (display-only, does not affect file access)
- **`src/network/CrossPointWebServer.cpp`** — URL-decode `upload.filename` in `handleUpload()` so new files are saved with clean names
- **`.gitignore`** — Add `.venv` (Python virtual environment used for debugging scripts)

## AI Usage
While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? yes, claude
Previous:
[screenshot_without_decoding.bmp](https://github.com/user-attachments/files/25301016/screenshot_without_decoding.bmp)

After:
[screenshot_with_decoding.bmp](https://github.com/user-attachments/files/25301019/screenshot_with_decoding.bmp)

