### PR TITLE
fix: Removed white boxes extending passed the bounds of the empty button icon when hint text is blank/null

### DIFF
--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -203,16 +203,18 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   const char* labels[] = {btn1, btn2, btn3, btn4};
 
   for (int i = 0; i < 4; i++) {
-    // Only draw if the label is non-empty
     const int x = buttonPositions[i];
-    renderer.fillRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, false);
     if (labels[i] != nullptr && labels[i][0] != '\0') {
+      // Draw the filled background and border for a FULL-sized button
+      renderer.fillRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, false);
       renderer.drawRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, 1, cornerRadius, true, true, false,
                                false, true);
       const int textWidth = renderer.getTextWidth(SMALL_FONT_ID, labels[i]);
       const int textX = x + (buttonWidth - 1 - textWidth) / 2;
       renderer.drawText(SMALL_FONT_ID, textX, pageHeight - buttonY + textYOffset, labels[i]);
     } else {
+      // Draw the filled background and border for a SMALL-sized button
+      renderer.fillRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, false);
       renderer.drawRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, 1, cornerRadius, true,
                                true, false, false, true);
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)

Empty Button Icons (I.E. Back button in the home menu) were still rendering the full sized white rectangles going passed the boarders of the little button nub. This was not visible on the home screen due to the white background, but it does cause issues if we ever want to have bmp files displayed while buttons are visible or implement a dark mode. 

* **What changes are included?**

Made it so that when a button hint text is empty string or null the displayed mini button nub does not have a white rectangle extending passed the bounds of the mini button nub

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

Having that extended rectangle was likely never noticed due to the only space where that feature is used being the main menu where the background is completely white. I am working on some new features that would have an image displayed while there are button hints and noticed this issue while implementing that. 

One other note is that this only affects the Lyra Theme

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
