### PR TITLE
perf: Optimize hyphenation with stack-allocated scores

### DIFF
--- a/lib/Epub/Epub/hyphenation/LiangHyphenation.cpp
+++ b/lib/Epub/Epub/hyphenation/LiangHyphenation.cpp
@@ -300,9 +300,8 @@ bool transition(const EmbeddedAutomaton& automaton, const AutomatonState& state,
   return false;
 }
 
-// Converts odd score positions back into codepoint indexes, honoring min prefix/suffix constraints.
+// Converts odd-valued score entries into codepoint break (hyphen) indexes while honoring min prefix/suffix constraints.
 // Each break corresponds to scores[breakIndex + 1] because of the leading '.' sentinel.
-// Convert odd score entries into hyphen positions while honoring prefix/suffix limits.
 // Template version that works with both stack arrays and heap vectors.
 template <typename ScoreContainer>
 std::vector<size_t> collectBreakIndexesImpl(const std::vector<CodepointInfo>& cps, const ScoreContainer& scores,


### PR DESCRIPTION
## Summary

* Use stack allocation for words ≤64 chars (99% of cases)

## Additional Context
* Reduces heap allocations from 4→3 per word
* Falls back to heap for exceptionally long words (>64 chars)
* Benchmark: 1.78x faster (stack vs heap), zero memory leaks
* Cost: +550 bytes Flash
* 
---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _YES_ validated in some benchmarks and tests
