### PR TITLE
fix: added cover image outlines to improve legibility

### DIFF
--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -275,8 +275,8 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
            i++) {
         std::string coverPath = recentBooks[i].coverBmpPath;
         int tileX = LyraMetrics::values.contentSidePadding + tileWidth * i;
-        renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection,
-                              tileWidth - 2 * hPaddingInSelection, LyraMetrics::values.homeCoverHeight);
+        renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection, tileWidth - 2 * hPaddingInSelection,
+                          LyraMetrics::values.homeCoverHeight);
         if (!coverPath.empty()) {
           const std::string coverBmpPath = UITheme::getCoverThumbPath(coverPath, LyraMetrics::values.homeCoverHeight);
 
@@ -293,7 +293,7 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
               float cropX = 1.0f - (tileRatio / ratio);
               renderer.drawBitmap(bitmap, tileX + hPaddingInSelection, tileY + hPaddingInSelection,
                                   tileWidth - 2 * hPaddingInSelection, LyraMetrics::values.homeCoverHeight, cropX);
-            } 
+            }
             file.close();
           }
         }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)

Improve legibility of Cover Icons on the home page and elsewhere. Fixes #898 

* **What changes are included?**
Cover outline is now shown even when cover is found to prevent issues with low contrast covers blending into the background. Photo is attached below:

<img width="404" height="510" alt="Group 1 (4)" src="https://github.com/user-attachments/assets/9d794b51-554b-486d-8520-6ef920548b9a" />


## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

Not much else to say here. I did simplify the logic in lyratheme.cpp based on there no longer being a requirement for any non-cover specific rendering differences.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
