### PR TITLE
feat: Add ability to wrap text to UI elements

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -679,78 +679,58 @@ std::string GfxRenderer::truncatedText(const int fontId, const char* text, const
   return item.empty() ? ellipsis : item + ellipsis;
 }
 
-std::vector<std::string> GfxRenderer::wrappedText(
-    const int fontId,
-    const char* text,
-    const int maxWidth,
-    const int maxLines,
-    const EpdFontFamily::Style style) const
-{
-    std::vector<std::string> lines;
+std::vector<std::string> GfxRenderer::wrappedText(const int fontId, const char* text, const int maxWidth,
+                                                  const int maxLines, const EpdFontFamily::Style style) const {
+  std::vector<std::string> lines;
 
-    if (!text || maxWidth <= 0 || maxLines <= 0)
-        return lines;
+  if (!text || maxWidth <= 0 || maxLines <= 0) return lines;
 
-    std::string remaining = text;
-    std::string currentLine;
+  std::string remaining = text;
+  std::string currentLine;
 
-    while (!remaining.empty())
-    {
-        if ((int)lines.size() == maxLines - 1)
-        {
-            std::string lastLine = truncatedText(fontId, remaining.c_str(), maxWidth, style);
-            lines.push_back(lastLine);
-            return lines;
-        }
-
-        // Find next word
-        size_t spacePos = remaining.find(' ');
-        std::string word;
-
-        if (spacePos == std::string::npos)
-        {
-            word = remaining;
-            remaining.clear();
-        }
-        else
-        {
-            word = remaining.substr(0, spacePos);
-            remaining.erase(0, spacePos + 1);
-        }
-
-        std::string testLine = currentLine.empty()
-            ? word
-            : currentLine + " " + word;
-
-        if (getTextWidth(fontId, testLine.c_str(), style) <= maxWidth)
-        {
-            currentLine = testLine;
-        }
-        else
-        {
-            if (!currentLine.empty())
-            {
-                lines.push_back(currentLine);
-                currentLine = word;
-            }
-            else
-            {
-                // If a single word longer than maxWidth, we will truncate it and return
-                // this is to avoid complicated splitting rules since they are different 
-                // between languages. This results in an aesthetically pleasing end.
-                std::string truncated = truncatedText(fontId, word.c_str(), maxWidth, style);
-                lines.push_back(truncated);
-                return lines;
-            }
-        }
+  while (!remaining.empty()) {
+    if ((int)lines.size() == maxLines - 1) {
+      std::string lastLine = truncatedText(fontId, remaining.c_str(), maxWidth, style);
+      lines.push_back(lastLine);
+      return lines;
     }
 
-    if (!currentLine.empty() && (int)lines.size() < maxLines)
-    {
+    // Find next word
+    size_t spacePos = remaining.find(' ');
+    std::string word;
+
+    if (spacePos == std::string::npos) {
+      word = remaining;
+      remaining.clear();
+    } else {
+      word = remaining.substr(0, spacePos);
+      remaining.erase(0, spacePos + 1);
+    }
+
+    std::string testLine = currentLine.empty() ? word : currentLine + " " + word;
+
+    if (getTextWidth(fontId, testLine.c_str(), style) <= maxWidth) {
+      currentLine = testLine;
+    } else {
+      if (!currentLine.empty()) {
         lines.push_back(currentLine);
+        currentLine = word;
+      } else {
+        // If a single word longer than maxWidth, we will truncate it and return
+        // this is to avoid complicated splitting rules since they are different
+        // between languages. This results in an aesthetically pleasing end.
+        std::string truncated = truncatedText(fontId, word.c_str(), maxWidth, style);
+        lines.push_back(truncated);
+        return lines;
+      }
     }
+  }
 
-    return lines;
+  if (!currentLine.empty() && (int)lines.size() < maxLines) {
+    lines.push_back(currentLine);
+  }
+
+  return lines;
 }
 
 // Note: Internal driver treats screen in command orientation; this library exposes a logical orientation

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -111,7 +111,7 @@ class GfxRenderer {
                             EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
 
   std::vector<std::string> wrappedText(int fontId, const char* text, int maxWidth, int maxLines,
-                            EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+                                       EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
 
   // Helper for drawing rotated text (90 degrees clockwise, for side buttons)
   void drawTextRotated90CW(int fontId, int x, int y, const char* text, bool black = true,


### PR DESCRIPTION

## Summary
New function "wrappedText" added to the GfxRenderer

Similarly to how truncatedText it will take a text string and a width and return a truncated string, this function will wrap the text into a vector of strings. A maximum number of lines is specified, and the rest of the text (if any) is truncated using truncatedText

The function only wraps on spaces, as rules for how words are split varies by language.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

This was requested by CaptainFrito in [732](https://github.com/crosspoint-reader/crosspoint-reader/pull/732#issuecomment-3883078980).

As part of the lyra theme.
Before:
![before](https://github.com/user-attachments/assets/1f75884b-7323-4e47-a4b4-d0047987744e)

After:
![after](https://github.com/user-attachments/assets/73c11d78-e413-4b8f-a1b8-10bd7cccab3b)

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? Used chatgpt to validate that std::vector<std::string> was an appropriate return type
