### PR TITLE
fix: Fixed formatting of paragraph under a list item

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -388,14 +388,21 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         self->flushPartWordBuffer();
       }
       self->startNewTextBlock(self->currentTextBlock->getBlockStyle());
+    } else if (strcmp(name, "li") == 0) {
+      self->currentCssStyle = cssStyle;
+      self->startNewTextBlock(userAlignmentBlockStyle);
+      self->updateEffectiveInlineStyle();
+      self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+      self->listItemUntilDepth = std::min(self->listItemUntilDepth, self->depth);
+    } else if (strcmp(name, "p") == 0 && self->listItemUntilDepth < self->depth) {
+      // Inside a <li> element - don't start a new text block for <p>
+      // This prevents bullet points from appearing on their own line
+      self->currentCssStyle = cssStyle;
+      self->updateEffectiveInlineStyle();
     } else {
       self->currentCssStyle = cssStyle;
       self->startNewTextBlock(userAlignmentBlockStyle);
       self->updateEffectiveInlineStyle();
-
-      if (strcmp(name, "li") == 0) {
-        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
-      }
     }
   } else if (matches(name, UNDERLINE_TAGS, NUM_UNDERLINE_TAGS)) {
     // Flush buffer before style change so preceding text gets current style
@@ -669,6 +676,11 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   // Leaving underline tag
   if (self->underlineUntilDepth == self->depth) {
     self->underlineUntilDepth = INT_MAX;
+  }
+
+  // Leaving list item
+  if (self->listItemUntilDepth == self->depth) {
+    self->listItemUntilDepth = INT_MAX;
   }
 
   // Pop from inline style stack if we pushed an entry at this depth

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -29,6 +29,7 @@ class ChapterHtmlSlimParser {
   int boldUntilDepth = INT_MAX;
   int italicUntilDepth = INT_MAX;
   int underlineUntilDepth = INT_MAX;
+  int listItemUntilDepth = INT_MAX;
   // buffer for building up words from characters, will auto break if longer than this
   // leave one char at end for null pointer
   char partWordBuffer[MAX_WORD_SIZE + 1] = {};


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**
* Fixing the layout of paragraphs inside list items (Issue #956)

**What changes are included?**
* Using the existing `elemUntilDepth` pattern, adds a state for when a paragraph is is a list item
* When in a paragraph inside a list item, skip creating a new text block

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
