### PR TITLE
fix: go to prev page on the first one, get teleported to the end of book

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -241,7 +241,7 @@ void EpubReaderActivity::loop() {
   if (prevTriggered) {
     if (section->currentPage > 0) {
       section->currentPage--;
-    } else {
+    } else if (currentSpineIndex > 0) {
       // We don't want to delete the section mid-render, so grab the semaphore
       {
         RenderLock lock(*this);


### PR DESCRIPTION
## Summary

1. Go to the first page in a .epub file.
2. Hit `Up` button
3. Get teleported to the last page :)

`TxtRenderActivity` seems to have this if check, but EPUB one does not.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
