### PR TITLE
fix: Fix dangling pointer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,9 +216,9 @@ void onGoHome();
 void onGoToMyLibraryWithPath(const std::string& path);
 void onGoToRecentBooks();
 void onGoToReader(const std::string& initialEpubPath) {
+  const std::string bookPath = initialEpubPath;  // Copy before exitActivity() invalidates the reference
   exitActivity();
-  enterNewActivity(
-      new ReaderActivity(renderer, mappedInputManager, initialEpubPath, onGoHome, onGoToMyLibraryWithPath));
+  enterNewActivity(new ReaderActivity(renderer, mappedInputManager, bookPath, onGoHome, onGoToMyLibraryWithPath));
 }
 
 void onGoToFileTransfer() {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Small fix for bug I found.

## Additional Context


  1. `RecentBooksActivity::loop()` calls `onSelectBook(recentBooks[selectorIndex].path)` - passing a **reference** to the path
  2. `onSelectBook` is `onGoToReader` which first calls `exitActivity()`
  3. `exitActivity()` triggers `RecentBooksActivity::onExit()` which call `recentBooks.clear()`
  4. The string reference `initialEpubPath` is now a **dangling reference** - the underlying string has been destroyed
  5. When the reference is then used in `new ReaderActivity(...)`, it reads garbage memory
  6. The same issue occurs in `HomeActivity` at line 200 with the same pattern

  The fix is to make a copy of the string in `onGoToReader` before calling `exitActivity()`, so the path data persists even after the activity clears its data structures.

---

### AI Usage

Did you use AI tools to help write this code? _**< YES >**_ Claude found the bug, after I shared with it a serial log.
