### PR TITLE
fix: Strip unused CSS rules

### DIFF
--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -367,6 +367,24 @@ void CssParser::processRuleBlockWithStyle(const std::string& selectorGroup, cons
       continue;
     }
 
+    // TODO: Consider adding support for ID css selectors in the future
+    // Ensure no # in selector as we don't support ID CSS selectors for now
+    if (key.find('#') != std::string_view::npos) {
+      continue;
+    }
+
+    // TODO: Consider adding support for general sibling combinator selectors in the future
+    // Ensure no ~ in selector as we don't support general sibling combinator CSS selectors for now
+    if (key.find('~') != std::string_view::npos) {
+      continue;
+    }
+
+    // TODO: Consider adding support for wildcard css selectors in the future
+    // Ensure no * in selector as we don't support wildcard CSS selectors for now
+    if (key.find('*') != std::string_view::npos) {
+      continue;
+    }
+
     // TODO: Add support for more complex selectors in the future
     // At the moment, we only ever check for `tag`, `tag.class1` or `.class1`
     // If the selector has whitespace in it, then it's either a CSS selector for a descendant element (e.g. `tag1 tag2`)


### PR DESCRIPTION
## Summary

* In a sample book I loaded, it had 900+ CSS rules, and took up 180kB of memory loading the cache in
  * Looking at the rules, a lot of them were completely useless as we only ever apply look for 3 kinds of CSS rules:
    * `tag`
    * `tag.class1`
    * `.class1`
* Stripping out CSS rules with descendant, nested, attribute matching, sibling matching, pseudo element selection (as we never actually read these from the cache) reduced the rule count down to 200

## Additional Context

* I've left in `.class1.class2` rules for now, even though we technically can never match on them as they're likely to be addressed soonest out of the all the CSS expansion
* Because we don't ever delete the CSS cache, users will need to delete the book cache through the menu in order to get this new logic
  * A new PR should be done up to address this - tracked here https://github.com/crosspoint-reader/crosspoint-reader/issues/1015

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? No
