### PR TITLE
fix: re-implementing Cover Outlines for the new Lyra Themes

### DIFF
--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -65,8 +65,8 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
           }
         }
         // Draw either way
-        renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection,
-                            tileWidth - 2 * hPaddingInSelection, Lyra3CoversMetrics::values.homeCoverHeight, true);
+        renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection, tileWidth - 2 * hPaddingInSelection,
+                          Lyra3CoversMetrics::values.homeCoverHeight, true);
 
         if (!hasCover) {
           // Render empty cover

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -449,8 +449,8 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
       }
 
       // Draw either way
-      renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection, coverWidth, 
-      LyraMetrics::values.homeCoverHeight, true);
+      renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection, coverWidth,
+                        LyraMetrics::values.homeCoverHeight, true);
 
       if (!hasCover) {
         // Render empty cover


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)

Improve legibility of Cover Icons on the home page and elsewhere. Fixes #898 
Re implements the changes made in #907 that were overwritten by the new lyra themes

* **What changes are included?**
Cover outline is now shown even when cover is found to prevent issues with low contrast covers blending into the background. Photo is attached below:

<img width="1137" height="758" alt="Untitled (4)" src="https://github.com/user-attachments/assets/21ae6c94-4b43-4a0c-bec7-a6e4c642ffad" />



## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

Re implements the changes made in #907 that were overwritten by the new lyra themes

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**Yes**_
