### PR TITLE
fix: Destroy CSS Cache file when invalid

### DIFF
--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -640,6 +640,10 @@ constexpr char rulesCache[] = "/css_rules.cache";
 
 bool CssParser::hasCache() const { return Storage.exists((cachePath + rulesCache).c_str()); }
 
+void CssParser::deleteCache() const {
+  if (hasCache()) Storage.remove((cachePath + rulesCache).c_str());
+}
+
 bool CssParser::saveToCache() const {
   if (cachePath.empty()) {
     return false;

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -86,6 +86,11 @@ class CssParser {
   bool hasCache() const;
 
   /**
+   * Delete CSS rules cache file exists
+   */
+  void deleteCache() const;
+
+  /**
    * Save parsed CSS rules to a cache file.
    * @return true if cache was written successfully
    */


### PR DESCRIPTION
## Summary

* Destroy CSS Cache file when invalid

## Additional Context

* Fixes issue where it would attempt to rebuild every book open

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? No
