### PR TITLE
fix: Consider extra quotation styles when hyphenating quoted words

### DIFF
--- a/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp
+++ b/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp
@@ -86,6 +86,7 @@ bool isPunctuation(const uint32_t cp) {
     case 0x00BB:  // »
     case 0x2018:  // ‘
     case 0x2019:  // ’
+    case 0x201A:  // ‚
     case 0x201C:  // “
     case 0x201D:  // ”
     case 0x201E:  // „
@@ -95,6 +96,7 @@ bool isPunctuation(const uint32_t cp) {
     case '[':
     case ']':
     case '/':
+    case 0x2039:  // ‹
     case 0x203A:  // ›
     case 0x2026:  // …
       return true;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Address expected hyphenation issue from https://github.com/crosspoint-reader/crosspoint-reader/issues/998#issuecomment-3940533510
* Closes #998 
* **What changes are included?** Add `„` (U+201E, _Double Low-9 Quotation Mark_), `‚` (U+201A, _Single Low-9 Quotation Mark_) and `‹` (U+2039, _Single Left-pointing Angle Quotation Mark_) exceptions, other quote types were handled correctly.

**Before**
<img width="480" height="155" alt="hyph3" src="https://github.com/user-attachments/assets/e06b4071-2c8c-4814-965d-96fbe302a450" />
**After**
<img width="480" height="154" alt="hyph3-fix" src="https://github.com/user-attachments/assets/4f7f5406-e200-451c-8bee-3f410cc84bbe" />


## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
