### PR TITLE
fix: Koreadersync - stop sntp on exit

### DIFF
--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <GfxRenderer.h>
 #include <I18n.h>
+#include <InflateReader.h>
 #include <Logging.h>
 #include <WiFi.h>
 #include <esp_sntp.h>
@@ -238,6 +239,9 @@ void KOReaderSyncActivity::onExit() {
   delay(100);
   WiFi.mode(WIFI_OFF);
   delay(100);
+
+  // Reclaim inflate ring buffer immediately while heap is freshly defragmented
+  InflateReader::claimSharedBuffer();
 }
 
 void KOReaderSyncActivity::render(Activity::RenderLock&&) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** The sntp routine wasn't properly terminated -> added explicit close on exit

## Additional Context

---

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
