### PR TITLE
feat: remember selected menu item when returning to Home

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -114,10 +114,19 @@ void HomeActivity::onEnter() {
   // Check if OPDS browser URL is configured
   hasOpdsUrl = strlen(SETTINGS.opdsServerUrl) > 0;
 
-  selectorIndex = 0;
-
   auto metrics = UITheme::getInstance().getMetrics();
   loadRecentBooks(metrics.homeRecentBooksCount);
+
+  // Resolve initialMenuItem to selectorIndex
+  int base = recentBooks.size();
+  switch (initialMenuItem) {
+    case HomeMenuItem::MY_LIBRARY:    selectorIndex = base; break;
+    case HomeMenuItem::RECENTS:       selectorIndex = base + 1; break;
+    case HomeMenuItem::OPDS_BROWSER:  selectorIndex = hasOpdsUrl ? base + 2 : 0; break;
+    case HomeMenuItem::FILE_TRANSFER: selectorIndex = base + (hasOpdsUrl ? 3 : 2); break;
+    case HomeMenuItem::SETTINGS_MENU:  selectorIndex = base + (hasOpdsUrl ? 4 : 3); break;
+    default: selectorIndex = 0; break;
+  }
 
   // Trigger first update
   requestUpdate();

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -9,6 +9,8 @@
 struct RecentBook;
 struct Rect;
 
+enum class HomeMenuItem { NONE, MY_LIBRARY, RECENTS, OPDS_BROWSER, FILE_TRANSFER, SETTINGS_MENU };
+
 class HomeActivity final : public Activity {
   ButtonNavigator buttonNavigator;
   int selectorIndex = 0;
@@ -26,6 +28,7 @@ class HomeActivity final : public Activity {
   const std::function<void()> onSettingsOpen;
   const std::function<void()> onFileTransferOpen;
   const std::function<void()> onOpdsBrowserOpen;
+  const HomeMenuItem initialMenuItem;
 
   int getMenuItemCount() const;
   bool storeCoverBuffer();    // Store frame buffer for cover image
@@ -39,14 +42,16 @@ class HomeActivity final : public Activity {
                         const std::function<void(const std::string& path)>& onSelectBook,
                         const std::function<void()>& onMyLibraryOpen, const std::function<void()>& onRecentsOpen,
                         const std::function<void()>& onSettingsOpen, const std::function<void()>& onFileTransferOpen,
-                        const std::function<void()>& onOpdsBrowserOpen)
+                        const std::function<void()>& onOpdsBrowserOpen,
+                        HomeMenuItem initialMenuItem = HomeMenuItem::NONE)
       : Activity("Home", renderer, mappedInput),
         onSelectBook(onSelectBook),
         onMyLibraryOpen(onMyLibraryOpen),
         onRecentsOpen(onRecentsOpen),
         onSettingsOpen(onSettingsOpen),
         onFileTransferOpen(onFileTransferOpen),
-        onOpdsBrowserOpen(onOpdsBrowserOpen) {}
+        onOpdsBrowserOpen(onOpdsBrowserOpen),
+        initialMenuItem(initialMenuItem) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,49 +212,55 @@ void enterDeepSleep() {
   powerManager.startDeepSleep(gpio);
 }
 
-void onGoHome();
+void onGoHome(HomeMenuItem item = HomeMenuItem::NONE);
 void onGoToMyLibraryWithPath(const std::string& path);
 void onGoToRecentBooks();
 void onGoToReader(const std::string& initialEpubPath) {
   const std::string bookPath = initialEpubPath;  // Copy before exitActivity() invalidates the reference
   exitActivity();
-  enterNewActivity(new ReaderActivity(renderer, mappedInputManager, bookPath, onGoHome, onGoToMyLibraryWithPath));
+  enterNewActivity(new ReaderActivity(renderer, mappedInputManager, bookPath, [] { onGoHome(); }, onGoToMyLibraryWithPath));
 }
 
 void onGoToFileTransfer() {
   exitActivity();
-  enterNewActivity(new CrossPointWebServerActivity(renderer, mappedInputManager, onGoHome));
+  enterNewActivity(new CrossPointWebServerActivity(renderer, mappedInputManager,
+                                                   [] { onGoHome(HomeMenuItem::FILE_TRANSFER); }));
 }
 
 void onGoToSettings() {
   exitActivity();
-  enterNewActivity(new SettingsActivity(renderer, mappedInputManager, onGoHome));
+  enterNewActivity(new SettingsActivity(renderer, mappedInputManager,
+                                        [] { onGoHome(HomeMenuItem::SETTINGS_MENU); }));
 }
 
 void onGoToMyLibrary() {
   exitActivity();
-  enterNewActivity(new MyLibraryActivity(renderer, mappedInputManager, onGoHome, onGoToReader));
+  enterNewActivity(new MyLibraryActivity(renderer, mappedInputManager,
+                                         [] { onGoHome(HomeMenuItem::MY_LIBRARY); }, onGoToReader));
 }
 
 void onGoToRecentBooks() {
   exitActivity();
-  enterNewActivity(new RecentBooksActivity(renderer, mappedInputManager, onGoHome, onGoToReader));
+  enterNewActivity(new RecentBooksActivity(renderer, mappedInputManager,
+                                           [] { onGoHome(HomeMenuItem::RECENTS); }, onGoToReader));
 }
 
 void onGoToMyLibraryWithPath(const std::string& path) {
   exitActivity();
-  enterNewActivity(new MyLibraryActivity(renderer, mappedInputManager, onGoHome, onGoToReader, path));
+  enterNewActivity(new MyLibraryActivity(renderer, mappedInputManager,
+                                         [] { onGoHome(HomeMenuItem::MY_LIBRARY); }, onGoToReader, path));
 }
 
 void onGoToBrowser() {
   exitActivity();
-  enterNewActivity(new OpdsBookBrowserActivity(renderer, mappedInputManager, onGoHome));
+  enterNewActivity(new OpdsBookBrowserActivity(renderer, mappedInputManager,
+                                               [] { onGoHome(HomeMenuItem::OPDS_BROWSER); }));
 }
 
-void onGoHome() {
+void onGoHome(HomeMenuItem item) {
   exitActivity();
   enterNewActivity(new HomeActivity(renderer, mappedInputManager, onGoToReader, onGoToMyLibrary, onGoToRecentBooks,
-                                    onGoToSettings, onGoToFileTransfer, onGoToBrowser));
+                                    onGoToSettings, onGoToFileTransfer, onGoToBrowser, item));
 }
 
 void setupDisplayAndFonts() {


### PR DESCRIPTION
## Summary

When navigating back to Home always reset the cursor to the top. Now each activity passes its corresponding HomeMenuItem enum value so the cursor returns to the item the user navigated from.