### PR TITLE
feat: set WiFi hostname to CrossPoint-Reader-XXXXXXXXXXXX

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -219,6 +219,12 @@ void WifiSelectionActivity::attemptConnection() {
 
   WiFi.mode(WIFI_STA);
 
+  // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
+  String mac = WiFi.macAddress();
+  mac.replace(":", "");
+  String hostname = "CrossPoint-Reader-" + mac;
+  WiFi.setHostname(hostname.c_str());
+
   if (selectedRequiresPassword && !enteredPassword.empty()) {
     WiFi.begin(selectedSSID.c_str(), enteredPassword.c_str());
   } else {


### PR DESCRIPTION
## Summary

Replace the default esp32-XXXXXXXXXXXX hostname with CrossPoint-Reader-AABBCCDDEEFF (full MAC address) so the device is easily identifiable on the router's client list.