### PR TITLE
fix: acquire power lock before sleeping

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,6 +200,7 @@ void waitForPowerRelease() {
 
 // Enter deep sleep mode
 void enterDeepSleep() {
+  HalPowerManager::Lock powerLock;  // Ensure we are at normal CPU frequency for sleep preparation
   APP_STATE.lastSleepFromReader = currentActivity && currentActivity->isReaderActivity();
   APP_STATE.saveToFile();
   exitActivity();


### PR DESCRIPTION
## Summary

Ref: https://github.com/crosspoint-reader/crosspoint-reader/issues/1110

Power lock is automatically acquired on `render()`. However, instead of using `render()`, sleep activity render everything right inside `onEnter()`, so no power lock was acquired.

After https://github.com/crosspoint-reader/crosspoint-reader/pull/1016 , the power lock will also be acquired on activity transition.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **NO**
