### PR TITLE
chore: add firmware size history script

### DIFF
--- a/scripts/firmware_size_history.py
+++ b/scripts/firmware_size_history.py
@@ -36,6 +36,7 @@ import sys
 FLASH_RE = re.compile(
     r"Flash:.*?(\d+)\s+bytes\s+from\s+(\d+)\s+bytes"
 )
+BOX_CHAR = "\u2500"
 
 
 def run(cmd, capture=True, check=True):
@@ -130,10 +131,10 @@ def format_table(rows):
         f"Title"
     )
     sep = (
-        f"{'\u2500' * COL_COMMIT}  "
-        f"{'\u2500' * COL_FLASH}  "
-        f"{'\u2500' * COL_DELTA}  "
-        f"{'\u2500' * 40}"
+        f"{BOX_CHAR * COL_COMMIT}  "
+        f"{BOX_CHAR * COL_FLASH}  "
+        f"{BOX_CHAR * COL_DELTA}  "
+        f"{BOX_CHAR * 40}"
     )
     print(header)
     print(sep)


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

- Adds `scripts/firmware_size_history.py`, a developer tool that builds firmware at selected git commits and reports flash usage with deltas between them.
- Supports two input modes: `--range START END` to walk every commit in a range, or `--commits REF [REF ...]` to compare specific refs (which can span branches).
- Defaults to a human-readable aligned table; pass `--csv` for machine-readable output to stdout or `--csv FILE` to write to a file.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES, fully written by AI**_
