### PR TITLE
chore: remove rendundant xTaskCreate

### DIFF
--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -204,25 +204,7 @@ void KOReaderSyncActivity::onEnter() {
   // Check if already connected (e.g. from settings page auth)
   if (WiFi.status() == WL_CONNECTED) {
     LOG_DBG("KOSync", "Already connected to WiFi");
-    state = SYNCING;
-    statusMessage = tr(STR_SYNCING_TIME);
-    requestUpdate(true);
-
-    // Perform sync directly (will be handled in loop)
-    xTaskCreate(
-        [](void* param) {
-          auto* self = static_cast<KOReaderSyncActivity*>(param);
-          // Sync time first
-          syncTimeWithNTP();
-          {
-            RenderLock lock(*self);
-            self->statusMessage = tr(STR_CALC_HASH);
-          }
-          self->requestUpdate(true);
-          self->performSync();
-          vTaskDelete(nullptr);
-        },
-        "SyncTask", 4096, this, 1, nullptr);
+    onWifiSelectionComplete(true);
     return;
   }
 

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -51,23 +51,9 @@ void KOReaderAuthActivity::performAuthentication() {
 void KOReaderAuthActivity::onEnter() {
   Activity::onEnter();
 
-  // Turn on WiFi
-  WiFi.mode(WIFI_STA);
-
   // Check if already connected
   if (WiFi.status() == WL_CONNECTED) {
-    state = AUTHENTICATING;
-    statusMessage = tr(STR_AUTHENTICATING);
-    requestUpdate();
-
-    // Perform authentication in a separate task
-    xTaskCreate(
-        [](void* param) {
-          auto* self = static_cast<KOReaderAuthActivity*>(param);
-          self->performAuthentication();
-          vTaskDelete(nullptr);
-        },
-        "AuthTask", 4096, this, 1, nullptr);
+    onWifiSelectionComplete(true);
     return;
   }
 


### PR DESCRIPTION
## Summary

Ref discussion: https://github.com/crosspoint-reader/crosspoint-reader/pull/1222#discussion_r2865402110

Important note that this is a bug-for-bug fix. In reality, this branch `WiFi.status() == WL_CONNECTED` is pretty much a dead code because the entry point of these 2 activities don't use wifi.

It is better to refactor the management of network though, but it's better to be a dedicated PR.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **NO**
