### PR TITLE
feat: add logs filter by language code for i18n script

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -226,7 +226,7 @@ This file contains:
 ### For Developers (Adding Features)
 
 1. Add new strings to `lib/I18n/translations/english.yaml`
-2. Run `python3 scripts/gen_i18n.py lib/I18n/translations lib/I18n/`
+2. Run `python3 scripts/gen_i18n.py`
 3. Use the new `StrId` in your code
 4. Request translations from translators
 
@@ -236,5 +236,21 @@ This file contains:
 2. Add or update translations using the format `STR_KEY: "translated text"`
 3. Keep translations concise (E-ink space constraints)
 4. Make sure the file is in UTF-8 encoding
-5. Run `python3 scripts/gen_i18n.py lib/I18n/translations lib/I18n/` to verify
+5. Run `python3 scripts/gen_i18n.py` to verify
 6. Test on device or submit for review
+
+### i18n script flags system
+```bash
+usage: gen_i18n.py [-h] [-l LANGUAGE] [-t TRANSLATIONS] [-o OUTPUT]
+
+18n flags
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l LANGUAGE, --language LANGUAGE
+                        Filter terminal logs by language code. Ex. -l=UK shows only logs related to the Ukrainian translation
+  -t TRANSLATIONS, --translations TRANSLATIONS
+                        Default translation dir path relative to project root
+  -o OUTPUT, --output OUTPUT
+                        Default output dir path relative to project root
+```

--- a/scripts/gen_i18n.py
+++ b/scripts/gen_i18n.py
@@ -597,16 +597,24 @@ def _write_file(path: str, lines: List[str]) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def main(translations_dir=None, output_dir=None, argv=None) -> None:
+def main(
+    translations_dir: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    argv: Optional[List[str]] = None,
+) -> None:
     # Setup argparse
     parser = argparse.ArgumentParser(description="18n flags")
     parser.add_argument("-l", "--language", type=str, help="Filter terminal logs by language code. Ex. -l=UK shows only logs related to the Ukrainian translation")
     parser.add_argument("-t", "--translations", type=str, default="lib/I18n/translations", help="Default translation dir path relative to project root")
     parser.add_argument("-o", "--output", type=str, default="lib/I18n/", help="Default output dir path relative to project root")
     
-    flags, _unknown = parser.parse_known_args(argv)
-    translations_dir = flags.translations
-    output_dir = flags.output
+    argv = [] if argv is None else argv
+    flags, unknown = parser.parse_known_args(argv)
+    if unknown:
+        parser.error(f"unrecognized arguments: {' '.join(unknown)}")
+
+    translations_dir = translations_dir or flags.translations
+    output_dir = output_dir or flags.output
     language_code_filter = flags.language.upper() if flags.language is not None else None
 
     if language_code_filter:

--- a/scripts/gen_i18n.py
+++ b/scripts/gen_i18n.py
@@ -25,6 +25,7 @@ Example:
 import sys
 import os
 import re
+import argparse
 from pathlib import Path
 from typing import List, Dict, Tuple
 
@@ -105,6 +106,7 @@ def parse_yaml_file(filepath: str) -> Dict[str, str]:
 
 def load_translations(
     translations_dir: str,
+    language_code_filter: str
 ) -> Tuple[List[str], List[str], List[str], Dict[str, List[str]]]:
     """
     Read every YAML file in *translations_dir* and return:
@@ -183,7 +185,11 @@ def load_translations(
             if not value.strip() and fname != english_file:
                 value = english_data[key]
                 lang_code = parsed[fname].get("_language_code", fname)
-                print(f"  INFO: '{key}' missing in {lang_code}, using English fallback")
+                # Filter out all logs not related to the picked filter
+                if language_code_filter != None and language_code_filter != lang_code:
+                  pass
+                else:
+                  print(f"  INFO: '{key}' missing in {lang_code}, using English fallback")
             row.append(value)
         translations[key] = row
 
@@ -195,7 +201,14 @@ def load_translations(
         extra = [k for k in data if not k.startswith("_") and k not in english_data]
         if extra:
             lang_code = data.get("_language_code", fname)
-            print(f"  WARNING: {lang_code} has keys not in English: {', '.join(extra)}")
+            # Filter out all logs not related to the picked filter
+            if language_code_filter != None and language_code_filter != lang_code:
+              pass
+            else:
+              print(f"  WARNING: {lang_code} has keys not in English: {', '.join(extra)}")
+
+    if not language_code_filter in language_codes:
+      print(f"  WARNING: A translation file not found for language code: {language_code_filter}")
 
     print(f"Loaded {len(language_codes)} languages, {len(string_keys)} string keys")
     return language_codes, language_names, string_keys, translations
@@ -587,19 +600,21 @@ def _write_file(path: str, lines: List[str]) -> None:
 # ---------------------------------------------------------------------------
 
 def main(translations_dir=None, output_dir=None) -> None:
-    # Default paths (relative to project root)
-    default_translations_dir = "lib/I18n/translations"
-    default_output_dir = "lib/I18n/"
+    # Setup argparse
+    parser = argparse.ArgumentParser(description="18n flags")
+    parser.add_argument("-l", "--language", type=str, help="Filter terminal logs by language code. Ex. -l=UK shows only logs related to the Ukrainian translation")
+    parser.add_argument("-t", "--translations", type=str, default="lib/I18n/translations", help="Default translation dir path relative to project root")
+    parser.add_argument("-o", "--output", type=str, default="lib/I18n/", help="Default output dir path relative to project root")
+    
+    flags = parser.parse_args()
+    translations_dir = flags.translations
+    output_dir = flags.output
+    language_code_filter = flags.language
 
-    if translations_dir is None or output_dir is None:
-        if len(sys.argv) == 3:
-            translations_dir = sys.argv[1]
-            output_dir = sys.argv[2]
-        else:
-            # Default for no arguments or weird arguments (e.g. SCons)
-            translations_dir = default_translations_dir
-            output_dir = default_output_dir
-
+    if language_code_filter:
+      print("===================================================")
+      print(f"You filtered out all logs by this language code: {language_code_filter}")
+      print("===================================================")
 
     if not os.path.isdir(translations_dir):
         print(f"Error: Translations directory not found: {translations_dir}")
@@ -615,7 +630,8 @@ def main(translations_dir=None, output_dir=None) -> None:
 
     try:
         languages, language_names, string_keys, translations = load_translations(
-            translations_dir
+            translations_dir,
+            language_code_filter
         )
 
         out = Path(output_dir)

--- a/scripts/gen_i18n.py
+++ b/scripts/gen_i18n.py
@@ -609,7 +609,7 @@ def main(translations_dir=None, output_dir=None) -> None:
     flags = parser.parse_args()
     translations_dir = flags.translations
     output_dir = flags.output
-    language_code_filter = flags.language
+    language_code_filter = flags.language.upper() if not flags.language == None else None
 
     if language_code_filter:
       print("===================================================")

--- a/scripts/gen_i18n.py
+++ b/scripts/gen_i18n.py
@@ -27,7 +27,7 @@ import os
 import re
 import argparse
 from pathlib import Path
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ def parse_yaml_file(filepath: str) -> Dict[str, str]:
 
 def load_translations(
     translations_dir: str,
-    language_code_filter: str
+    language_code_filter: Optional[str]
 ) -> Tuple[List[str], List[str], List[str], Dict[str, List[str]]]:
     """
     Read every YAML file in *translations_dir* and return:
@@ -186,10 +186,8 @@ def load_translations(
                 value = english_data[key]
                 lang_code = parsed[fname].get("_language_code", fname)
                 # Filter out all logs not related to the picked filter
-                if language_code_filter != None and language_code_filter != lang_code:
-                  pass
-                else:
-                  print(f"  INFO: '{key}' missing in {lang_code}, using English fallback")
+                if language_code_filter is None or language_code_filter == lang_code:
+                    print(f"  INFO: '{key}' missing in {lang_code}, using English fallback")
             row.append(value)
         translations[key] = row
 
@@ -202,12 +200,12 @@ def load_translations(
         if extra:
             lang_code = data.get("_language_code", fname)
             # Filter out all logs not related to the picked filter
-            if language_code_filter != None and language_code_filter != lang_code:
-              pass
-            else:
-              print(f"  WARNING: {lang_code} has keys not in English: {', '.join(extra)}")
+            if language_code_filter is None or language_code_filter == lang_code:
+                print(f"  WARNING: {lang_code} has keys not in English: {', '.join(extra)}")
 
-    if not language_code_filter in language_codes:
+    if language_code_filter is not None and language_code_filter not in {
+        code.upper() for code in language_codes
+    }:
       print(f"  WARNING: A translation file not found for language code: {language_code_filter}")
 
     print(f"Loaded {len(language_codes)} languages, {len(string_keys)} string keys")
@@ -599,17 +597,17 @@ def _write_file(path: str, lines: List[str]) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def main(translations_dir=None, output_dir=None) -> None:
+def main(translations_dir=None, output_dir=None, argv=None) -> None:
     # Setup argparse
     parser = argparse.ArgumentParser(description="18n flags")
     parser.add_argument("-l", "--language", type=str, help="Filter terminal logs by language code. Ex. -l=UK shows only logs related to the Ukrainian translation")
     parser.add_argument("-t", "--translations", type=str, default="lib/I18n/translations", help="Default translation dir path relative to project root")
     parser.add_argument("-o", "--output", type=str, default="lib/I18n/", help="Default output dir path relative to project root")
     
-    flags = parser.parse_args()
+    flags, _unknown = parser.parse_known_args(argv)
     translations_dir = flags.translations
     output_dir = flags.output
-    language_code_filter = flags.language.upper() if not flags.language == None else None
+    language_code_filter = flags.language.upper() if flags.language is not None else None
 
     if language_code_filter:
       print("===================================================")
@@ -652,11 +650,11 @@ def main(translations_dir=None, output_dir=None) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(argv=sys.argv[1:])
 else:
     try:
         Import("env")
         print("Running i18n generation script from PlatformIO...")
-        main()
+        main(argv=[])
     except NameError:
         pass


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Improve a workflow for the translators when multiple languages miss some translation lines. Additional effort to cover this problem https://github.com/crosspoint-reader/crosspoint-reader/pull/1203
* **What changes are included?**

updated `scripts/gen_i18n.py` with `argparse`  that includes the following API
```bash
usage: gen_i18n.py [-h] [-l LANGUAGE] [-t TRANSLATIONS] [-o OUTPUT]

18n flags

optional arguments:
  -h, --help            show this help message and exit
  -l LANGUAGE, --language LANGUAGE
                        Filter terminal logs by language code. Ex. -l=UK shows only logs related to the Ukrainian translation
  -t TRANSLATIONS, --translations TRANSLATIONS
                        Default translation dir path relative to project root
  -o OUTPUT, --output OUTPUT
                        Default output dir path relative to project root
```

## Additional Context
Examples of output.

With valid language code:
```bash
python3 scripts/gen_i18n.py -l=UK
===================================================
You filtered out all logs by this language code: UK
===================================================
Reading translations from: lib/I18n/translations
Output directory: lib/I18n/

  INFO: 'STR_DELETE' missing in UK, using English fallback
  INFO: 'STR_AUTO_TURN_ENABLED' missing in UK, using English fallback
  INFO: 'STR_AUTO_TURN_PAGES_PER_MIN' missing in UK, using English fallback
Loaded 17 languages, 335 string keys
Generated: lib/I18n/I18nKeys.h
Generated: lib/I18n/I18nStrings.h
Generated: lib/I18n/I18nStrings.cpp

✓ Code generation complete!
  Languages: 17
  String keys: 335
```

With invalid language code:
```bash
python3 scripts/gen_i18n.py -l=UA
===================================================
You filtered out all logs by this language code: UA
===================================================
Reading translations from: lib/I18n/translations
Output directory: lib/I18n/

  WARNING: A translation file not found for language code: UA
Loaded 17 languages, 335 string keys
Generated: lib/I18n/I18nKeys.h
Generated: lib/I18n/I18nStrings.h
Generated: lib/I18n/I18nStrings.cpp

✓ Code generation complete!
  Languages: 17
  String keys: 335
```

Without any flags (heavily trimmed):
```bash
python3 scripts/gen_i18n.py
Reading translations from: lib/I18n/translations
Output directory: lib/I18n/

  INFO: 'STR_SELECTED' missing in ES, using English fallback
  INFO: 'STR_SELECTED' missing in FR, using English fallback
  INFO: 'STR_SELECTED' missing in DA, using English fallback
  INFO: 'STR_SELECTED' missing in NL, using English fallback
  INFO: 'STR_SHOW' missing in ES, using English fallback
  INFO: 'STR_SHOW' missing in FR, using English fallback
  INFO: 'STR_SHOW' missing in BE, using English fallback
  INFO: 'STR_SHOW' missing in IT, using English fallback
  INFO: 'STR_SHOW' missing in FI, using English fallback
  INFO: 'STR_SHOW' missing in DA, using English fallback
  INFO: 'STR_HIDE' missing in ES, using English fallback
  INFO: 'STR_HIDE' missing in FR, using English fallback
  INFO: 'STR_HIDE' missing in DE, using English fallback
  INFO: 'STR_HIDE' missing in CS, using English fallback
  INFO: 'STR_BOOK_PROGRESS_PERCENTAGE' missing in SV, using English fallback
  INFO: 'STR_PROGRESS_BAR_THIN' missing in FI, using English fallback
  INFO: 'STR_PROGRESS_BAR_THIN' missing in DA, using English fallback
  INFO: 'STR_PROGRESS_BAR_MEDIUM' missing in ES, using English fallback
  INFO: 'STR_BOOK' missing in CA, using English fallback
  INFO: 'STR_BOOK' missing in BE, using English fallback
  INFO: 'STR_TITLE' missing in FI, using English fallback
  INFO: 'STR_TITLE' missing in DA, using English fallback
  INFO: 'STR_BATTERY' missing in ES, using English fallback
  INFO: 'STR_DELETE' missing in RO, using English fallback

  WARNING: BE has keys not in English: STR_STATUS_BAR_FULL_PERCENT, STR_STATUS_BAR_FULL_BOOK, STR_STATUS_BAR_BOOK_ONLY, STR_STATUS_BAR_FULL_CHAPTER
  WARNING: IT has keys not in English: STR_STATUS_BAR_FULL_PERCENT, STR_STATUS_BAR_FULL_BOOK, STR_STATUS_BAR_BOOK_ONLY, STR_STATUS_BAR_FULL_CHAPTER
  WARNING: FI has keys not in English: STR_SET, STR_ON_MARKER, STR_STATUS_BAR_FULL_PERCENT, STR_STATUS_BAR_FULL_BOOK, STR_STATUS_BAR_BOOK_ONLY, STR_STATUS_BAR_FULL_CHAPTER
  WARNING: DA has keys not in English: STR_SET, STR_ON_MARKER, STR_STATUS_BAR_FULL_PERCENT, STR_STATUS_BAR_FULL_BOOK, STR_STATUS_BAR_BOOK_ONLY, STR_STATUS_BAR_FULL_CHAPTER
  WARNING: NL has keys not in English: STR_SET, STR_ON_MARKER
  WARNING: A translation file not found for language code: None
Loaded 17 languages, 335 string keys
Generated: lib/I18n/I18nKeys.h
Generated: lib/I18n/I18nStrings.h
Generated: lib/I18n/I18nStrings.cpp

✓ Code generation complete!
  Languages: 17
  String keys: 335
```

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO **_
