### PR TITLE
fix: Properly shut down SD card and hold CS pins before deep sleep

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -1,7 +1,12 @@
 #include <HalGPIO.h>
 #include <SPI.h>
+#include <driver/gpio.h>
 
 void HalGPIO::begin() {
+  // Release any GPIO holds that were set before entering deep sleep,
+  // so the SPI bus and CS pins can be reconfigured normally.
+  gpio_hold_dis(static_cast<gpio_num_t>(SD_CS));
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_CS));
   inputMgr.begin();
   SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
   pinMode(UART0_RXD, INPUT);

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -13,6 +13,7 @@
 #define EPD_BUSY 6   // Busy
 
 #define SPI_MISO 7  // SPI MISO, shared between SD card and display (Master In Slave Out)
+#define SD_CS 12    // SD card Chip Select
 
 #define BAT_GPIO0 0  // Battery voltage
 

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -2,6 +2,7 @@
 
 #include <Logging.h>
 #include <WiFi.h>
+#include <driver/gpio.h>
 #include <esp_sleep.h>
 
 #include <cassert>
@@ -58,6 +59,10 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
     delay(50);
     gpio.update();
   }
+  // Hold SPI CS pins HIGH during deep sleep so they stay deselected while the 3.3V rail remains powered.
+  // Without this, CS pins float on entry to deep sleep and can accidentally select the SD card or display.
+  gpio_hold_en(static_cast<gpio_num_t>(SD_CS));
+  gpio_hold_en(static_cast<gpio_num_t>(EPD_CS));
   // Arm the wakeup trigger *after* the button is released
   esp_deep_sleep_enable_gpio_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
   // Enter Deep Sleep

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -59,10 +59,16 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
     delay(50);
     gpio.update();
   }
-  // Hold SPI CS pins HIGH during deep sleep so they stay deselected while the 3.3V rail remains powered.
-  // Without this, CS pins float on entry to deep sleep and can accidentally select the SD card or display.
+  // Drive SPI CS pins HIGH and latch them so they stay deselected through deep sleep.
+  // Without explicit direction+level before gpio_hold_en, the latched value is undefined if the pin floated.
+  // gpio_deep_sleep_hold_en() is required for the hold to survive deep sleep on ESP32-C3.
+  gpio_set_direction(static_cast<gpio_num_t>(SD_CS), GPIO_MODE_OUTPUT);
+  gpio_set_level(static_cast<gpio_num_t>(SD_CS), 1);
   gpio_hold_en(static_cast<gpio_num_t>(SD_CS));
+  gpio_set_direction(static_cast<gpio_num_t>(EPD_CS), GPIO_MODE_OUTPUT);
+  gpio_set_level(static_cast<gpio_num_t>(EPD_CS), 1);
   gpio_hold_en(static_cast<gpio_num_t>(EPD_CS));
+  gpio_deep_sleep_hold_en();
   // Arm the wakeup trigger *after* the button is released
   esp_deep_sleep_enable_gpio_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
   // Enter Deep Sleep

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -20,6 +20,8 @@ HalStorage::HalStorage() {
 
 bool HalStorage::begin() { return SDCard.begin(); }
 
+void HalStorage::end() { SDCard.end(); }
+
 bool HalStorage::ready() const { return SDCard.ready(); }
 
 // For the rest of the methods, we acquire the mutex to ensure thread safety

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -14,6 +14,7 @@ class HalStorage {
  public:
   HalStorage();
   bool begin();
+  void end();
   bool ready() const;
   std::vector<String> listFiles(const char* path = "/", int maxFiles = 200);
   // Read the entire file at `path` into a String. Returns empty string on failure.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,7 @@ void enterDeepSleep() {
 
   activityManager.goToSleep();
 
+  Storage.end();
   display.deepSleep();
   LOG_DBG("MAIN", "Power button press calibration value: %lu ms", t2 - t1);
   LOG_DBG("MAIN", "Entering deep sleep");


### PR DESCRIPTION
**THIS REQUIRES A THOROUGH REVIEW**
@ngxson What do you think, is the analysis below correct?

https://github.com/open-x4-epaper/community-sdk/pull/27

It would need two changes to the open-x4-sdk
* SDCardManager.h definition of end
* SDCardManager.cpp
```
void SDCardManager::end() {
  if (initialized) {
    sd.end();
    initialized = false;
  }
}
```
 
## Problem

Two related issues affect the device during deep sleep that this PR addresses together.

### 1. GPIO CS pins float on deep sleep entry

When `esp_deep_sleep_start()` is called, the ESP32-C3 puts all GPIO pins into a high-impedance (floating) state by default. On the CrossPoint hardware the 3.3V supply rail remains powered throughout deep sleep — the LDO regulator stays on to supply standby current for the wakeup circuitry. This means both the SD card and the SSD1677 e-ink controller remain electrically powered while the CPU is asleep.

Without explicitly holding the CS pins, GPIO 12 (SD CS) and GPIO 21 (EPD CS) float freely after `esp_deep_sleep_start()`. A floating CS line can settle LOW, which **accidentally asserts chip-select** on the peripheral. For the SD card this has two consequences:

- **Idle current draw**: An SD card with an asserted CS line actively drives its MISO line and waits for clock, drawing 1–5 mA continuously throughout the sleep period. For a device that may sleep for hours this is a significant battery drain.
- **SPI bus contention**: MISO is shared between the SD card and the display. If the SD card is driving MISO while EPD_CS is also asserted (both floating LOW), the two devices conflict on the same line.

### 2. No explicit SD card shutdown before sleep

The existing `enterDeepSleep()` sequence was:

```
APP_STATE.saveToFile()       ← writes to SD
activityManager.goToSleep()  ← renders sleep screen (may read SD for custom images)
display.deepSleep()          ← SSD1677 power-down via SPI
esp_deep_sleep_start()
```

`SdFat` closes files individually via `FsFile::close()`, but there was no call to `SdFat::end()` before sleep. `SdFat::end()` sends CMD0 to return the card to its idle/standby state and properly deasserts the CS line (drives it HIGH) before releasing control. Skipping it leaves the card in a partially active transaction state.

---

## Fix

Four targeted changes implement a clean, ordered shutdown and guaranteed CS pin stability.

### `SDCardManager::end()` (open-x4-sdk submodule)

Adds a thin wrapper that delegates to `SdFat::end()`:

```cpp
void SDCardManager::end() {
  if (initialized) {
    sd.end();
    initialized = false;
  }
}
```

`SdFat::end()` sends CMD0 (GO_IDLE_STATE) to the card, which puts it into SPI idle mode with CS deasserted. The `initialized` flag is cleared so subsequent accidental calls to storage methods fail gracefully rather than operating on an uninitialized bus.

### `HalStorage::end()` (HAL layer)

Exposes `SDCardManager::end()` through the `HalStorage` / `Storage` abstraction, consistent with the existing `begin()` / `ready()` pattern. No mutex is acquired — the same reasoning as `begin()` applies: this is only called from a single-threaded context during sleep preparation.

### Updated `enterDeepSleep()` in `main.cpp`

```
APP_STATE.saveToFile()       ← SD fully up; safe to write state
activityManager.goToSleep()  ← SD fully up; sleep screen may read custom images
Storage.end()                ← SdFat flush, CMD0, CS driven HIGH
display.deepSleep()          ← SSD1677 power-down sequence via SPI
powerManager.startDeepSleep()
```

`Storage.end()` is placed **after** `activityManager.goToSleep()` because the sleep screen renderer may still need to read from the SD card (e.g. a custom BMP or PNG from `/sleep/`). It is placed **before** `display.deepSleep()` so the SPI bus is no longer shared with the SD card when the final EPD commands are sent.

### GPIO hold in `HalPowerManager::startDeepSleep()`

```cpp
gpio_hold_en(static_cast<gpio_num_t>(SD_CS));   // GPIO 12
gpio_hold_en(static_cast<gpio_num_t>(EPD_CS));  // GPIO 21
esp_deep_sleep_enable_gpio_wakeup(...);
esp_deep_sleep_start();
```

`gpio_hold_en()` (ESP-IDF `driver/gpio.h`) latches the current output level of a pin and maintains it through deep sleep, even after the GPIO peripheral is powered down. Because `Storage.end()` and `display.deepSleep()` have already driven both CS lines HIGH, the holds lock them in the deasserted state for the entire sleep period.

The holds are applied **after** the power button release loop (so the button GPIO is in a known state) and **before** arming the wakeup source (consistent sequencing).

### `gpio_hold_dis()` in `HalGPIO::begin()`

```cpp
gpio_hold_dis(static_cast<gpio_num_t>(SD_CS));
gpio_hold_dis(static_cast<gpio_num_t>(EPD_CS));
inputMgr.begin();
SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
```

On every boot (cold or wake from deep sleep), the holds are released **before** `SPI.begin()` reconfigures the pins. If the holds were still active when `SPI.begin()` ran, the Arduino SPI layer would be unable to drive CS correctly. Releasing them unconditionally is safe — `gpio_hold_dis()` is a no-op when no hold is active (e.g. first power-on).

`SD_CS` (GPIO 12) is also added to `HalGPIO.h` alongside the existing EPD pin definitions so both pins are referenced from a single authoritative location.

---

## Files changed

| File | Change |
|---|---|
| `open-x4-sdk/.../SDCardManager.h` | `void end()` declaration |
| `open-x4-sdk/.../SDCardManager.cpp` | `end()` implementation via `SdFat::end()` |
| `lib/hal/HalStorage.h` | `void end()` declaration |
| `lib/hal/HalStorage.cpp` | `end()` delegates to `SDCard.end()` |
| `lib/hal/HalGPIO.h` | `#define SD_CS 12` added to pin definitions |
| `lib/hal/HalGPIO.cpp` | `begin()` releases GPIO holds before SPI init |
| `lib/hal/HalPowerManager.cpp` | `startDeepSleep()` holds CS pins HIGH before sleep |
| `src/main.cpp` | `enterDeepSleep()` calls `Storage.end()` before `display.deepSleep()` |

---

## Testing

- [ ] Device sleeps and wakes normally via power button
- [ ] Custom sleep screen images (BMP/PNG from `/sleep/`) still display correctly after this change (SD must still be up when `goToSleep()` runs)
- [ ] State is correctly saved and restored across sleep/wake cycles
- [ ] Battery current during deep sleep measured lower (SD card no longer draws idle current)
- [ ] No SD card corruption or reinitialization failures after repeated sleep/wake cycles