### PR TITLE
refactor: Avoid rebuilding cache path strings

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -274,11 +274,13 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
 }
 
 bool BookMetadataCache::cleanupTmpFiles() const {
-  if (Storage.exists((cachePath + tmpSpineBinFile).c_str())) {
-    Storage.remove((cachePath + tmpSpineBinFile).c_str());
+  const auto spineBinFile = cachePath + tmpSpineBinFile;
+  if (Storage.exists(spineBinFile.c_str())) {
+    Storage.remove(spineBinFile.c_str());
   }
-  if (Storage.exists((cachePath + tmpTocBinFile).c_str())) {
-    Storage.remove((cachePath + tmpTocBinFile).c_str());
+  const auto tocBinFile = cachePath + tmpTocBinFile;
+  if (Storage.exists(tocBinFile.c_str())) {
+    Storage.remove(tocBinFile.c_str());
   }
   return true;
 }

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -36,12 +36,10 @@ ContentOpfParser::~ContentOpfParser() {
   if (tempItemStore) {
     tempItemStore.close();
   }
-  if (Storage.exists((cachePath + itemCacheFile).c_str())) {
-    Storage.remove((cachePath + itemCacheFile).c_str());
+  const auto itemCachePath = cachePath + itemCacheFile;
+  if (Storage.exists(itemCachePath.c_str())) {
+    Storage.remove(itemCachePath.c_str());
   }
-  itemIndex.clear();
-  itemIndex.shrink_to_fit();
-  useItemIndex = false;
 }
 
 size_t ContentOpfParser::write(const uint8_t data) { return write(&data, 1); }


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Avoid building cache path strings twice, once to check existence of the file and a second time to delete the file.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
