### PR TITLE
fix: avoid zip filename overflow

### DIFF
--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -71,10 +71,15 @@ bool ZipFile::loadAllFileStatSlims() {
     file.read(&k, 2);
     file.seekCur(8);
     file.read(&fileStat.localHeaderOffset, 4);
-    file.read(itemName, nameLen);
-    itemName[nameLen] = '\0';
 
-    fileStatSlimCache.emplace(itemName, fileStat);
+    if (nameLen < sizeof(itemName)) {
+      file.read(itemName, nameLen);
+      itemName[nameLen] = '\0';
+      fileStatSlimCache.emplace(itemName, fileStat);
+    } else {
+      // Skip over oversized entry names to avoid writing past fixed buffer.
+      file.seekCur(nameLen);
+    }
 
     // Skip the rest of this entry (extra field + comment)
     file.seekCur(m + k);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Potential stack buffer overflow from untrusted ZIP entry name length 
* **What changes are included?** If nameLen >= 256 , this writes past the stack buffer. Risk: memory corruption/crash on malformed EPUB/ZIP.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _** PARTIALLY **_ Issue identified by AI
