### PR TITLE
chore: change label while on settings tab actions

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -243,8 +243,10 @@ void SettingsActivity::render(RenderLock&&) {
       true);
 
   // Draw help text
-  const StrId confirmLabel = (selectedSettingIndex == 0) ? StrId::STR_SELECT : StrId::STR_TOGGLE;
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), I18N.get(confirmLabel), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+  const auto confirmLabel = (selectedSettingIndex == 0)
+                                ? I18N.get(categoryNames[(selectedCategoryIndex + 1) % categoryCount])
+                                : tr(STR_TOGGLE);
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   // Always use standard refresh for settings screen


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** The "Toggle" label while on the "tab" actions of settings screen was misleading. Will show "Select" now , while "Toggle" remains in place for all 'real' settings

* **What changes are included?**

## Additional Context
<img width="240" alt="1" src="https://github.com/user-attachments/assets/dc198716-0aad-4c75-96fe-52595625e69d" />
<img width="240" alt="2" src="https://github.com/user-attachments/assets/85ce5368-801c-489d-aa94-51f126c3ddc8" />


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO **_
