### PR TITLE
fix: reset watchdog timer during chapter parsing (#1328)

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -4,6 +4,7 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <esp_task_wdt.h>
 #include <expat.h>
 
 #include "../../Epub.h"
@@ -957,6 +958,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   // Compute the time taken to parse and build pages
   const uint32_t chapterStartTime = millis();
   do {
+    esp_task_wdt_reset();  // Feed watchdog during long chapter parsing
     void* const buf = XML_GetBuffer(parser, PARSE_BUFFER_SIZE);
     if (!buf) {
       LOG_ERR("EHP", "Couldn't allocate memory for buffer");


### PR DESCRIPTION
## Summary

- Add `esp_task_wdt_reset()` inside the XML parsing loop in `ChapterHtmlSlimParser` to prevent hardware watchdog reboots when parsing large chapters

Fixes #1328

Large chapters can take long enough to parse that the ESP32 hardware watchdog timer fires, rebooting the device. This adds a watchdog reset at the top of each parse iteration, following the same pattern used 17 times elsewhere in the codebase (`CrossPointWebServer.cpp`, `WebDAVHandler.cpp`, `CalibreConnectActivity.cpp`).

## Change

2 lines in `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp`:
1. `#include <esp_task_wdt.h>`
2. `esp_task_wdt_reset();` at the top of the `do { }` parse loop

## Test plan

- [x] Builds with PlatformIO
- [x] Tested on ESP32-C3 hardware — large EPUB chapters no longer trigger WDT reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)