### PR TITLE
fix: show loading feedback for books and images (#1340, #1283)

### DIFF
--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -112,6 +112,10 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y) {
   }
 
   // No cache - need to decode the image
+  // Show placeholder border while decoding
+  renderer.drawRect(x + 1, y + 1, width - 2, height - 2, true);
+  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+
   // Check if image file exists
   FsFile file;
   if (!Storage.openFileForRead("IMG", imagePath, file)) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -945,8 +945,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
     return false;
   }
 
-  // Get file size to decide whether to show indexing popup.
-  if (popupFn && file.size() >= MIN_SIZE_FOR_POPUP) {
+  if (popupFn) {
     popupFn();
   }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -576,6 +576,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       LOG_DBG("ERS", "Cache not found, building...");
 
       const auto popupFn = [this]() { GUI.drawPopup(renderer, tr(STR_INDEXING)); };
+      popupFn();  // Show immediately before parsing starts
 
       if (!section->createSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                       SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,


### PR DESCRIPTION
## Summary

- Show "Indexing" popup immediately before chapter parsing starts, removing the 10KB file size threshold
- Draw a placeholder border rectangle while decoding uncached images, with a fast refresh for immediate feedback

Fixes #1340, fixes #1283

## Files changed

| File | Change |
|------|--------|
| `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp` | Remove `MIN_SIZE_FOR_POPUP` threshold — always show popup |
| `lib/Epub/Epub/blocks/ImageBlock.cpp` | Draw border placeholder before image decode |
| `src/activities/reader/EpubReaderActivity.cpp` | Call `popupFn()` immediately before `createSectionFile()` |

## Test plan

- [x] Builds with PlatformIO
- [x] Tested on ESP32-C3 hardware
- [x] Opening any EPUB shows "Indexing" popup immediately
- [x] Uncached images show border placeholder before decode completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)