### PR TITLE
fix: show "Select" instead of "Toggle" for non-toggle settings (#1268)

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -242,8 +242,14 @@ void SettingsActivity::render(RenderLock&&) {
       },
       true);
 
-  // Draw help text
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_TOGGLE), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+  // Draw help text — use context-appropriate label for the confirm button
+  const char* actionLabel = tr(STR_SELECT);
+  if (selectedSettingIndex > 0 && selectedSettingIndex - 1 < settingsCount) {
+    if ((*currentSettings)[selectedSettingIndex - 1].type == SettingType::TOGGLE) {
+      actionLabel = tr(STR_TOGGLE);
+    }
+  }
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), actionLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   // Always use standard refresh for settings screen


### PR DESCRIPTION
## Summary

- The confirm button hint in Settings was hardcoded to "Toggle" for all items
- Now shows "Toggle" only for boolean toggle settings and "Select" for action, enum, and value settings
- Uses existing `STR_SELECT` string (already translated in all languages)

Fixes #1268

## Change

`src/activities/settings/SettingsActivity.cpp` — 6 lines added, replacing the hardcoded `tr(STR_TOGGLE)` with a dynamic label based on the currently highlighted setting's type.

## Test plan

- [ ] Navigate to Settings, highlight a toggle item (e.g., Hyphenation) → button shows "Toggle"
- [ ] Highlight an action item (e.g., OPDS Browser, WiFi Networks) → button shows "Select"
- [ ] Highlight an enum item (e.g., Font Family, Orientation) → button shows "Select"
- [ ] Highlight a value item (e.g., Screen Margin) → button shows "Select"

🤖 Generated with [Claude Code](https://claude.com/claude-code)