### PR TITLE
fix: preserve CSS text-align:center when user sets Justify (#1029)

### DIFF
--- a/lib/Epub/Epub/blocks/BlockStyle.h
+++ b/lib/Epub/Epub/blocks/BlockStyle.h
@@ -86,9 +86,13 @@ struct BlockStyle {
       blockStyle.textIndentDefined = true;
     }
     blockStyle.textAlignDefined = cssStyle.hasTextAlign();
-    // User setting overrides CSS, unless "Book's Style" alignment setting is selected
+    // User setting overrides CSS, unless "Book's Style" alignment setting is selected.
+    // Exception: CSS text-align:center is always respected, as it typically serves a
+    // structural/decorative purpose (ornamental dividers, title pages, etc.)
     if (paragraphAlignment == CssTextAlign::None) {
       blockStyle.alignment = blockStyle.textAlignDefined ? cssStyle.textAlign : CssTextAlign::Justify;
+    } else if (blockStyle.textAlignDefined && cssStyle.textAlign == CssTextAlign::Center) {
+      blockStyle.alignment = CssTextAlign::Center;
     } else {
       blockStyle.alignment = paragraphAlignment;
     }


### PR DESCRIPTION
## Summary

- Preserve CSS `text-align: center` even when the user's paragraph alignment is set to Justify, Left, or Right
- Centered text almost always serves a structural/decorative purpose (ornamental dividers, title pages, dedications) and should not be overridden

Fixes #1029

## Root cause

`BlockStyle::fromCssStyle()` unconditionally replaced the CSS text-align with the user's paragraph alignment setting, except in "Book's Style" mode. This meant `text-align: center` from the book's CSS was ignored.

## Change

3-line addition in `lib/Epub/Epub/blocks/BlockStyle.h` — add an `else if` branch that preserves `CssTextAlign::Center` from the book's stylesheet, regardless of the user's alignment setting.

## Test plan

- [ ] EPUB with CSS `text-align: center` (ornamental dividers, title pages) renders centered with Justify setting
- [ ] Normal paragraphs still respect user's Justify/Left/Right setting
- [ ] "Book's Style" mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)