### PR TITLE
fix: show file extensions in file browser (#1097)

### DIFF
--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -240,8 +240,7 @@ std::string getFileName(std::string filename) {
   if (filename.back() == '/') {
     return filename.substr(0, filename.length() - 1);
   }
-  const auto pos = filename.rfind('.');
-  return filename.substr(0, pos);
+  return filename;
 }
 
 void FileBrowserActivity::render(RenderLock&&) {


### PR DESCRIPTION
## Summary

- File extensions are now shown in the file browser
- Previously `getFileName()` stripped everything after the last dot, making it impossible to distinguish file types

Fixes #1097

## Change

1-line change in `src/activities/home/FileBrowserActivity.cpp` — `getFileName()` now returns the full filename instead of stripping the extension. The existing `truncatedText()` method in `GfxRenderer` handles filenames too long for the display.

## Test plan

- [ ] Files show with extensions (e.g., "mybook.epub" not "mybook")
- [ ] Folders still display without trailing slash
- [ ] Long filenames are truncated with ellipsis (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)