### PR TITLE
fix: correct QR code version capacity thresholds (#1309)

### DIFF
--- a/src/util/QrUtils.cpp
+++ b/src/util/QrUtils.cpp
@@ -6,18 +6,24 @@
 #include <memory>
 
 #include "Logging.h"
+#include "fontIds.h"
 
 void QrUtils::drawQrCode(const GfxRenderer& renderer, const Rect& bounds, const std::string& textPayload) {
-  // Dynamically calculate the QR code version based on text length
-  // Version 4 holds ~114 bytes, Version 10 ~395, Version 20 ~1066, up to 40
-  // qrcode.h max version is 40.
-  // Formula: approx version = size / 26 + 1 (very rough estimate, better to find best fit)
+  // Dynamically calculate the QR code version based on text length.
+  // Capacities are for ECC_LOW byte mode, with overhead for mode indicator and length field.
   const size_t len = textPayload.length();
+
+  if (len > 2953) {
+    LOG_ERR("QR", "Text payload (%d bytes) exceeds QR v40 max capacity", (int)len);
+    renderer.drawCenteredText(UI_12_FONT_ID, bounds.y + bounds.height / 2, "Text too large for QR code", true);
+    return;
+  }
+
   int version = 4;
-  if (len > 114) version = 10;
-  if (len > 395) version = 20;
-  if (len > 1066) version = 30;
-  if (len > 2110) version = 40;
+  if (len > 78) version = 10;
+  if (len > 271) version = 20;
+  if (len > 858) version = 30;
+  if (len > 1732) version = 40;
 
   // Make sure we have a large enough buffer on the heap to avoid blowing the stack
   uint32_t bufferSize = qrcode_getBufferSize(version);
@@ -48,7 +54,8 @@ void QrUtils::drawQrCode(const GfxRenderer& renderer, const Rect& bounds, const 
       }
     }
   } else {
-    // If it fails (e.g. text too large), log an error
-    LOG_ERR("QR", "Text too large for QR Code version %d", version);
+    // If it fails (e.g. text too large), log and show error
+    LOG_ERR("QR", "QR code generation failed for version %d (%d bytes)", version, (int)len);
+    renderer.drawCenteredText(UI_12_FONT_ID, bounds.y + bounds.height / 2, "Text too large for QR code", true);
   }
 }


### PR DESCRIPTION
## Summary

- Fix incorrect QR version-to-capacity thresholds that caused corrupt/undecodable QR codes
- Add explicit overflow guard with user-visible error when text exceeds QR v40 maximum capacity

Fixes #1309

## Root cause

The version selection thresholds in `QrUtils.cpp` assumed higher capacities than the actual byte-mode limits at ECC_LOW. For example, version 4 was used for up to 114 bytes, but it can only hold ~78 bytes. The upstream `ricmoo/QRCode` library has a known missing bounds check (`// @TODO: Return error if data is too big`), so oversized data silently corrupts the QR structure.

## Changes

| Before | After | Actual capacity |
|--------|-------|----------------|
| v4: 114B | v4: 78B | 78 bytes |
| v10: 395B | v10: 271B | 271 bytes |
| v20: 1066B | v20: 858B | 858 bytes |
| v30: 2110B | v30: 1732B | 1732 bytes |
| v40: unlimited | v40: 2953B max | 2953 bytes |

Also shows "Text too large for QR code" error instead of a corrupt QR when the payload exceeds the maximum capacity.

## Test plan

- [ ] Small page text → QR code scans correctly
- [ ] Medium page text → QR version scales up, still scans
- [ ] Very large page (dense small font) → shows error message instead of corrupt QR
- [ ] Polish/UTF-8 text → QR encodes and scans correctly (multi-byte chars use more capacity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)