### PR TITLE
fix: back button in settings returns to tab bar first

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -89,8 +89,13 @@ void SettingsActivity::loop() {
   }
 
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-    SETTINGS.saveToFile();
-    onGoHome();
+    if (selectedSettingIndex > 0) {
+      selectedSettingIndex = 0;
+      requestUpdate();
+    } else {
+      SETTINGS.saveToFile();
+      onGoHome();
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- Pressing Back while browsing settings within a category now jumps focus to the category tab bar
- Pressing Back again from the tab bar exits settings to home
- Previously, Back always exited directly to home regardless of scroll position

Closes #797

## Test plan
- [ ] Scroll deep into a settings category → press Back → tab bar is focused
- [ ] Press Back again from tab bar → exits to home screen
- [ ] Use category switching (continuous hold) → still works as before
- [ ] Settings are saved on exit (not on tab-bar jump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)