### PR TITLE
fix: Init lastSleepImage (edge case)

### DIFF
--- a/src/CrossPointState.cpp
+++ b/src/CrossPointState.cpp
@@ -63,7 +63,7 @@ bool CrossPointState::loadFromBinaryFile() {
   if (version >= 2) {
     serialization::readPod(inputFile, lastSleepImage);
   } else {
-    lastSleepImage = 0;
+    lastSleepImage = UINT8_MAX;
   }
 
   if (version >= 3) {

--- a/src/CrossPointState.h
+++ b/src/CrossPointState.h
@@ -8,7 +8,7 @@ class CrossPointState {
 
  public:
   std::string openEpubPath;
-  uint8_t lastSleepImage;
+  uint8_t lastSleepImage = 0;
   uint8_t readerActivityLoadCount = 0;
   bool lastSleepFromReader = false;
   ~CrossPointState() = default;

--- a/src/CrossPointState.h
+++ b/src/CrossPointState.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 
@@ -8,7 +9,7 @@ class CrossPointState {
 
  public:
   std::string openEpubPath;
-  uint8_t lastSleepImage = 0;
+  uint8_t lastSleepImage = UINT8_MAX;  // UINT8_MAX = unset sentinel
   uint8_t readerActivityLoadCount = 0;
   bool lastSleepFromReader = false;
   ~CrossPointState() = default;

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -87,7 +87,7 @@ bool JsonSettingsIO::loadState(CrossPointState& s, const char* json) {
   }
 
   s.openEpubPath = doc["openEpubPath"] | std::string("");
-  s.lastSleepImage = doc["lastSleepImage"] | (uint8_t)0;
+  s.lastSleepImage = doc["lastSleepImage"] | (uint8_t)UINT8_MAX;
   s.readerActivityLoadCount = doc["readerActivityLoadCount"] | (uint8_t)0;
   s.lastSleepFromReader = doc["lastSleepFromReader"] | false;
   return true;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -80,7 +80,7 @@ void SleepActivity::renderCustomSleepScreen() const {
       // Generate a random number between 1 and numFiles
       auto randomFileIndex = random(numFiles);
       // If we picked the same image as last time, reroll
-      while (numFiles > 1 && randomFileIndex == APP_STATE.lastSleepImage) {
+      while (numFiles > 1 && APP_STATE.lastSleepImage != UINT8_MAX && randomFileIndex == APP_STATE.lastSleepImage) {
         randomFileIndex = random(numFiles);
       }
       APP_STATE.lastSleepImage = randomFileIndex;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** fix edge case for definition

## Additional Context

If loadFromFile() returns false (no state file exists — first boot, or SD missing), lastSleepImage is never set and contains garbage. [SleepActivity.cpp:83] then uses it in a while comparison to avoid repeating the same image. The JSON path (doc["lastSleepImage"] | (uint8_t)0) handles it, but only if the file exists.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _** NO **_
