### PR TITLE
fix: Fixes for unitialized structures

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -22,6 +22,10 @@ std::unique_ptr<PageLine> PageLine::deserialize(FsFile& file) {
   serialization::readPod(file, yPos);
 
   auto tb = TextBlock::deserialize(file);
+  if (!tb) {
+    LOG_ERR("PGE", "Failed to deserialize TextBlock");
+    return nullptr;
+  }
   return std::unique_ptr<PageLine>(new PageLine(std::move(tb), xPos, yPos));
 }
 
@@ -94,9 +98,17 @@ std::unique_ptr<Page> Page::deserialize(FsFile& file) {
 
     if (tag == TAG_PageLine) {
       auto pl = PageLine::deserialize(file);
+      if (!pl) {
+        LOG_ERR("PGE", "Failed to deserialize PageLine %u", i);
+        return nullptr;
+      }
       page->elements.push_back(std::move(pl));
     } else if (tag == TAG_PageImage) {
       auto pi = PageImage::deserialize(file);
+      if (!pi) {
+        LOG_ERR("PGE", "Failed to deserialize PageImage %u", i);
+        return nullptr;
+      }
       page->elements.push_back(std::move(pi));
     } else {
       LOG_ERR("PGE", "Deserialization failed: Unknown tag %u", tag);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1020,6 +1020,11 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
 void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
   const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
 
+  if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
   if (currentPageNextY + lineHeight > viewportHeight) {
     completePageFn(std::move(currentPage));
     completedPageCount++;

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -37,15 +37,23 @@ static void writeString(FsFile& file, const std::string& s) {
 }
 
 static void readString(std::istream& is, std::string& s) {
-  uint32_t len;
+  uint32_t len = 0;
   readPod(is, len);
+  if (len > 4096) {
+    s.clear();
+    return;
+  }  // Guard against corrupt/truncated length
   s.resize(len);
   is.read(&s[0], len);
 }
 
 static void readString(FsFile& file, std::string& s) {
-  uint32_t len;
+  uint32_t len = 0;
   readPod(file, len);
+  if (len > 4096) {
+    s.clear();
+    return;
+  }  // Guard against corrupt/truncated length
   s.resize(len);
   file.read(&s[0], len);
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes for 3 edge cases
* **What changes are included?**

## Additional Context

* addLineToPage null page crash — When the first text block in a chapter exceeded 750 words, the early-flush path in characterData called addLineToPage before any page had been created. Unlike makePages(), addLineToPage had no guard for a null currentPage, causing a null pointer dereference. Fixed by adding the same if (!currentPage) initialization guard that makePages() already had.

* PageLine::deserialize propagates null TextBlock — TextBlock::deserialize returns nullptr when it detects a corrupt word count (wc > 10000), but PageLine::deserialize constructed a PageLine with the null block anyway. When that page was later rendered or re-serialized, block->render() / block->serialize() crashed. Page::deserialize also pushed the result without checking. Fixed by returning nullptr from PageLine::deserialize on failure and checking the result in Page::deserialize before pushing.

* readString uninitialized len on truncated read — len was declared but not initialized before readPod. If the file read returned fewer than 4 bytes (truncated/corrupt section cache), len held stack garbage and s.resize(len) would attempt a massive heap allocation, causing OOM on the ESP32. Fixed by initializing len = 0 and adding a 4096-byte sanity cap that clears the string and returns early on corrupt data.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _** Partially **_ Asked claude to look got unitialized structures
