### PR TITLE
fix: enable DESTRUCTOR_CLOSES_FILE flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ build_flags =
   -DMINIZ_NO_STDIO=1
   -DEINK_DISPLAY_SINGLE_BUFFER_MODE=1
   -DDISABLE_FS_H_WARNING=1
+  -DDESTRUCTOR_CLOSES_FILE=1
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
@@ -90,4 +91,3 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
-  


### PR DESCRIPTION
Enables the `DESTRUCTOR_CLOSES_FILE` flag so file handles are properly closed when they go out of scope, preventing resource leaks on early returns.