### PR TITLE
fix: guard RTC_NOINIT_ATTR logHead against uninitialized values

### DIFF
--- a/lib/Logging/Logging.cpp
+++ b/lib/Logging/Logging.cpp
@@ -10,6 +10,10 @@ RTC_NOINIT_ATTR char logMessages[MAX_LOG_LINES][MAX_ENTRY_LEN];
 RTC_NOINIT_ATTR size_t logHead = 0;
 
 void addToLogRingBuffer(const char* message) {
+  // Guard against uninitialized RTC memory (logHead is RTC_NOINIT_ATTR)
+  if (logHead >= MAX_LOG_LINES) {
+    logHead = 0;
+  }
   // Add the message to the ring buffer, overwriting old messages if necessary
   strncpy(logMessages[logHead], message, MAX_ENTRY_LEN - 1);
   logMessages[logHead][MAX_ENTRY_LEN - 1] = '\0';
@@ -63,6 +67,9 @@ void logPrintf(const char* level, const char* origin, const char* format, ...) {
 }
 
 std::string getLastLogs() {
+  if (logHead >= MAX_LOG_LINES) {
+    logHead = 0;
+  }
   std::string output;
   for (size_t i = 0; i < MAX_LOG_LINES; i++) {
     size_t idx = (logHead + i) % MAX_LOG_LINES;


### PR DESCRIPTION
## Summary

- Fixes #1374
- Bounds-check `logHead` before every access in `addToLogRingBuffer()` and `getLastLogs()`
- `logHead` is `RTC_NOINIT_ATTR` (not zeroed on reboot), so after a flash erase or first boot, it contains garbage. This causes `logMessages[logHead]` to compute a wild pointer (e.g. `0x5001af18`, far past the 8KB RTC region), triggering a **Store access fault** during global constructors — resulting in an unrecoverable boot loop.

cc @ngxson as the original author of the RTC crash log ring buffer (#1145, #1332) — would appreciate your review.

## Test plan

- [x] Erase flash, re-flash firmware — device boots without crash
- [ ] Verify crash log ring buffer still works correctly after a real crash (logs survive reboot)


🤖 Generated with [Claude Code](https://claude.com/claude-code)