### PR TITLE
fix: Prevent line breaks on common English contractions

### DIFF
--- a/lib/Epub/Epub/hyphenation/Hyphenator.cpp
+++ b/lib/Epub/Epub/hyphenation/Hyphenator.cpp
@@ -102,7 +102,7 @@ void appendSegmentPatternBreaks(const std::vector<CodepointInfo>& cps, const Lan
 void appendApostropheContractionBreaks(const std::vector<CodepointInfo>& cps,
                                        std::vector<Hyphenator::BreakInfo>& outBreaks) {
   constexpr size_t kMinLeftSegmentLen = 3;
-  constexpr size_t kMinRightSegmentLen = 2;
+  constexpr size_t kMinRightSegmentLen = 3;
   size_t segmentStart = 0;
 
   for (size_t i = 0; i < cps.size(); ++i) {
@@ -123,7 +123,7 @@ void appendApostropheContractionBreaks(const std::vector<CodepointInfo>& cps,
           }
         }
 
-        // Avoid stranding short clitics like "l'"/"d'" or tiny suffixes like "'t".
+        // Avoid stranding short clitics like "l'"/"d'" or contraction tails like "'ve"/"'re"/"'ll".
         if (leftPrefixLen >= kMinLeftSegmentLen && rightSuffixLen >= kMinRightSegmentLen) {
           outBreaks.push_back({cps[i + 1].byteOffset, false});
         }

--- a/lib/Epub/Epub/hyphenation/Hyphenator.h
+++ b/lib/Epub/Epub/hyphenation/Hyphenator.h
@@ -26,8 +26,8 @@ class Hyphenator {
   //   2. Apostrophe contractions between letters (e.g. all'improvviso).
   //      Liang patterns are run per alphabetic segment around apostrophes.
   //      A direct break at the apostrophe boundary is allowed only when the left
-  //      segment has at least 3 letters and the right segment has at least 2 letters,
-  //      avoiding short clitics (e.g. l', d') and short contraction tails (e.g. can't).
+  //      segment has at least 3 letters and the right segment has at least 3 letters,
+  //      avoiding short clitics (e.g. l', d') and contraction tails (e.g. 've, 're, 'll).
   //   3. Language-specific Liang patterns (e.g. German de_patterns).
   //      Example: "Quadratkilometer" -> Qua|drat|ki|lo|me|ter.
   //   4. Fallback every-N-chars splitting (only when includeFallback is true AND no


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Follow up to 3dabd30287fd164282fccca3f6a04aa736e05d4a: prevent line breaks in common English contractions with two tail characters. Prior to this change, I saw a line break inserted in "they've" as "they'" | "ve".

Fixes #1403

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
