### PR TITLE
fix: Build with -fno-exceptions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,9 +36,11 @@ build_flags =
   -DPNG_MAX_BUFFERED_PIXELS=16416
   -Wno-bidi-chars
   -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort
+  -fno-exceptions
 
 build_unflags =
   -std=gnu++11
+  -fexceptions
 
 ; Board configuration
 board_build.flash_mode = dio


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Until today, I sincerely thought we were building without exception support. The codebase is not set up with any exception handling infrastructure. The SKILL.md file specifies no exceptions. 

I just learned that we actually were building with exceptions enabled, with `-fexceptions` coming from ~/.platformio/packages/framework-arduinoespressif32-libs/esp32c3/pioarduino-build.py. 

This change removes the `-fexceptions` flag and adds `-fno-exceptions`. The result is **53,670 bytes in flash savings**.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
