### PR TITLE
refactor: Use C++20 'requires' in ActivityResult constructor

### DIFF
--- a/src/activities/ActivityResult.h
+++ b/src/activities/ActivityResult.h
@@ -59,7 +59,8 @@ struct ActivityResult {
 
   explicit ActivityResult() = default;
 
-  template <typename ResultType, typename = std::enable_if_t<std::is_constructible_v<ResultVariant, ResultType&&>>>
+  template <typename ResultType>
+    requires std::is_constructible_v<ResultVariant, ResultType&&>
   // cppcheck-suppress noExplicitConstructor
   ActivityResult(ResultType&& result) : data{std::forward<ResultType>(result)} {}
 };


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Replace SFINAE std::enable_if_t with a C++20 `requires` clause for clearer constraint expression and better compiler diagnostics on mismatch.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
