### PR TITLE
chore: Update SKILL.md to reflect generated i18n files are gitignored

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -664,7 +664,7 @@ Tested in all 4 orientations with 5MB+ files.
    - `lib/I18n/I18nKeys.h`, `lib/I18n/I18nStrings.h`, `lib/I18n/I18nStrings.cpp`
    - **Source**: YAML translation files in `lib/I18n/translations/` (one per language)
    - **To modify**: Edit source YAML files, then run `python scripts/gen_i18n.py lib/I18n/translations lib/I18n/`
-   - **Commit**: Source YAML files + `I18nKeys.h` and `I18nStrings.h` (needed for IDE symbol resolution), but NOT `I18nStrings.cpp`
+   - **Commit**: Source YAML files only. All three generated files (`I18nKeys.h`, `I18nStrings.h`, `I18nStrings.cpp`) are in `.gitignore` and regenerated at build time.
 
 3. **Build Artifacts** (in `.gitignore`):
    - `.pio/` - PlatformIO build output
@@ -686,7 +686,7 @@ Tested in all 4 orientations with 5MB+ files.
    - English (`english.yaml`) is the reference; missing keys in other languages fall back to English
 2. Run generator: `python scripts/gen_i18n.py lib/I18n/translations lib/I18n/`
 3. Generated files update: `I18nKeys.h`, `I18nStrings.h`, `I18nStrings.cpp`
-4. **Commit** source YAML files + `I18nKeys.h` and `I18nStrings.h` (IDE needs these for symbol resolution), but NOT `I18nStrings.cpp`
+4. **Commit** source YAML files only. All three generated files are in `.gitignore` and regenerated at build time.
 
 **To use translated strings in code**:
 ```cpp


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Update SKILL.md to stop instructing contributors to commit `I18nKeys.h` and `I18nStrings.h`. All three generated i18n files have been gitignored since ff577540 and are regenerated at build time.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
