### PR TITLE
refactor: Use default member initializers for JpegContext and PngContext

### DIFF
--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -18,38 +18,25 @@ namespace {
 // The draw callback receives this via pDraw->pUser (set by setUserPointer()).
 // The file I/O callbacks receive the FsFile* via pFile->fHandle (set by jpegOpen()).
 struct JpegContext {
-  GfxRenderer* renderer;
-  const RenderConfig* config;
-  int screenWidth;
-  int screenHeight;
+  GfxRenderer* renderer{nullptr};
+  const RenderConfig* config{nullptr};
+  int screenWidth{0};
+  int screenHeight{0};
 
   // Source dimensions after JPEGDEC's built-in scaling
-  int scaledSrcWidth;
-  int scaledSrcHeight;
+  int scaledSrcWidth{0};
+  int scaledSrcHeight{0};
 
   // Final output dimensions
-  int dstWidth;
-  int dstHeight;
+  int dstWidth{0};
+  int dstHeight{0};
 
   // Fine scale in 16.16 fixed-point (ESP32-C3 has no FPU)
-  int32_t fineScaleFP;  // src -> dst mapping
-  int32_t invScaleFP;   // dst -> src mapping
+  int32_t fineScaleFP{1 << 16};  // src -> dst mapping
+  int32_t invScaleFP{1 << 16};   // dst -> src mapping
 
   PixelCache cache;
-  bool caching;
-
-  JpegContext()
-      : renderer(nullptr),
-        config(nullptr),
-        screenWidth(0),
-        screenHeight(0),
-        scaledSrcWidth(0),
-        scaledSrcHeight(0),
-        dstWidth(0),
-        dstHeight(0),
-        fineScaleFP(1 << 16),
-        invScaleFP(1 << 16),
-        caching(false) {}
+  bool caching{false};
 };
 
 // File I/O callbacks use pFile->fHandle to access the FsFile*,

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -18,37 +18,23 @@ namespace {
 // The draw callback receives this via pDraw->pUser (set by png.decode()).
 // The file I/O callbacks receive the FsFile* via pFile->fHandle (set by pngOpen()).
 struct PngContext {
-  GfxRenderer* renderer;
-  const RenderConfig* config;
-  int screenWidth;
-  int screenHeight;
+  GfxRenderer* renderer{nullptr};
+  const RenderConfig* config{nullptr};
+  int screenWidth{0};
+  int screenHeight{0};
 
   // Scaling state
-  float scale;
-  int srcWidth;
-  int srcHeight;
-  int dstWidth;
-  int dstHeight;
-  int lastDstY;  // Track last rendered destination Y to avoid duplicates
+  float scale{1.f};
+  int srcWidth{0};
+  int srcHeight{0};
+  int dstWidth{0};
+  int dstHeight{0};
+  int lastDstY{-1};  // Track last rendered destination Y to avoid duplicates
 
   PixelCache cache;
-  bool caching;
+  bool caching{false};
 
-  uint8_t* grayLineBuffer;
-
-  PngContext()
-      : renderer(nullptr),
-        config(nullptr),
-        screenWidth(0),
-        screenHeight(0),
-        scale(1.0f),
-        srcWidth(0),
-        srcHeight(0),
-        dstWidth(0),
-        dstHeight(0),
-        lastDstY(-1),
-        caching(false),
-        grayLineBuffer(nullptr) {}
+  uint8_t* grayLineBuffer{nullptr};
 };
 
 // File I/O callbacks use pFile->fHandle to access the FsFile*,


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Replace verbose constructor initializer lists with in-class default member initializers in JpegContext and PngContext

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
