### PR TITLE
fix: Use theme metrics for ChapterSelectionActivity, fix truncation

### DIFF
--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -125,7 +125,7 @@ void EpubReaderChapterSelectionActivity::render(RenderLock&&) {
 
     // Indent per TOC level while keeping content within the gutter-safe region.
     const int indentSize = contentX + metrics.contentSidePadding + (item.level - 1) * 15;
-    const int availableWidth = contentWidth - indentSize - metrics.contentSidePadding;
+    const int availableWidth = contentWidth - (indentSize - contentX) - metrics.contentSidePadding;
     const std::string chapterName = renderer.truncatedText(UI_10_FONT_ID, item.title.c_str(), availableWidth);
 
     renderer.drawText(UI_10_FONT_ID, indentSize, displayY, chapterName.c_str(), !isSelected);


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Use theme metrics to calculate side margins in the epub chapter select activity, avoid prematurely truncating chapter names.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_
