### PR TITLE
fix: Overlapping battery percentage on image pages with anti-aliasing

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -732,8 +732,8 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);
 
       // Re-render page content to restore images into the blanked area
+      // Status bar is not re-rendered here to avoid reading stale dynamic values (e.g. battery %)
       page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
-      renderStatusBar();
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);
     } else {
       renderer.displayBuffer(HalDisplay::HALF_REFRESH);


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

When viewing a page with images and anti-aliasing enabled, the `imagePageWithAA` path renders the page twice with fast refreshes (blank image area, then restore). Both passes called `renderStatusBar()`, which reads the battery percentage live. If the value changed between the two renders (e.g. 88% -> 87%), the digits would overlap on screen.                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                            
Fix: Removed the redundant `renderStatusBar()` from the second BW render. The status bar is already drawn and displayed in the first pass, and only the image area needs restoration.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
