### PR TITLE
fix: webserver /delete API backward compatibility

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -959,16 +959,31 @@ void CrossPointWebServer::handleMove() const {
 }
 
 void CrossPointWebServer::handleDelete() const {
-  // Check if 'paths' argument is provided
-  if (!server->hasArg("paths")) {
-    server->send(400, "text/plain", "Missing paths");
+  // To ensure backwards compatibility, plain `path` is mapped
+  // to a single element JSON array.
+  bool hasPathArg = server->hasArg("path");
+  bool hasPathsArg = server->hasArg("paths");
+  // Check 'paths' or `path` argument is provided
+  if (!(hasPathArg || hasPathsArg)) {
+    server->send(400, "text/plain", "Missing `path` or `paths` argument");
+    return;
+  }
+  if (hasPathArg && hasPathsArg) {
+    server->send(400, "text/plain", "Provide either 'path' or 'paths', not both");
     return;
   }
 
   // Parse paths
-  String pathsArg = server->arg("paths");
+  String pathsArg;
   JsonDocument doc;
-  DeserializationError error = deserializeJson(doc, pathsArg);
+  DeserializationError error = DeserializationError(DeserializationError::Code::Ok);
+  if (hasPathsArg) {
+    pathsArg = server->arg("paths");
+    error = deserializeJson(doc, pathsArg);
+  } else {
+    pathsArg = server->arg("path");
+    doc.add(pathsArg);
+  }
   if (error) {
     server->send(400, "text/plain", "Invalid paths format");
     return;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)

This fixes #682 by restoring API compatibility for external users, eg deleting on-device books in bulk via calibre using the crosspoint plugin works now.

* **What changes are included?**

The `/delete` webserver API now accepts the old `path` argument and maps it to a JSON array element. It is made an error to provide both arguments.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

I have compiled, flashed, and tested this on master at commit 0245972132b54563976525a5841a0e9c49e8e498. Before this change, calibre cannot delete books, either individually or in bulk.

After this change, it can do so successfully.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
