### PR TITLE
fix: Fix failing very first wifi connection attempt

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -217,7 +217,10 @@ void WifiSelectionActivity::attemptConnection() {
   connectionError.clear();
   requestUpdate();
 
+  WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
   WiFi.mode(WIFI_STA);
+  WiFi.disconnect(true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
+  delay(100);
 
   // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
   String mac = WiFi.macAddress();

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -219,7 +219,7 @@ void WifiSelectionActivity::attemptConnection() {
 
   WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
   WiFi.mode(WIFI_STA);
-  WiFi.disconnect(true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
+  WiFi.disconnect(true, true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
   delay(100);
 
   // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** The very first Wifi connection attempt with saved credentials failed, subsequent attempts succeeded. This PR fixes the first-attempt-issue.
* **What changes are included?**

## Additional Context
Claude analysis for WifiSelectionActivity

In attemptConnection() ,there's no WiFi.disconnect() before WiFi.begin() — unlike the scan path earlier which does do a disconnect first.

The root cause on ESP32 is the built-in auto-connect feature: the ESP32 WiFi stack saves credentials to NVS flash and automatically starts trying to connect on boot before your application code runs. When your attemptConnection() then calls WiFi.begin(), the stack is already in a transitional CONNECTING state, and the new begin() call either gets ignored or collides with the in-progress attempt.

The fix is to add WiFi.disconnect(true) + a short delay in attemptConnection() before calling WiFi.begin(), and optionally call WiFi.persistent(false) to stop the ESP32 from auto-connecting on its own.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
