### PR TITLE
refactor: Make screenshot generation resolution agnostic and orientation aware

### DIFF
--- a/scripts/debugging_monitor.py
+++ b/scripts/debugging_monitor.py
@@ -179,6 +179,7 @@ def parse_memory_line(line: str) -> tuple[int | None, int | None, int | None]:
     Format: Free: N bytes, Total: N bytes, Min Free: N bytes, MaxAlloc: N bytes
     Returns: (free_bytes, total_bytes, max_alloc_bytes)
     """
+
     def _find(pattern: str) -> int | None:
         m = re.search(pattern, line)
         if m:
@@ -221,6 +222,9 @@ def serial_worker(ser, kwargs: dict[str, str]) -> None:
 
     expecting_screenshot = False
     screenshot_size = 0
+    screenshot_width = 0
+    screenshot_height = 0
+    screenshot_orientation = 0
     screenshot_data = b""
 
     try:
@@ -232,9 +236,18 @@ def serial_worker(ser, kwargs: dict[str, str]) -> None:
                 screenshot_data += data
                 if len(screenshot_data) == screenshot_size:
                     if Image:
-                        img = Image.frombytes("1", (800, 480), screenshot_data)
-                        # We need to rotate the image because the raw data is in landscape mode
-                        img = img.transpose(Image.ROTATE_270)
+                        img = Image.frombytes(
+                            "1", (screenshot_width, screenshot_height), screenshot_data
+                        )
+                        # Rotate raw framebuffer to match the selected display orientation
+                        # 0=Portrait, 1=LandscapeCW, 2=PortraitInverted, 3=LandscapeCCW
+                        if screenshot_orientation == 0:
+                            img = img.transpose(Image.Transpose.ROTATE_270)
+                        elif screenshot_orientation == 1:
+                            img = img.transpose(Image.Transpose.ROTATE_180)
+                        elif screenshot_orientation == 2:
+                            img = img.transpose(Image.Transpose.ROTATE_90)
+                        # 3 = LandscapeCCW = native panel orientation, no rotation needed
                         img.save("screenshot.bmp")
                         print(
                             f"{Fore.GREEN}Screenshot saved to screenshot.bmp{Style.RESET_ALL}"
@@ -259,7 +272,11 @@ def serial_worker(ser, kwargs: dict[str, str]) -> None:
                         continue
 
                     if clean_line.startswith("SCREENSHOT_START:"):
-                        screenshot_size = int(clean_line.split(":")[1])
+                        parts = clean_line.split(":")
+                        screenshot_size = int(parts[1])
+                        screenshot_width = int(parts[2]) if len(parts) > 2 else 800
+                        screenshot_height = int(parts[3]) if len(parts) > 3 else 480
+                        screenshot_orientation = int(parts[4]) if len(parts) > 4 else 0
                         expecting_screenshot = True
                         continue
                     elif clean_line == "SCREENSHOT_END":
@@ -271,7 +288,9 @@ def serial_worker(ser, kwargs: dict[str, str]) -> None:
 
                     # Check for Memory Line
                     if "[MEM]" in formatted_line:
-                        free_val, total_val, max_alloc_val = parse_memory_line(formatted_line)
+                        free_val, total_val, max_alloc_val = parse_memory_line(
+                            formatted_line
+                        )
                         if free_val is not None and total_val is not None:
                             with data_lock:
                                 time_data.append(pc_time)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,7 +332,8 @@ void loop() {
       String cmd = line.substring(4);
       cmd.trim();
       if (cmd == "SCREENSHOT") {
-        logSerial.printf("SCREENSHOT_START:%d\n", HalDisplay::BUFFER_SIZE);
+        logSerial.printf("SCREENSHOT_START:%d:%d:%d:%d\n", HalDisplay::BUFFER_SIZE, HalDisplay::DISPLAY_WIDTH,
+                         HalDisplay::DISPLAY_HEIGHT, static_cast<int>(renderer.getOrientation()));
         uint8_t* buf = display.getFrameBuffer();
         logSerial.write(buf, HalDisplay::BUFFER_SIZE);
         logSerial.printf("SCREENSHOT_END\n");

--- a/src/util/ScreenshotUtil.cpp
+++ b/src/util/ScreenshotUtil.cpp
@@ -15,7 +15,7 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
   if (fb) {
     String filename_str = "/screenshots/screenshot-" + String(millis()) + ".bmp";
     if (ScreenshotUtil::saveFramebufferAsBmp(filename_str.c_str(), fb, HalDisplay::DISPLAY_WIDTH,
-                                             HalDisplay::DISPLAY_HEIGHT)) {
+                                             HalDisplay::DISPLAY_HEIGHT, renderer.getOrientation())) {
       LOG_DBG("SCR", "Screenshot saved to %s", filename_str.c_str());
     } else {
       LOG_ERR("SCR", "Failed to save screenshot");
@@ -26,7 +26,7 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
 
   // Display a border around the screen to indicate a screenshot was taken
   if (renderer.storeBwBuffer()) {
-    renderer.drawRect(6, 6, HalDisplay::DISPLAY_HEIGHT - 12, HalDisplay::DISPLAY_WIDTH - 12, 2, true);
+    renderer.drawRect(6, 6, renderer.getScreenWidth() - 12, renderer.getScreenHeight() - 12, 2, true);
     renderer.displayBuffer();
     delay(1000);
     renderer.restoreBwBuffer();
@@ -34,14 +34,27 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
   }
 }
 
-bool ScreenshotUtil::saveFramebufferAsBmp(const char* filename, const uint8_t* framebuffer, int width, int height) {
+bool ScreenshotUtil::saveFramebufferAsBmp(const char* filename, const uint8_t* framebuffer, int width, int height,
+                                          GfxRenderer::Orientation orientation) {
   if (!framebuffer) {
     return false;
   }
 
-  // Note: the width and height, we rotate the image 90d counter-clockwise to match the default display orientation
-  int phyWidth = height;
-  int phyHeight = width;
+  // Determine logical (output BMP) dimensions based on orientation
+  int bmpWidth, bmpHeight;
+  switch (orientation) {
+    case GfxRenderer::Portrait:
+    case GfxRenderer::PortraitInverted:
+      bmpWidth = height;
+      bmpHeight = width;
+      break;
+    case GfxRenderer::LandscapeClockwise:
+    case GfxRenderer::LandscapeCounterClockwise:
+    default:
+      bmpWidth = width;
+      bmpHeight = height;
+      break;
+  }
 
   std::string path(filename);
   size_t last_slash = path.find_last_of('/');
@@ -62,7 +75,7 @@ bool ScreenshotUtil::saveFramebufferAsBmp(const char* filename, const uint8_t* f
 
   BmpHeader header;
 
-  createBmpHeader(&header, phyWidth, phyHeight);
+  createBmpHeader(&header, bmpWidth, bmpHeight);
 
   bool write_error = false;
   if (file.write(reinterpret_cast<uint8_t*>(&header), sizeof(header)) != sizeof(header)) {
@@ -75,9 +88,11 @@ bool ScreenshotUtil::saveFramebufferAsBmp(const char* filename, const uint8_t* f
     return false;
   }
 
-  const uint32_t rowSizePadded = (phyWidth + 31) / 32 * 4;
-  // Max row size for 480px width = 60 bytes; use fixed buffer to avoid VLA
-  constexpr size_t kMaxRowSize = 64;
+  const uint32_t rowSizePadded = (bmpWidth + 31) / 32 * 4;
+  // Derive max row size from the largest display dimension (covers any orientation)
+  constexpr int maxDim =
+      HalDisplay::DISPLAY_WIDTH > HalDisplay::DISPLAY_HEIGHT ? HalDisplay::DISPLAY_WIDTH : HalDisplay::DISPLAY_HEIGHT;
+  constexpr size_t kMaxRowSize = (maxDim + 31) / 32 * 4;
   if (rowSizePadded > kMaxRowSize) {
     LOG_ERR("SCR", "Row size %u exceeds buffer capacity", rowSizePadded);
     file.close();
@@ -85,18 +100,46 @@ bool ScreenshotUtil::saveFramebufferAsBmp(const char* filename, const uint8_t* f
     return false;
   }
 
-  // rotate the image 90d counter-clockwise on-the-fly while writing to save memory
+  // Transform framebuffer pixels to match the selected orientation on-the-fly
+  // BMP rows are bottom-to-top, so outY=0 is the bottom of the displayed image
   uint8_t rowBuffer[kMaxRowSize];
   memset(rowBuffer, 0, rowSizePadded);
 
-  for (int outY = 0; outY < phyHeight; outY++) {
-    for (int outX = 0; outX < phyWidth; outX++) {
-      // 90d counter-clockwise: source (srcX, srcY)
-      // BMP rows are bottom-to-top, so outY=0 is the bottom of the displayed image
-      int srcX = width - 1 - outY;     // phyHeight == width
-      int srcY = phyWidth - 1 - outX;  // phyWidth == height
-      int fbIndex = srcY * (width / 8) + (srcX / 8);
-      uint8_t pixel = (framebuffer[fbIndex] >> (7 - (srcX % 8))) & 0x01;
+  const int W = width;   // physical panel width (DISPLAY_WIDTH)
+  const int H = height;  // physical panel height (DISPLAY_HEIGHT)
+
+  for (int outY = 0; outY < bmpHeight; outY++) {
+    for (int outX = 0; outX < bmpWidth; outX++) {
+      // Map BMP output pixel to logical coordinates
+      // outY=0 is BMP bottom row = logical row (bmpHeight-1)
+      int logX = outX;
+      int logY = bmpHeight - 1 - outY;
+
+      // Map logical coordinates to physical framebuffer coordinates
+      // (same transform as rotateCoordinates in GfxRenderer)
+      int phyX, phyY;
+      switch (orientation) {
+        case GfxRenderer::Portrait:
+          phyX = logY;
+          phyY = H - 1 - logX;
+          break;
+        case GfxRenderer::LandscapeClockwise:
+          phyX = W - 1 - logX;
+          phyY = H - 1 - logY;
+          break;
+        case GfxRenderer::PortraitInverted:
+          phyX = W - 1 - logY;
+          phyY = logX;
+          break;
+        case GfxRenderer::LandscapeCounterClockwise:
+        default:
+          phyX = logX;
+          phyY = logY;
+          break;
+      }
+
+      int fbIndex = phyY * (W / 8) + (phyX / 8);
+      uint8_t pixel = (framebuffer[fbIndex] >> (7 - (phyX % 8))) & 0x01;
       rowBuffer[outX / 8] |= pixel << (7 - (outX % 8));
     }
     if (file.write(rowBuffer, rowSizePadded) != rowSizePadded) {

--- a/src/util/ScreenshotUtil.h
+++ b/src/util/ScreenshotUtil.h
@@ -4,5 +4,6 @@
 class ScreenshotUtil {
  public:
   static void takeScreenshot(GfxRenderer& renderer);
-  static bool saveFramebufferAsBmp(const char* filename, const uint8_t* framebuffer, int width, int height);
+  static bool saveFramebufferAsBmp(const char* filename, const uint8_t* framebuffer, int width, int height,
+                                   GfxRenderer::Orientation orientation);
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
With the X3 and de-link around the corner, which support different resolutions, it was time to overhaul the screenshot utilities:
  - BMP screenshots now respect the active display orientation instead of always assuming Portrait
  - Removed all hardcoded 800×480 assumptions — dimensions are derived from HalDisplay constants, ready for X3 support
  - Extended the serial SCREENSHOT_START protocol to include width, height, and orientation (SCREENSHOT_START:<size>:<width>:<height>:<orientation>), with backward-compatible fallback in the Python monitor
  -  Fixed the screenshot feedback border to use logical screen dimensions via renderer.getScreenWidth()/getScreenHeight()
* **What changes are included?**

## Additional Context

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
