### PR TITLE
[feat] Add Battery to Status in Web Server

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -3,6 +3,7 @@
 #include <ArduinoJson.h>
 #include <Epub.h>
 #include <FsHelpers.h>
+#include <HalPowerManager.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <WiFi.h>
@@ -342,12 +343,14 @@ void CrossPointWebServer::handleNotFound() const {
 void CrossPointWebServer::handleStatus() const {
   // Get correct IP based on AP vs STA mode
   const String ipAddr = apMode ? WiFi.softAPIP().toString() : WiFi.localIP().toString();
+  const uint16_t batteryPercentage = powerManager.getBatteryPercentage();
 
   JsonDocument doc;
   doc["version"] = CROSSPOINT_VERSION;
   doc["ip"] = ipAddr;
   doc["mode"] = apMode ? "AP" : "STA";
   doc["rssi"] = apMode ? 0 : WiFi.RSSI();
+  doc["batteryPercentage"] = batteryPercentage;
   doc["freeHeap"] = ESP.getFreeHeap();
   doc["uptime"] = millis() / 1000;
 


### PR DESCRIPTION
## Summary
This PR adds a new status field for battery percentage to the `/api/status` endpoint of the CrossPoint web server.

Additionally, it uses this field to display the battery percentage on the web server's home page alongside the existing information.

<img width="867" height="819" alt="Screenshot 2026-03-30 at 7 19 43 PM" src="https://github.com/user-attachments/assets/09cdd3a2-20eb-4f2f-9a39-17b9aab703d4" />