### PR TITLE
refactor: logPrintf and predefined log level strings

### DIFF
--- a/lib/Logging/Logging.cpp
+++ b/lib/Logging/Logging.cpp
@@ -38,37 +38,26 @@ void logPrintf(const char* level, const char* origin, const char* format, ...) {
   va_start(args, format);
   char buf[MAX_ENTRY_LEN];
   char* c = buf;
-  // add the timestamp
+  // add timestamp, level and origin
   {
     unsigned long ms = millis();
-    int len = snprintf(c, sizeof(buf), "[%lu] ", ms);
+    int len = snprintf(c, sizeof(buf), "[%lu] [%s] [%s] ", ms, level, origin);
+    // erro while writing => return
     if (len < 0) {
-      return;  // encoding error, skip logging
+      va_end(args);
+      return;
     }
-    c += len;
-  }
-  // add the level
-  {
-    const char* p = level;
-    size_t remaining = sizeof(buf) - (c - buf);
-    while (*p && remaining > 1) {
-      *c++ = *p++;
-      remaining--;
-    }
-    if (remaining > 1) {
-      *c++ = ' ';
-    }
-  }
-  // add the origin
-  {
-    int len = snprintf(c, sizeof(buf) - (c - buf), "[%s] ", origin);
-    if (len < 0) {
-      return;  // encoding error, skip logging
-    }
-    c += len;
+    // clamp c to be in buffer range
+    c += std::min(len, MAX_ENTRY_LEN);
   }
   // add the user message
-  vsnprintf(c, sizeof(buf) - (c - buf), format, args);
+  {
+    int len = vsnprintf(c, sizeof(buf) - (c - buf), format, args);
+    if (len < 0) {
+      va_end(args);
+      return;
+    }
+  }
   va_end(args);
   if (logSerial) {
     logSerial.print(buf);

--- a/lib/Logging/Logging.h
+++ b/lib/Logging/Logging.h
@@ -33,19 +33,19 @@ void logPrintf(const char* level, const char* origin, const char* format, ...);
 
 #ifdef ENABLE_SERIAL_LOG
 #if LOG_LEVEL >= 0
-#define LOG_ERR(origin, format, ...) logPrintf("[ERR]", origin, format "\n", ##__VA_ARGS__)
+#define LOG_ERR(origin, format, ...) logPrintf("ERR", origin, format "\n", ##__VA_ARGS__)
 #else
 #define LOG_ERR(origin, format, ...)
 #endif
 
 #if LOG_LEVEL >= 1
-#define LOG_INF(origin, format, ...) logPrintf("[INF]", origin, format "\n", ##__VA_ARGS__)
+#define LOG_INF(origin, format, ...) logPrintf("INF", origin, format "\n", ##__VA_ARGS__)
 #else
 #define LOG_INF(origin, format, ...)
 #endif
 
 #if LOG_LEVEL >= 2
-#define LOG_DBG(origin, format, ...) logPrintf("[DBG]", origin, format "\n", ##__VA_ARGS__)
+#define LOG_DBG(origin, format, ...) logPrintf("DBG", origin, format "\n", ##__VA_ARGS__)
 #else
 #define LOG_DBG(origin, format, ...)
 #endif


### PR DESCRIPTION
## Summary

* More consistent string formatting in logPrintf
* Moved [ and ] from log level strings into new format string
* Behaviour change: Early exit if user string format fails

## Additional Context

* Should not have performance implications, debug monitor etc work as before
* Clamp may be unnecessary due to information snprintf currently never being able to exceed max buffer length, but not having it would bug me

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY, to reason about correctness**_
