### PR TITLE
feat: render ordered and unordered HTML list items with correct markers

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -554,10 +554,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
   }
 
-  // Track ul/ol nesting so li markers can be numbered or bulleted accordingly
   if (strcmp(name, "ul") == 0 || strcmp(name, "ol") == 0) {
-    self->listStack.push_back({self->depth, strcmp(name, "ol") == 0, 0});
-    // fall through to depth increment
+    self->listStack.push_back({self->depth, name[0] == 'o', 0});
   }
 
   const float emSize = static_cast<float>(self->renderer.getFontAscenderSize(self->fontId));
@@ -592,7 +590,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
           self->listStack.back().counter += 1;
           snprintf(marker, sizeof(marker), "%d.", self->listStack.back().counter);
         } else {
-          strncpy(marker, "\xe2\x80\xa2", sizeof(marker));
+          strcpy(marker, "\xe2\x80\xa2");
         }
         self->currentTextBlock->addWord(marker, EpdFontFamily::REGULAR);
       }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -554,6 +554,12 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
   }
 
+  // Track ul/ol nesting so li markers can be numbered or bulleted accordingly
+  if (strcmp(name, "ul") == 0 || strcmp(name, "ol") == 0) {
+    self->listStack.push_back({self->depth, strcmp(name, "ol") == 0, 0});
+    // fall through to depth increment
+  }
+
   const float emSize = static_cast<float>(self->renderer.getFontAscenderSize(self->fontId));
   const auto userAlignmentBlockStyle = BlockStyle::fromCssStyle(
       cssStyle, emSize, static_cast<CssTextAlign>(self->paragraphAlignment), self->viewportWidth);
@@ -581,7 +587,14 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {
-        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+        char marker[12];
+        if (!self->listStack.empty() && self->listStack.back().isOrdered) {
+          self->listStack.back().counter += 1;
+          snprintf(marker, sizeof(marker), "%d.", self->listStack.back().counter);
+        } else {
+          strncpy(marker, "\xe2\x80\xa2", sizeof(marker));
+        }
+        self->currentTextBlock->addWord(marker, EpdFontFamily::REGULAR);
       }
     }
   } else if (matches(name, UNDERLINE_TAGS, NUM_UNDERLINE_TAGS)) {
@@ -892,6 +905,11 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   }
 
   self->depth -= 1;
+
+  // Pop list entries whose ul/ol is now out of scope
+  while (!self->listStack.empty() && self->listStack.back().depth >= self->depth) {
+    self->listStack.pop_back();
+  }
 
   // Closing a footnote link — create entry from collected text and href
   if (self->insideFootnoteLink && self->depth == self->footnoteLinkDepth) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -70,6 +70,14 @@ class ChapterHtmlSlimParser {
   int tableRowIndex = 0;
   int tableColIndex = 0;
 
+  // List nesting tracking for ul/ol markers
+  struct ListEntry {
+    int depth;
+    bool isOrdered;
+    int counter;
+  };
+  std::vector<ListEntry> listStack;
+
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;
   std::vector<std::pair<std::string, uint16_t>> anchorData;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -70,7 +70,6 @@ class ChapterHtmlSlimParser {
   int tableRowIndex = 0;
   int tableColIndex = 0;
 
-  // List nesting tracking for ul/ol markers
   struct ListEntry {
     int depth;
     bool isOrdered;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Improve rendering of HTML lists so that `<ol>` items display numbered markers (`1.`, `2.`, …) and `<ul>` items continue to display bullet (`•`) markers. Previously all `<li>` elements received a hardcoded bullet regardless of list type.
* **What changes are included?**
  - Added a `ListEntry` depth-tracking stack (`listStack`) to `ChapterHtmlSlimParser`, pushed on `<ul>`/`<ol>` open and popped on close.
  - `<li>` handler now checks the innermost list entry: ordered lists increment a per-list counter and emit `"N."`, unordered lists emit `•` as before.
  - Orphan `<li>` (no enclosing list element) falls back to `•`.
  - Nested and sequential lists handled correctly by the depth-based push/pop.

## Additional Context

* The approach is adapted from the papyrix-reader implementation (commit `4111df0`) but simplified for this codebase: no suspend/resume path means no `pendingListMarker_` buffer is needed.
* Stack depth in practice is 1–3 levels; `std::vector` overhead is negligible.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_