### PR TITLE
chore: Remember and use last known mac address for immediate display

### DIFF
--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -248,6 +248,7 @@ bool JsonSettingsIO::loadKOReader(KOReaderCredentialStore& store, const char* js
 bool JsonSettingsIO::saveWifi(const WifiCredentialStore& store, const char* path) {
   JsonDocument doc;
   doc["lastConnectedSsid"] = store.getLastConnectedSsid();
+  doc["lastKnownMacAddress"] = store.getLastKnownMacAddress();
 
   JsonArray arr = doc["credentials"].to<JsonArray>();
   for (const auto& cred : store.getCredentials()) {
@@ -271,6 +272,7 @@ bool JsonSettingsIO::loadWifi(WifiCredentialStore& store, const char* json, bool
   }
 
   store.lastConnectedSsid = doc["lastConnectedSsid"] | std::string("");
+  store.lastKnownMacAddress = doc["lastKnownMacAddress"] | std::string("");
 
   store.credentials.clear();
   JsonArray arr = doc["credentials"].as<JsonArray>();

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 #include <ObfuscationUtils.h>
 
+#include <cctype>
 #include <cstring>
 #include <string>
 
@@ -272,7 +273,33 @@ bool JsonSettingsIO::loadWifi(WifiCredentialStore& store, const char* json, bool
   }
 
   store.lastConnectedSsid = doc["lastConnectedSsid"] | std::string("");
+
+  const auto isValidDashedMac = [](const std::string& value) -> bool {
+    if (value.empty()) {
+      return true;
+    }
+    if (value.size() != 17) {
+      return false;
+    }
+    for (size_t i = 0; i < value.size(); i++) {
+      if (i == 2 || i == 5 || i == 8 || i == 11 || i == 14) {
+        if (value[i] != '-') {
+          return false;
+        }
+      } else if (!std::isxdigit(static_cast<unsigned char>(value[i]))) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   store.lastKnownMacAddress = doc["lastKnownMacAddress"] | std::string("");
+  if (!isValidDashedMac(store.lastKnownMacAddress)) {
+    store.lastKnownMacAddress.clear();
+    if (needsResave) {
+      *needsResave = true;
+    }
+  }
 
   store.credentials.clear();
   JsonArray arr = doc["credentials"].as<JsonArray>();

--- a/src/WifiCredentialStore.cpp
+++ b/src/WifiCredentialStore.cpp
@@ -168,9 +168,19 @@ void WifiCredentialStore::clearLastConnectedSsid() {
   }
 }
 
+void WifiCredentialStore::setLastKnownMacAddress(const std::string& mac) {
+  if (lastKnownMacAddress != mac) {
+    lastKnownMacAddress = mac;
+    saveToFile();
+  }
+}
+
+const std::string& WifiCredentialStore::getLastKnownMacAddress() const { return lastKnownMacAddress; }
+
 void WifiCredentialStore::clearAll() {
   credentials.clear();
   lastConnectedSsid.clear();
+  lastKnownMacAddress.clear();
   saveToFile();
   LOG_DBG("WCS", "Cleared all WiFi credentials");
 }

--- a/src/WifiCredentialStore.h
+++ b/src/WifiCredentialStore.h
@@ -24,6 +24,7 @@ class WifiCredentialStore {
   static WifiCredentialStore instance;
   std::vector<WifiCredential> credentials;
   std::string lastConnectedSsid;
+  std::string lastKnownMacAddress;
 
   static constexpr size_t MAX_NETWORKS = 8;
 
@@ -62,6 +63,10 @@ class WifiCredentialStore {
   void setLastConnectedSsid(const std::string& ssid);
   const std::string& getLastConnectedSsid() const;
   void clearLastConnectedSsid();
+
+  // Last known device MAC (formatted as AA-BB-CC-DD-EE-FF for instant UI display)
+  void setLastKnownMacAddress(const std::string& mac);
+  const std::string& getLastKnownMacAddress() const;
 
   // Clear all credentials
   void clearAll();

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -13,6 +13,27 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 
+namespace {
+
+bool isLikelyValidMac(const uint8_t mac[6]) {
+  bool allZero = true;
+  bool allFF = true;
+  for (int i = 0; i < 6; i++) {
+    allZero = allZero && (mac[i] == 0x00);
+    allFF = allFF && (mac[i] == 0xFF);
+  }
+  return !allZero && !allFF;
+}
+
+std::string formatMacLabel(const uint8_t mac[6]) {
+  char macStr[64];
+  snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS), mac[0], mac[1], mac[2],
+           mac[3], mac[4], mac[5]);
+  return std::string(macStr);
+}
+
+}  // namespace
+
 void WifiSelectionActivity::onEnter() {
   Activity::onEnter();
 
@@ -21,6 +42,13 @@ void WifiSelectionActivity::onEnter() {
   {
     RenderLock lock(*this);
     WIFI_STORE.loadFromFile();
+  }
+
+  // Show persisted MAC immediately so UI doesn't briefly display a bogus value.
+  if (!WIFI_STORE.getLastKnownMacAddress().empty()) {
+    cachedMacAddress = std::string(tr(STR_MAC_ADDRESS)) + " " + WIFI_STORE.getLastKnownMacAddress();
+  } else {
+    cachedMacAddress = std::string(tr(STR_MAC_ADDRESS)) + " --";
   }
 
   // Reset state
@@ -36,13 +64,19 @@ void WifiSelectionActivity::onEnter() {
   forgetPromptSelection = 0;
   autoConnecting = false;
 
-  // Cache MAC address for display
+  // Refresh displayed MAC from live hardware value when valid.
   uint8_t mac[6];
   WiFi.macAddress(mac);
-  char macStr[64];
-  snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS), mac[0], mac[1], mac[2],
-           mac[3], mac[4], mac[5]);
-  cachedMacAddress = std::string(macStr);
+  if (isLikelyValidMac(mac)) {
+    cachedMacAddress = formatMacLabel(mac);
+    char persistedMac[18];
+    snprintf(persistedMac, sizeof(persistedMac), "%02x-%02x-%02x-%02x-%02x-%02x", mac[0], mac[1], mac[2], mac[3],
+             mac[4], mac[5]);
+    if (WIFI_STORE.getLastKnownMacAddress() != persistedMac) {
+      RenderLock lock(*this);
+      WIFI_STORE.setLastKnownMacAddress(persistedMac);
+    }
+  }
 
   // Trigger first update to show scanning message
   requestUpdate();

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -4,6 +4,7 @@
 #include <I18n.h>
 #include <Logging.h>
 #include <WiFi.h>
+#include <esp_mac.h>
 
 #include <map>
 
@@ -15,21 +16,26 @@
 
 namespace {
 
-bool isLikelyValidMac(const uint8_t mac[6]) {
-  bool allZero = true;
-  bool allFF = true;
-  for (int i = 0; i < 6; i++) {
-    allZero = allZero && (mac[i] == 0x00);
-    allFF = allFF && (mac[i] == 0xFF);
-  }
-  return !allZero && !allFF;
-}
+void readDeviceBaseMac(uint8_t mac[6]) { esp_efuse_mac_get_default(mac); }
 
 std::string formatMacLabel(const uint8_t mac[6]) {
   char macStr[64];
   snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS), mac[0], mac[1], mac[2],
            mac[3], mac[4], mac[5]);
   return std::string(macStr);
+}
+
+std::string formatMacDashed(const uint8_t mac[6]) {
+  char persistedMac[18];
+  snprintf(persistedMac, sizeof(persistedMac), "%02x-%02x-%02x-%02x-%02x-%02x", mac[0], mac[1], mac[2], mac[3], mac[4],
+           mac[5]);
+  return std::string(persistedMac);
+}
+
+String formatMacCompact(const uint8_t mac[6]) {
+  char compactMac[13];
+  snprintf(compactMac, sizeof(compactMac), "%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  return String(compactMac);
 }
 
 }  // namespace
@@ -44,12 +50,10 @@ void WifiSelectionActivity::onEnter() {
     WIFI_STORE.loadFromFile();
   }
 
-  // Show persisted MAC immediately so UI doesn't briefly display a bogus value.
-  if (!WIFI_STORE.getLastKnownMacAddress().empty()) {
-    cachedMacAddress = std::string(tr(STR_MAC_ADDRESS)) + " " + WIFI_STORE.getLastKnownMacAddress();
-  } else {
-    cachedMacAddress = std::string(tr(STR_MAC_ADDRESS)) + " --";
-  }
+  // Use base MAC from eFuse (stable per-device, independent of WiFi init timing).
+  uint8_t mac[6];
+  readDeviceBaseMac(mac);
+  cachedMacAddress = formatMacLabel(mac);
 
   // Reset state
   selectedNetworkIndex = 0;
@@ -64,18 +68,10 @@ void WifiSelectionActivity::onEnter() {
   forgetPromptSelection = 0;
   autoConnecting = false;
 
-  // Refresh displayed MAC from live hardware value when valid.
-  uint8_t mac[6];
-  WiFi.macAddress(mac);
-  if (isLikelyValidMac(mac)) {
-    cachedMacAddress = formatMacLabel(mac);
-    char persistedMac[18];
-    snprintf(persistedMac, sizeof(persistedMac), "%02x-%02x-%02x-%02x-%02x-%02x", mac[0], mac[1], mac[2], mac[3],
-             mac[4], mac[5]);
-    if (WIFI_STORE.getLastKnownMacAddress() != persistedMac) {
-      RenderLock lock(*this);
-      WIFI_STORE.setLastKnownMacAddress(persistedMac);
-    }
+  const std::string persistedMac = formatMacDashed(mac);
+  if (WIFI_STORE.getLastKnownMacAddress() != persistedMac) {
+    RenderLock lock(*this);
+    WIFI_STORE.setLastKnownMacAddress(persistedMac);
   }
 
   // Trigger first update to show scanning message
@@ -253,10 +249,10 @@ void WifiSelectionActivity::attemptConnection() {
 
   WiFi.mode(WIFI_STA);
 
-  // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
-  String mac = WiFi.macAddress();
-  mac.replace(":", "");
-  String hostname = "CrossPoint-Reader-" + mac;
+  // Use stable base MAC so hostname suffix is deterministic across WiFi states.
+  uint8_t baseMac[6];
+  readDeviceBaseMac(baseMac);
+  String hostname = "CrossPoint-Reader-" + formatMacCompact(baseMac);
   WiFi.setHostname(hostname.c_str());
 
   if (selectedRequiresPassword && !enteredPassword.empty()) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  Show MAC immediately in WifiSelectionActivity without waiting for the live fetch, by persisting the last known correct value and using it as instant fallback. Avoids display of a bogus value. Uses the device specific eFuse base MAC instead of the transient WiFi.macAddress().

* **What changes are included?**

## Additional Context
Persist a last-known MAC in WifiCredentialStore (saved in wifi.json), show it immediately on activity entry, then refresh from live WiFi.macAddress() only when the live value is valid.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
