### PR TITLE
fix: long-press back navigates to book's directory

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -161,7 +161,7 @@ void EpubReaderActivity::loop() {
 
   // Long press BACK (1s+) goes to file selection
   if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= ReaderUtils::GO_HOME_MS) {
-    activityManager.goToFileBrowser(epub ? epub->getPath() : "");
+    goToLibrary(epub ? epub->getPath() : "");
     return;
   }
 

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -60,7 +60,7 @@ void TxtReaderActivity::onExit() {
 void TxtReaderActivity::loop() {
   // Long press BACK (1s+) goes to file selection
   if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= ReaderUtils::GO_HOME_MS) {
-    activityManager.goToFileBrowser(txt ? txt->getPath() : "");
+    goToLibrary(txt ? txt->getPath() : "");
     return;
   }
 

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -70,7 +70,7 @@ void XtcReaderActivity::loop() {
 
   // Long press BACK (1s+) goes to file selection
   if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= goHomeMs) {
-    activityManager.goToFileBrowser(xtc ? xtc->getPath() : "");
+    goToLibrary(xtc ? xtc->getPath() : "");
     return;
   }
 


### PR DESCRIPTION
## Summary

Long-pressing the back button while reading now navigates to the book's parent directory instead of root.

Routes long-press BACK through the existing `goToLibrary()` helper (which uses `extractFolderPath()`) instead of passing the full book path directly to `goToFileBrowser()`. The file browser was receiving a file path and failing to open it as a directory.

Fixes #1117
Supersedes #1349

## Change

One-line fix in each of the three reader activities (`EpubReaderActivity`, `TxtReaderActivity`, `XtcReaderActivity`): replace `activityManager.goToFileBrowser(path)` with `goToLibrary(path)`.

## Test plan

- [ ] Open a book in a subdirectory (e.g., `/Books/SciFi/MyBook.epub`)
- [ ] Long-press the back button
- [ ] File browser opens showing the book's parent directory contents (not root)
- [ ] Works for EPUB, TXT, and XTC file types

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_