### PR TITLE
fix: epub images not rendering correctly on x3

### DIFF
--- a/lib/Epub/Epub/converters/DirectPixelWriter.h
+++ b/lib/Epub/Epub/converters/DirectPixelWriter.h
@@ -15,6 +15,7 @@
 struct DirectPixelWriter {
   uint8_t* fb;
   GfxRenderer::RenderMode mode;
+  uint16_t displayWidthBytes;  // Runtime framebuffer stride (X4: 100, X3: 99)
 
   // Orientation is collapsed into a linear transform:
   //   phyX = phyXBase + x * phyXStepX + y * phyXStepY
@@ -29,12 +30,16 @@ struct DirectPixelWriter {
   void init(GfxRenderer& renderer) {
     fb = renderer.getFrameBuffer();
     mode = renderer.getRenderMode();
+    displayWidthBytes = display.getDisplayWidthBytes();
+
+    const int phyW = display.getDisplayWidth();
+    const int phyH = display.getDisplayHeight();
 
     switch (renderer.getOrientation()) {
       case GfxRenderer::Portrait:
         // phyX = y, phyY = (DISPLAY_HEIGHT-1) - x
         phyXBase = 0;
-        phyYBase = HalDisplay::DISPLAY_HEIGHT - 1;
+        phyYBase = phyH - 1;
         phyXStepX = 0;
         phyYStepX = -1;
         phyXStepY = 1;
@@ -42,8 +47,8 @@ struct DirectPixelWriter {
         break;
       case GfxRenderer::LandscapeClockwise:
         // phyX = (DISPLAY_WIDTH-1) - x, phyY = (DISPLAY_HEIGHT-1) - y
-        phyXBase = HalDisplay::DISPLAY_WIDTH - 1;
-        phyYBase = HalDisplay::DISPLAY_HEIGHT - 1;
+        phyXBase = phyW - 1;
+        phyYBase = phyH - 1;
         phyXStepX = -1;
         phyYStepX = 0;
         phyXStepY = 0;
@@ -51,7 +56,7 @@ struct DirectPixelWriter {
         break;
       case GfxRenderer::PortraitInverted:
         // phyX = (DISPLAY_WIDTH-1) - y, phyY = x
-        phyXBase = HalDisplay::DISPLAY_WIDTH - 1;
+        phyXBase = phyW - 1;
         phyYBase = 0;
         phyXStepX = 0;
         phyYStepX = 1;
@@ -115,7 +120,7 @@ struct DirectPixelWriter {
     const int phyX = rowPhyXBase + logicalX * phyXStepX;
     const int phyY = rowPhyYBase + logicalX * phyYStepX;
 
-    const uint16_t byteIndex = phyY * HalDisplay::DISPLAY_WIDTH_BYTES + (phyX >> 3);
+    const uint16_t byteIndex = phyY * displayWidthBytes + (phyX >> 3);
     const uint8_t bitMask = 1 << (7 - (phyX & 7));
 
     if (state) {

--- a/src/util/ScreenshotUtil.cpp
+++ b/src/util/ScreenshotUtil.cpp
@@ -14,8 +14,8 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
   const uint8_t* fb = renderer.getFrameBuffer();
   if (fb) {
     String filename_str = "/screenshots/screenshot-" + String(millis()) + ".bmp";
-    if (ScreenshotUtil::saveFramebufferAsBmp(filename_str.c_str(), fb, HalDisplay::DISPLAY_WIDTH,
-                                             HalDisplay::DISPLAY_HEIGHT)) {
+    if (ScreenshotUtil::saveFramebufferAsBmp(filename_str.c_str(), fb, display.getDisplayWidth(),
+                                             display.getDisplayHeight())) {
       LOG_DBG("SCR", "Screenshot saved to %s", filename_str.c_str());
     } else {
       LOG_ERR("SCR", "Failed to save screenshot");
@@ -26,7 +26,7 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
 
   // Display a border around the screen to indicate a screenshot was taken
   if (renderer.storeBwBuffer()) {
-    renderer.drawRect(6, 6, HalDisplay::DISPLAY_HEIGHT - 12, HalDisplay::DISPLAY_WIDTH - 12, 2, true);
+    renderer.drawRect(6, 6, display.getDisplayHeight() - 12, display.getDisplayWidth() - 12, 2, true);
     renderer.displayBuffer();
     delay(1000);
     renderer.restoreBwBuffer();
@@ -76,8 +76,8 @@ bool ScreenshotUtil::saveFramebufferAsBmp(const char* filename, const uint8_t* f
   }
 
   const uint32_t rowSizePadded = (phyWidth + 31) / 32 * 4;
-  // Max row size for 480px width = 60 bytes; use fixed buffer to avoid VLA
-  constexpr size_t kMaxRowSize = 64;
+  // Max row size for 528px width (X3) = 68 bytes; use fixed buffer to avoid VLA
+  constexpr size_t kMaxRowSize = 68;
   if (rowSizePadded > kMaxRowSize) {
     LOG_ERR("SCR", "Row size %u exceeds buffer capacity", rowSizePadded);
     file.close();


### PR DESCRIPTION
Replace hardcoded DISPLAY_WIDTH, DISPLAY_HEIGHT, and DISPLAY_WIDTH_BYTES constants with runtime values from display object to support multiple device models (X3 and X4) with different screen dimensions.


