### PR TITLE
fix: epubs with more than 2000 chapters/toc items crashing

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -396,29 +396,36 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
 
   // TOC Pass - try EPUB 3 nav first, fall back to NCX
   const uint32_t tocStart = millis();
+
   if (!bookMetadataCache->beginTocPass()) {
     LOG_ERR("EBP", "Could not begin writing toc pass");
     return false;
   }
 
-  bool tocParsed = false;
+  // Do a ToC pass
+  // A toc pass reads as much of the spine as fits into memory and then reads the entire ToC
+  // An initial spine read is performed in beginTocPass
+  // After every pass the tocFile position is reset so the next pass may write in positions missed by the first
+  do {
+    bool tocParsed = false;
+    // Try EPUB 3 nav document first (preferred)
+    if (!tocNavItem.empty()) {
+      LOG_DBG("EBP", "Attempting to parse EPUB 3 nav document");
+      tocParsed = parseTocNavFile();
+    }
 
-  // Try EPUB 3 nav document first (preferred)
-  if (!tocNavItem.empty()) {
-    LOG_DBG("EBP", "Attempting to parse EPUB 3 nav document");
-    tocParsed = parseTocNavFile();
-  }
+    // Fall back to NCX if nav parsing failed or wasn't available
+    if (!tocParsed && !tocNcxItem.empty()) {
+      LOG_DBG("EBP", "Falling back to NCX TOC");
+      tocParsed = parseTocNcxFile();
+    }
 
-  // Fall back to NCX if nav parsing failed or wasn't available
-  if (!tocParsed && !tocNcxItem.empty()) {
-    LOG_DBG("EBP", "Falling back to NCX TOC");
-    tocParsed = parseTocNcxFile();
-  }
-
-  if (!tocParsed) {
-    LOG_ERR("EBP", "Warning: Could not parse any TOC format");
-    // Continue anyway - book will work without TOC
-  }
+    if (!tocParsed) {
+      LOG_ERR("EBP", "Warning: Could not parse any TOC format");
+      break;
+      // Continue anyway - book will work without TOC
+    }
+  } while (bookMetadataCache->continueTocPass());
 
   if (!bookMetadataCache->endTocPass()) {
     LOG_ERR("EBP", "Could not end writing toc pass");

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -140,6 +140,7 @@ bool Epub::parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata) {
   return true;
 }
 
+/// Returns true on success, false on failure
 bool Epub::parseTocNcxFile() const {
   // the ncx file should have been specified in the content.opf file
   if (tocNcxItem.empty()) {
@@ -197,6 +198,7 @@ bool Epub::parseTocNcxFile() const {
   return true;
 }
 
+/// Returns true on success, false on failure
 bool Epub::parseTocNavFile() const {
   // the nav file should have been specified in the content.opf file (EPUB 3)
   if (tocNavItem.empty()) {
@@ -402,30 +404,40 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
     return false;
   }
 
+  bool decidingToCParser = true;
+  bool usingTocNavParser = false;
   // Do a ToC pass
   // A toc pass reads as much of the spine as fits into memory and then reads the entire ToC
-  // An initial spine read is performed in beginTocPass
   // After every pass the tocFile position is reset so the next pass may write in positions missed by the first
-  do {
-    bool tocParsed = false;
+  while (bookMetadataCache->continueTocPass()) {
     // Try EPUB 3 nav document first (preferred)
-    if (!tocNavItem.empty()) {
+    if ((usingTocNavParser || decidingToCParser) && !tocNavItem.empty()) {
       LOG_DBG("EBP", "Attempting to parse EPUB 3 nav document");
-      tocParsed = parseTocNavFile();
+      bool success = parseTocNavFile();
+      if (decidingToCParser) {
+        usingTocNavParser = success;
+        decidingToCParser = false;
+      }
+      // Continue on success, else falls through to error or (only on error on first pass) try Ncx Parser
+      if (success) {
+        continue;
+      }
     }
 
     // Fall back to NCX if nav parsing failed or wasn't available
-    if (!tocParsed && !tocNcxItem.empty()) {
+    if (!usingTocNavParser && !tocNcxItem.empty()) {
       LOG_DBG("EBP", "Falling back to NCX TOC");
-      tocParsed = parseTocNcxFile();
+      bool success = parseTocNcxFile();
+      // Continue on success, else falls through to error
+      if (success) {
+        continue;
+      }
     }
 
-    if (!tocParsed) {
-      LOG_ERR("EBP", "Warning: Could not parse any TOC format");
-      break;
-      // Continue anyway - book will work without TOC
-    }
-  } while (bookMetadataCache->continueTocPass());
+    LOG_ERR("EBP", "Warning: Could not parse any TOC format");
+    break;
+    // Continue anyway - book will work without TOC
+  };
 
   if (!bookMetadataCache->endTocPass()) {
     LOG_ERR("EBP", "Could not end writing toc pass");

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -409,7 +409,8 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   // Do a ToC pass
   // A toc pass reads as much of the spine as fits into memory and then reads the entire ToC
   // After every pass the tocFile position is reset so the next pass may write in positions missed by the first
-  while (bookMetadataCache->continueTocPass()) {
+  // Do at least one run so we parse the files even when not batch processing
+  while (bookMetadataCache->continueTocPass() || decidingToCParser) {
     // Try EPUB 3 nav document first (preferred)
     if ((usingTocNavParser || decidingToCParser) && !tocNavItem.empty()) {
       LOG_DBG("EBP", "Attempting to parse EPUB 3 nav document");

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -187,40 +187,69 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     LOG_DBG("BMC", "Using batch size lookup for %d spine items", spineCount);
+    uint16_t batches = 1;
+    uint16_t elementsPerBatch = spineCount;
     {
-      uint32_t required_mem_spine = sizeof(spineSizes[0]) * spineCount;
-      uint32_t required_mem_sizes = sizeof(ZipFile::SizeTarget) * spineCount;
+      uint16_t overestimatedSpineCount = spineCount + spineCount / 4;
+      // Approximate required memory
+      uint32_t approxSpineSizesMem = sizeof(spineSizes[0]) * overestimatedSpineCount;
+      uint32_t approxTargetsMem = sizeof(ZipFile::SizeTarget) * overestimatedSpineCount;
+      uint32_t maxAvailableMem = ESP.getFreeHeap();
+
       // While not perfectly accurate due to min allocation sizes etc, its at least a metric
-      uint32_t max_available_mem = ESP.getFreeHeap(); 
-      if (required_mem_sizes + required_mem_spine > max_available_mem) {
-        LOG_ERR("BMC", "Low memory situation detected for %d spine items: %d (%d for spines, %d for sizes) required for %d available. This may be fatal", spineCount, required_mem_sizes + required_mem_spine, required_mem_spine, required_mem_sizes, max_available_mem);
+      if (approxSpineSizesMem + approxTargetsMem > maxAvailableMem) {
+        LOG_ERR("BMC",
+                "Low memory situation detected for %d spine items: %d bytes (%d for spines, %d for sizes) required for "
+                "%d available. This may be fatal",
+                spineCount, approxSpineSizesMem + approxTargetsMem, approxSpineSizesMem, approxTargetsMem,
+                maxAvailableMem);
+        uint32_t memAfterSizes = maxAvailableMem - approxSpineSizesMem;
+        batches = (approxTargetsMem + memAfterSizes - 1) / memAfterSizes;
+        elementsPerBatch = (spineCount + batches - 1) / batches;
+        LOG_DBG("BMC", "Trying processing in %d batches with %d elements", batches, elementsPerBatch);
       }
     }
-
     // Resize spineSizes early to run into OOM earlier
     spineSizes.resize(spineCount, 0);
+
     // Followed by targets
-    std::deque<ZipFile::SizeTarget> targets(spineCount);
-
+    std::deque<ZipFile::SizeTarget> targets(elements_per_batch);
+    // Go to start of spine file
     spineFile.seek(0);
-    for (int i = 0; i < spineCount; i++) {
-      auto entry = readSpineEntry(spineFile);
-      std::string path = FsHelpers::normalisePath(entry.href);
 
-      ZipFile::SizeTarget t;
-      t.hash = ZipFile::fnvHash64(path.c_str(), path.size());
-      t.len = static_cast<uint16_t>(path.size());
-      t.index = static_cast<uint16_t>(i);
-      targets[i] = t;
+    uint16_t total_matched = 0;
+    // Run main loop
+    for (uint16_t b = 0; b < batches; b++) {
+      // Indices start at last batch border
+      uint16_t batchStartIndex = b * elementsPerBatch;
+      // Indices end at next batch border or end of spine
+      uint16_t batchEndIndex = std::min(static_cast<uint16_t>((b + 1) * elementsPerBatch), spineCount);
+      // I have decided not to clear the targets array at this point
+      // Either we reallocate the array every batch or we just keep some old entries in the final batch
+      // ZipFile::fillUncompressedSizes is able to deal with these old entries anyways
+      for (int i = batchStartIndex; i < batchEndIndex; i++) {
+        // Read a spine entry
+        auto entry = readSpineEntry(spineFile);
+        std::string path = FsHelpers::normalisePath(entry.href);
+
+        ZipFile::SizeTarget t;
+        t.hash = ZipFile::fnvHash64(path.c_str(), path.size());
+        t.len = static_cast<uint16_t>(path.size());
+        t.index = static_cast<uint16_t>(i);
+        // Insert at appropriate position in targets array
+        targets[i % elementsPerBatch] = t;
+      }
+      // Sort the targets array to speed up ZipFile::fillUncompressedSizes
+      std::sort(targets.begin(), targets.end(), [](const ZipFile::SizeTarget& a, const ZipFile::SizeTarget& b) {
+        return a.hash < b.hash || (a.hash == b.hash && a.len < b.len);
+      });
+
+      // Partially fill the spineSizes array
+      total_matched += zip.fillUncompressedSizes(targets, spineSizes);
+      LOG_DBG("BMC", "Batch lookup matched %d/%d spine items after batch %d", total_matched, spineCount, b);
     }
 
-    std::sort(targets.begin(), targets.end(), [](const ZipFile::SizeTarget& a, const ZipFile::SizeTarget& b) {
-      return a.hash < b.hash || (a.hash == b.hash && a.len < b.len);
-    });
-
-    int matched = zip.fillUncompressedSizes(targets, spineSizes);
-    LOG_DBG("BMC", "Batch lookup matched %d/%d spine items", matched, spineCount);
-
+    // Finally: clear targets array
     targets.clear();
     targets.shrink_to_fit();
 

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -72,7 +72,7 @@ bool BookMetadataCache::beginTocPass() {
         LOG_DBG("BMC", "Trying fast index in %d batches with %d elements", this->tocBatches, this->tocElementsPerBatch);
       }
     }
-    
+
     spineHrefIndex.resize(this->tocElementsPerBatch);
     spineFile.seek(0);
     LOG_DBG("BMC", "Using fast index for %d spine items", spineCount);
@@ -85,7 +85,7 @@ bool BookMetadataCache::beginTocPass() {
   return true;
 }
 
-/// Continues the Toc parsing by generating SpineHref entries 
+/// Continues the Toc parsing by generating SpineHref entries
 /// Returns true when new entries have been processed
 bool BookMetadataCache::continueTocPass() {
   // We are done with the ToC pass if we don't use spineHrefIndices or we have finished our batches
@@ -94,7 +94,8 @@ bool BookMetadataCache::continueTocPass() {
     spineFile.seek(0);
     return false;
   }
-  // Reset toc file position since we parse the entire toc file every time and want to write entries at the same position every time
+  // Reset toc file position since we parse the entire toc file every time and want to write entries at the same
+  // position every time
   tocFile.seek(0);
   // Also reset tocCount so we don't count entries multiple times
   tocCount = 0;
@@ -104,8 +105,9 @@ bool BookMetadataCache::continueTocPass() {
 
   uint16_t batchStartIndex = this->tocCurrentBatch * this->tocElementsPerBatch;
   // Indices end at next batch border or end of spine
-  uint16_t batchEndIndex = std::min(static_cast<uint16_t>((this->tocCurrentBatch + 1) * this->tocElementsPerBatch), spineCount);
- 
+  uint16_t batchEndIndex =
+      std::min(static_cast<uint16_t>((this->tocCurrentBatch + 1) * this->tocElementsPerBatch), spineCount);
+
   for (int i = batchStartIndex; i < batchEndIndex; i++) {
     auto entry = readSpineEntry(spineFile);
     SpineHrefIndexEntry idx;
@@ -118,7 +120,7 @@ bool BookMetadataCache::continueTocPass() {
             [](const SpineHrefIndexEntry& a, const SpineHrefIndexEntry& b) {
               return a.hrefHash < b.hrefHash || (a.hrefHash == b.hrefHash && a.hrefLen < b.hrefLen);
             });
-  
+
   // We got new data => return true
   return true;
 }

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -192,7 +192,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
       uint32_t required_mem_sizes = sizeof(ZipFile::SizeTarget) * spineCount;
       // While not perfectly accurate due to min allocation sizes etc, its at least a metric
       uint32_t max_available_mem = ESP.getFreeHeap(); 
-      if (required_mem_sizes + required_mem_sizes > max_available_mem) {
+      if (required_mem_sizes + required_mem_spine > max_available_mem) {
         LOG_ERR("BMC", "Low memory situation detected for %d spine items: %d (%d for spines, %d for sizes) required for %d available. This may be fatal", spineCount, required_mem_sizes + required_mem_spine, required_mem_spine, required_mem_sizes, max_available_mem);
       }
     }

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -4,7 +4,7 @@
 #include <Serialization.h>
 #include <ZipFile.h>
 
-#include <vector>
+#include <deque>
 
 #include "FsHelpers.h"
 
@@ -50,7 +50,8 @@ bool BookMetadataCache::beginTocPass() {
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     spineHrefIndex.clear();
-    spineHrefIndex.reserve(spineCount);
+    spineHrefIndex.shrink_to_fit();
+    spineHrefIndex.resize(spineCount);
     spineFile.seek(0);
     for (int i = 0; i < spineCount; i++) {
       auto entry = readSpineEntry(spineFile);
@@ -58,7 +59,7 @@ bool BookMetadataCache::beginTocPass() {
       idx.hrefHash = fnvHash64(entry.href);
       idx.hrefLen = static_cast<uint16_t>(entry.href.size());
       idx.spineIndex = static_cast<int16_t>(i);
-      spineHrefIndex.push_back(idx);
+      spineHrefIndex[i] = idx;
     }
     std::sort(spineHrefIndex.begin(), spineHrefIndex.end(),
               [](const SpineHrefIndexEntry& a, const SpineHrefIndexEntry& b) {
@@ -153,7 +154,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   // Loop through spines from spine file matching up TOC indexes, calculating cumulative size and writing to book.bin
 
   // Build spineIndex->tocIndex mapping in one pass (O(n) instead of O(n*m))
-  std::vector<int16_t> spineToTocIndex(spineCount, -1);
+  std::deque<int16_t> spineToTocIndex(spineCount, -1);
   tocFile.seek(0);
   for (int j = 0; j < tocCount; j++) {
     auto tocEntry = readTocEntry(tocFile);
@@ -181,14 +182,13 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   // This is O(n*log(m)) instead of O(n*m) while avoiding memory exhaustion.
   // See: https://github.com/crosspoint-reader/crosspoint-reader/issues/134
 
-  std::vector<uint32_t> spineSizes;
+  std::deque<uint32_t> spineSizes;
   bool useBatchSizes = false;
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     LOG_DBG("BMC", "Using batch size lookup for %d spine items", spineCount);
 
-    std::vector<ZipFile::SizeTarget> targets;
-    targets.reserve(spineCount);
+    std::deque<ZipFile::SizeTarget> targets(spineCount);
 
     spineFile.seek(0);
     for (int i = 0; i < spineCount; i++) {
@@ -199,7 +199,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
       t.hash = ZipFile::fnvHash64(path.c_str(), path.size());
       t.len = static_cast<uint16_t>(path.size());
       t.index = static_cast<uint16_t>(i);
-      targets.push_back(t);
+      targets[i] = t;
     }
 
     std::sort(targets.begin(), targets.end(), [](const ZipFile::SizeTarget& a, const ZipFile::SizeTarget& b) {

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -187,7 +187,19 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     LOG_DBG("BMC", "Using batch size lookup for %d spine items", spineCount);
+    {
+      uint32_t required_mem_spine = sizeof(spineSizes[0]) * spineCount;
+      uint32_t required_mem_sizes = sizeof(ZipFile::SizeTarget) * spineCount;
+      // While not perfectly accurate due to min allocation sizes etc, its at least a metric
+      uint32_t max_available_mem = ESP.getFreeHeap(); 
+      if (required_mem_sizes + required_mem_sizes > max_available_mem) {
+        LOG_ERR("BMC", "Low memory situation detected for %d spine items: %d (%d for spines, %d for sizes) required for %d available. This may be fatal", spineCount, required_mem_sizes + required_mem_spine, required_mem_spine, required_mem_sizes, max_available_mem);
+      }
+    }
 
+    // Resize spineSizes early to run into OOM earlier
+    spineSizes.resize(spineCount, 0);
+    // Followed by targets
     std::deque<ZipFile::SizeTarget> targets(spineCount);
 
     spineFile.seek(0);
@@ -206,7 +218,6 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
       return a.hash < b.hash || (a.hash == b.hash && a.len < b.len);
     });
 
-    spineSizes.resize(spineCount, 0);
     int matched = zip.fillUncompressedSizes(targets, spineSizes);
     LOG_DBG("BMC", "Batch lookup matched %d/%d spine items", matched, spineCount);
 

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -89,13 +89,18 @@ bool BookMetadataCache::beginTocPass() {
 /// Returns true when new entries have been processed
 bool BookMetadataCache::continueTocPass() {
   // We are done with the ToC pass if we don't use spineHrefIndices or we have finished our batches
-  if (!useSpineHrefIndex || this->tocCurrentBatch == this->tocBatches) {
+  if (!useSpineHrefIndex || this->tocCurrentBatch == this->tocBatches - 1) {
     // If we're done we reset the spine seek position
     spineFile.seek(0);
     return false;
   }
-  // Reset toc file position since we parse the entire toc file every time and want to write entries at any position
+  // Reset toc file position since we parse the entire toc file every time and want to write entries at the same position every time
   tocFile.seek(0);
+  // Also reset tocCount so we don't count entries multiple times
+  tocCount = 0;
+
+  // Increment -1 initialized batch number
+  this->tocCurrentBatch++;
 
   uint16_t batchStartIndex = this->tocCurrentBatch * this->tocElementsPerBatch;
   // Indices end at next batch border or end of spine
@@ -114,8 +119,6 @@ bool BookMetadataCache::continueTocPass() {
               return a.hrefHash < b.hrefHash || (a.hrefHash == b.hrefHash && a.hrefLen < b.hrefLen);
             });
   
-  // Increment batch number
-  this->tocCurrentBatch++;
   // We got new data => return true
   return true;
 }
@@ -456,7 +459,7 @@ void BookMetadataCache::createTocEntry(const std::string& title, const std::stri
 
   const TocEntry entry(title, href, anchor, level, spineIndex);
   // Only overwrite existing entries if we are not in the first batch (or not batch processing at all)
-  writeTocEntry(tocFile, entry, this->tocCurrentBatch == 0);
+  writeTocEntry(tocFile, entry, this->tocCurrentBatch == 0 || this->tocCurrentBatch == -1);
   tocCount++;
 }
 

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -55,7 +55,7 @@ bool BookMetadataCache::beginTocPass() {
     this->tocBatches = 1;
     this->tocElementsPerBatch = spineCount;
     {
-      uint16_t overestimatedSpineCount = spineCount + spineCount / 4;
+      uint32_t overestimatedSpineCount = static_cast<uint32_t>(spineCount) + spineCount / 4;
       // Approximate required memory
       uint32_t approxSpineHrefMem = sizeof(SpineHrefIndexEntry) * overestimatedSpineCount;
       uint32_t maxAvailableMem = ESP.getFreeHeap();
@@ -76,8 +76,6 @@ bool BookMetadataCache::beginTocPass() {
     spineHrefIndex.resize(this->tocElementsPerBatch);
     spineFile.seek(0);
     LOG_DBG("BMC", "Using fast index for %d spine items", spineCount);
-    // Initial tocPass
-    this->continueTocPass();
   } else {
     useSpineHrefIndex = false;
   }
@@ -240,7 +238,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     uint16_t batches = 1;
     uint16_t elementsPerBatch = spineCount;
     {
-      uint16_t overestimatedSpineCount = spineCount + spineCount / 4;
+      uint32_t overestimatedSpineCount = static_cast<uint32_t>(spineCount) + spineCount / 4;
       // Approximate required memory
       uint32_t approxSpineSizesMem = sizeof(spineSizes[0]) * overestimatedSpineCount;
       uint32_t approxTargetsMem = sizeof(ZipFile::SizeTarget) * overestimatedSpineCount;
@@ -253,7 +251,8 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
                 "%d available. This may be fatal",
                 spineCount, approxSpineSizesMem + approxTargetsMem, approxSpineSizesMem, approxTargetsMem,
                 maxAvailableMem);
-        uint32_t memAfterSizes = maxAvailableMem - approxSpineSizesMem;
+        uint32_t memAfterSizes =
+            static_cast<uint32_t>(std::max(static_cast<int64_t>(maxAvailableMem) - approxSpineSizesMem, 1LL));
         batches = (approxTargetsMem + memAfterSizes - 1) / memAfterSizes;
         elementsPerBatch = (spineCount + batches - 1) / batches;
         LOG_DBG("BMC", "Trying processing in %d batches with %d elements", batches, elementsPerBatch);

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -49,29 +49,74 @@ bool BookMetadataCache::beginTocPass() {
   }
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
+    useSpineHrefIndex = true;
     spineHrefIndex.clear();
     spineHrefIndex.shrink_to_fit();
-    spineHrefIndex.resize(spineCount);
-    spineFile.seek(0);
-    for (int i = 0; i < spineCount; i++) {
-      auto entry = readSpineEntry(spineFile);
-      SpineHrefIndexEntry idx;
-      idx.hrefHash = fnvHash64(entry.href);
-      idx.hrefLen = static_cast<uint16_t>(entry.href.size());
-      idx.spineIndex = static_cast<int16_t>(i);
-      spineHrefIndex[i] = idx;
+    this->tocBatches = 1;
+    this->tocElementsPerBatch = spineCount;
+    {
+      uint16_t overestimatedSpineCount = spineCount + spineCount / 4;
+      // Approximate required memory
+      uint32_t approxSpineHrefMem = sizeof(SpineHrefIndexEntry) * overestimatedSpineCount;
+      uint32_t maxAvailableMem = ESP.getFreeHeap();
+
+      // While not perfectly accurate due to min allocation sizes etc, its at least a metric
+      if (approxSpineHrefMem > maxAvailableMem) {
+        LOG_ERR("BMC",
+                "Low memory situation detected for %d spine items: %d bytes required for "
+                "%d available. This may be fatal",
+                spineCount, approxSpineHrefMem, maxAvailableMem);
+
+        this->tocBatches = (approxSpineHrefMem + maxAvailableMem - 1) / maxAvailableMem;
+        this->tocElementsPerBatch = (spineCount + this->tocBatches - 1) / this->tocBatches;
+        LOG_DBG("BMC", "Trying fast index in %d batches with %d elements", this->tocBatches, this->tocElementsPerBatch);
+      }
     }
-    std::sort(spineHrefIndex.begin(), spineHrefIndex.end(),
-              [](const SpineHrefIndexEntry& a, const SpineHrefIndexEntry& b) {
-                return a.hrefHash < b.hrefHash || (a.hrefHash == b.hrefHash && a.hrefLen < b.hrefLen);
-              });
+    
+    spineHrefIndex.resize(this->tocElementsPerBatch);
     spineFile.seek(0);
-    useSpineHrefIndex = true;
     LOG_DBG("BMC", "Using fast index for %d spine items", spineCount);
+    // Initial tocPass
+    this->continueTocPass();
   } else {
     useSpineHrefIndex = false;
   }
 
+  return true;
+}
+
+/// Continues the Toc parsing by generating SpineHref entries 
+/// Returns true when new entries have been processed
+bool BookMetadataCache::continueTocPass() {
+  // We are done with the ToC pass if we don't use spineHrefIndices or we have finished our batches
+  if (!useSpineHrefIndex || this->tocCurrentBatch == this->tocBatches) {
+    // If we're done we reset the spine seek position
+    spineFile.seek(0);
+    return false;
+  }
+  // Reset toc file position since we parse the entire toc file every time and want to write entries at any position
+  tocFile.seek(0);
+
+  uint16_t batchStartIndex = this->tocCurrentBatch * this->tocElementsPerBatch;
+  // Indices end at next batch border or end of spine
+  uint16_t batchEndIndex = std::min(static_cast<uint16_t>((this->tocCurrentBatch + 1) * this->tocElementsPerBatch), spineCount);
+ 
+  for (int i = batchStartIndex; i < batchEndIndex; i++) {
+    auto entry = readSpineEntry(spineFile);
+    SpineHrefIndexEntry idx;
+    idx.hrefHash = fnvHash64(entry.href);
+    idx.hrefLen = static_cast<uint16_t>(entry.href.size());
+    idx.spineIndex = static_cast<int16_t>(i);
+    spineHrefIndex[i % this->tocElementsPerBatch] = idx;
+  }
+  std::sort(spineHrefIndex.begin(), spineHrefIndex.end(),
+            [](const SpineHrefIndexEntry& a, const SpineHrefIndexEntry& b) {
+              return a.hrefHash < b.hrefHash || (a.hrefHash == b.hrefHash && a.hrefLen < b.hrefLen);
+            });
+  
+  // Increment batch number
+  this->tocCurrentBatch++;
+  // We got new data => return true
   return true;
 }
 
@@ -213,7 +258,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     spineSizes.resize(spineCount, 0);
 
     // Followed by targets
-    std::deque<ZipFile::SizeTarget> targets(elements_per_batch);
+    std::deque<ZipFile::SizeTarget> targets(elementsPerBatch);
     // Go to start of spine file
     spineFile.seek(0);
 
@@ -302,7 +347,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   tocFile.seek(0);
   for (int i = 0; i < tocCount; i++) {
     auto tocEntry = readTocEntry(tocFile);
-    writeTocEntry(bookFile, tocEntry);
+    writeTocEntry(bookFile, tocEntry, true);
   }
 
   bookFile.close();
@@ -333,8 +378,20 @@ uint32_t BookMetadataCache::writeSpineEntry(FsFile& file, const SpineEntry& entr
   return pos;
 }
 
-uint32_t BookMetadataCache::writeTocEntry(FsFile& file, const TocEntry& entry) const {
+uint32_t BookMetadataCache::writeTocEntry(FsFile& file, const TocEntry& entry, const bool overwrite) const {
   const uint32_t pos = file.position();
+  // Are we here to overwrite existing entries?
+  if (!overwrite) {
+    // If not, read the existing entry and check if the spineIndex is "invalid"
+    // If so this entry might or might not be a dud and we can overwrite it anyways
+    // Else skip
+    TocEntry existingEntry = readTocEntry(file);
+    if (existingEntry.spineIndex != -1) {
+      return pos;
+    }
+    // Reset seek position and overwrite
+    file.seek(pos);
+  }
   serialization::writeString(file, entry.title);
   serialization::writeString(file, entry.href);
   serialization::writeString(file, entry.anchor);
@@ -398,7 +455,8 @@ void BookMetadataCache::createTocEntry(const std::string& title, const std::stri
   }
 
   const TocEntry entry(title, href, anchor, level, spineIndex);
-  writeTocEntry(tocFile, entry);
+  // Only overwrite existing entries if we are not in the first batch (or not batch processing at all)
+  writeTocEntry(tocFile, entry, this->tocCurrentBatch == 0);
   tocCount++;
 }
 

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -64,7 +64,7 @@ class BookMetadataCache {
   std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
   uint16_t tocBatches = 1;
-  uint16_t tocElementsPerBatch = -1;
+  uint16_t tocElementsPerBatch = 0;
   int16_t tocCurrentBatch = -1;
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -3,8 +3,8 @@
 #include <HalStorage.h>
 
 #include <algorithm>
-#include <string>
 #include <deque>
+#include <string>
 
 class BookMetadataCache {
  public:

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -65,7 +65,7 @@ class BookMetadataCache {
   bool useSpineHrefIndex = false;
   uint16_t tocBatches;
   uint16_t tocElementsPerBatch;
-  uint16_t tocCurrentBatch = 0;
+  uint16_t tocCurrentBatch = -1;
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 
   // FNV-1a 64-bit hash function
@@ -79,7 +79,7 @@ class BookMetadataCache {
   }
 
   uint32_t writeSpineEntry(FsFile& file, const SpineEntry& entry) const;
-  uint32_t writeTocEntry(FsFile& file, const TocEntry& entry, bool overwrite) const;
+  uint32_t writeTocEntry(FsFile& file, const TocEntry& entry, const bool overwrite) const;
   SpineEntry readSpineEntry(FsFile& file) const;
   TocEntry readTocEntry(FsFile& file) const;
 

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include <string>
-#include <vector>
+#include <deque>
 
 class BookMetadataCache {
  public:
@@ -61,7 +61,7 @@ class BookMetadataCache {
     uint16_t hrefLen;   // length for collision reduction
     int16_t spineIndex;
   };
-  std::vector<SpineHrefIndexEntry> spineHrefIndex;
+  std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
 
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -63,7 +63,9 @@ class BookMetadataCache {
   };
   std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
-
+  uint16_t tocBatches;
+  uint16_t tocElementsPerBatch;
+  uint16_t tocCurrentBatch = 0;
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 
   // FNV-1a 64-bit hash function
@@ -77,7 +79,7 @@ class BookMetadataCache {
   }
 
   uint32_t writeSpineEntry(FsFile& file, const SpineEntry& entry) const;
-  uint32_t writeTocEntry(FsFile& file, const TocEntry& entry) const;
+  uint32_t writeTocEntry(FsFile& file, const TocEntry& entry, bool overwrite) const;
   SpineEntry readSpineEntry(FsFile& file) const;
   TocEntry readTocEntry(FsFile& file) const;
 
@@ -94,6 +96,7 @@ class BookMetadataCache {
   void createSpineEntry(const std::string& href);
   bool endContentOpfPass();
   bool beginTocPass();
+  bool continueTocPass();
   void createTocEntry(const std::string& title, const std::string& href, const std::string& anchor, uint8_t level);
   bool endTocPass();
   bool endWrite();

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -65,7 +65,7 @@ class BookMetadataCache {
   bool useSpineHrefIndex = false;
   uint16_t tocBatches = 1;
   uint16_t tocElementsPerBatch = -1;
-  uint16_t tocCurrentBatch = -1;
+  int16_t tocCurrentBatch = -1;
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 
   // FNV-1a 64-bit hash function

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -63,8 +63,8 @@ class BookMetadataCache {
   };
   std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
-  uint16_t tocBatches;
-  uint16_t tocElementsPerBatch;
+  uint16_t tocBatches = 1;
+  uint16_t tocElementsPerBatch = -1;
   uint16_t tocCurrentBatch = -1;
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -133,9 +133,8 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
 
     // Sort item index for binary search if we have enough items
     if (self->itemIndex.size() >= LARGE_SPINE_THRESHOLD) {
-      std::sort(self->itemIndex.begin(), self->itemIndex.end(), [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
-        return a.idHash < b.idHash;
-      });
+      std::sort(self->itemIndex.begin(), self->itemIndex.end(),
+                [](const ItemIndexEntry& a, const ItemIndexEntry& b) { return a.idHash < b.idHash; });
       self->useItemIndex = true;
       LOG_DBG("COF", "Using fast index for %zu manifest items", self->itemIndex.size());
     }
@@ -251,11 +250,9 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             uint32_t targetHash = fnvHash(idref);
             uint16_t targetLen = static_cast<uint16_t>(idref.size());
 
-            auto it = std::lower_bound(self->itemIndex.begin(), self->itemIndex.end(),
-                                       ItemIndexEntry{targetHash, 0},
-                                       [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
-                                         return a.idHash < b.idHash;
-                                       });
+            auto it =
+                std::lower_bound(self->itemIndex.begin(), self->itemIndex.end(), ItemIndexEntry{targetHash, 0},
+                                 [](const ItemIndexEntry& a, const ItemIndexEntry& b) { return a.idHash < b.idHash; });
 
             // Check for match (may need to check a few due to hash collisions)
             while (it != self->itemIndex.end() && it->idHash == targetHash) {

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -134,7 +134,7 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     // Sort item index for binary search if we have enough items
     if (self->itemIndex.size() >= LARGE_SPINE_THRESHOLD) {
       std::sort(self->itemIndex.begin(), self->itemIndex.end(), [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
-        return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
+        return a.idHash < b.idHash;
       });
       self->useItemIndex = true;
       LOG_DBG("COF", "Using fast index for %zu manifest items", self->itemIndex.size());
@@ -192,7 +192,6 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     if (self->tempItemStore) {
       ItemIndexEntry entry;
       entry.idHash = fnvHash(itemId);
-      entry.idLen = static_cast<uint16_t>(itemId.size());
       entry.fileOffset = static_cast<uint32_t>(self->tempItemStore.position());
       self->itemIndex.push_back(entry);
     }
@@ -253,9 +252,9 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             uint16_t targetLen = static_cast<uint16_t>(idref.size());
 
             auto it = std::lower_bound(self->itemIndex.begin(), self->itemIndex.end(),
-                                       ItemIndexEntry{targetHash, targetLen, 0},
+                                       ItemIndexEntry{targetHash, 0},
                                        [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
-                                         return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
+                                         return a.idHash < b.idHash;
                                        });
 
             // Check for match (may need to check a few due to hash collisions)

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -34,7 +34,6 @@ class ContentOpfParser final : public Print {
   // Index for fast idref→href lookup (used only for large EPUBs)
   struct ItemIndexEntry {
     uint32_t idHash;      // FNV-1a hash of itemId
-    uint16_t idLen;       // length for collision reduction
     uint32_t fileOffset;  // offset in .items.bin
   };
   std::deque<ItemIndexEntry> itemIndex;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -2,7 +2,7 @@
 #include <Print.h>
 
 #include <algorithm>
-#include <vector>
+#include <deque>
 
 #include "Epub.h"
 #include "expat.h"
@@ -37,7 +37,7 @@ class ContentOpfParser final : public Print {
     uint16_t idLen;       // length for collision reduction
     uint32_t fileOffset;  // offset in .items.bin
   };
-  std::vector<ItemIndexEntry> itemIndex;
+  std::deque<ItemIndexEntry> itemIndex;
   bool useItemIndex = false;
 
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -312,7 +312,7 @@ bool ZipFile::getInflatedFileSize(const char* filename, size_t* size) {
   return true;
 }
 
-int ZipFile::fillUncompressedSizes(std::vector<SizeTarget>& targets, std::vector<uint32_t>& sizes) {
+int ZipFile::fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes) {
   if (targets.empty()) {
     return 0;
   }

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -312,6 +312,9 @@ bool ZipFile::getInflatedFileSize(const char* filename, size_t* size) {
   return true;
 }
 
+/// This function iterates through the epub zip file to get the uncompressed size for every chapter in the spine (targets array)
+/// Sizes is filled via memory accesses at target->index positions, sizes therefore need to contain at least max(target->index) entries
+/// It is safe to call this function multiple times with the same sizes array and different targets
 int ZipFile::fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes) {
   if (targets.empty()) {
     return 0;
@@ -337,9 +340,10 @@ int ZipFile::fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<u
   char itemName[256];
 
   while (file.available()) {
+    // Check magic
     file.read(&sig, 4);
     if (sig != 0x02014b50) break;
-
+    // Read header
     file.seekCur(6);
     uint16_t method;
     file.read(&method, 2);
@@ -354,7 +358,8 @@ int ZipFile::fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<u
     file.seekCur(8);
     uint32_t localHeaderOffset;
     file.read(&localHeaderOffset, 4);
-
+    // If the name is to EPUB spec, read the name, hash it and compare it with hashes in targets
+    // If match is found, insert decompressed size in appropriate sizes array position
     if (nameLen < 256) {
       file.read(itemName, nameLen);
       itemName[nameLen] = '\0';

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -312,9 +312,10 @@ bool ZipFile::getInflatedFileSize(const char* filename, size_t* size) {
   return true;
 }
 
-/// This function iterates through the epub zip file to get the uncompressed size for every chapter in the spine (targets array)
-/// Sizes is filled via memory accesses at target->index positions, sizes therefore need to contain at least max(target->index) entries
-/// It is safe to call this function multiple times with the same sizes array and different targets
+/// This function iterates through the epub zip file to get the uncompressed size for every chapter in the spine
+/// (targets array) Sizes is filled via memory accesses at target->index positions, sizes therefore need to contain at
+/// least max(target->index) entries It is safe to call this function multiple times with the same sizes array and
+/// different targets
 int ZipFile::fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes) {
   if (targets.empty()) {
     return 0;

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <unordered_map>
-#include <vector>
+#include <deque>
 
 class ZipFile {
  public:
@@ -64,7 +64,7 @@ class ZipFile {
   // Batch lookup: scan ZIP central dir once and fill sizes for matching targets.
   // targets must be sorted by (hash, len). sizes[target.index] receives uncompressedSize.
   // Returns number of targets matched.
-  int fillUncompressedSizes(std::vector<SizeTarget>& targets, std::vector<uint32_t>& sizes);
+  int fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes);
   // Due to the memory required to run each of these, it is recommended to not preopen the zip file for multiple
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <HalStorage.h>
 
+#include <deque>
 #include <string>
 #include <unordered_map>
-#include <deque>
 
 class ZipFile {
  public:

--- a/scripts/generate_mega_epub.py
+++ b/scripts/generate_mega_epub.py
@@ -1,6 +1,6 @@
 from ebooklib import epub
 
-book_sizes = [1000, 2000, 3000, 5000, 10000, 65530]
+book_sizes = [1000, 2000, 3000, 5000, 10000, 17000, 19000, 65530]
 
 # This script generates epubs with entirely too many toc and spine entries
 for x in book_sizes:

--- a/scripts/generate_mega_epub.py
+++ b/scripts/generate_mega_epub.py
@@ -1,0 +1,21 @@
+from ebooklib import epub
+
+book_sizes = [1000,5000,10000,65535]
+
+# This script generates epubs with entirely too many toc and spine entries
+for x in book_sizes:
+    book = epub.EpubBook()
+    book.set_identifier(f"MegaBook-{x}")
+    book.set_title(f"MegaBook-{x}")
+    book.set_language('en')
+    book.spine = ['nav']
+    for y in range(0,x):
+        chapter = epub.EpubHtml(title=f'{y}', file_name=f'{y}.xhtml')
+        chapter.content = f"<h1>Chap {y}</h1><p>Chapchapt {y}</p>"
+        book.add_item(chapter)
+        book.spine.append(chapter)
+        book.toc.append(chapter)
+    # Add navigation
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    epub.write_epub(f'{x}.epub', book)

--- a/scripts/generate_mega_epub.py
+++ b/scripts/generate_mega_epub.py
@@ -1,6 +1,6 @@
 from ebooklib import epub
 
-book_sizes = [1000,5000,10000,65535]
+book_sizes = [1000, 2000, 3000, 5000, 10000, 65530]
 
 # This script generates epubs with entirely too many toc and spine entries
 for x in book_sizes:


### PR DESCRIPTION
## Why draft?
* I'm currently working on file-backed arrays that will a) make sure we reliably don't run out of memory while parsing (at least from causes I have identified so far)
* After that we will be able to parse large-enough epubs to for me to call this final

## Summary

* **What is the goal of this PR?** 
* Increase the maximum supported spine size for epubs
* Initially intended to provide support for books up to 65000 entries long, however this would require a larger restructuring of the contents.opf parser
* Motivation: I have books with more than 2.5k chapter entries

* **What changes are included?** 
* Batch-based processing of toc and spine items
* Switched to deques instead of vectors for parsing data, making use more available memory
* Added generate_mega_epub.py to generate test books
* Now supports books with 10000 chapters/toc entries, limit (not confirmed but mused to be) ~12000 entries instead of ~2500
* These limits are not guaranteed => Log message when potential OOM when parsing (not added for parsing content.opf)

## Additional Context

* The overwrite argument was added to writeToCEntry to keep the ordering of toC entries. Normal parsing behaves as before, batch parsing first writes every ToC entry in order then selectively overwrites entries with missing spine connections if found
* Removed length from itemIndexEntry because matches are later string compared, allowing us to halve the required memory for parsing items

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
