### PR TITLE
feat: force contrast filter for sleep screen based on filename

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -337,7 +337,7 @@ To use custom sleep images, set the sleep screen mode to **Custom** or **Cover +
 > For best results:
 > - Use uncompressed BMP files with 24-bit color depth
 > - Use a resolution of 480x800 pixels to match the device's screen resolution.
-> - For a mix of grayscale images where some look washed out. Add `contrast` to their filename. This will force the **Contrast** filter for them specificaly
+> - For a mix of grayscale images where some look washed out, add `contrast` to their filename. This will force the **Contrast** filter for those images specifically
 
 ---
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -337,6 +337,7 @@ To use custom sleep images, set the sleep screen mode to **Custom** or **Cover +
 > For best results:
 > - Use uncompressed BMP files with 24-bit color depth
 > - Use a resolution of 480x800 pixels to match the device's screen resolution.
+> - For a mix of grayscale images where some look washed out. Add `contrast` to their filename. This will force the **Contrast** filter for them specificaly
 
 ---
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -89,10 +89,13 @@ void SleepActivity::renderCustomSleepScreen() const {
       FsFile file;
       if (Storage.openFileForRead("SLP", filename, file)) {
         LOG_DBG("SLP", "Randomly loading: %s/%s", sleepDir, files[randomFileIndex].c_str());
+        LOG_DBG("SLP", "ForceContrast: %i", (int)(files[randomFileIndex].find("contrast") != std::string::npos));
+        bool forceContrast = (files[randomFileIndex].find("contrast") != std::string::npos);
+
         delay(100);
         Bitmap bitmap(file, true);
         if (bitmap.parseHeaders() == BmpReaderError::Ok) {
-          renderBitmapSleepScreen(bitmap);
+          renderBitmapSleepScreen(bitmap, forceContrast);
           file.close();
           dir.close();
           return;
@@ -110,7 +113,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
-      renderBitmapSleepScreen(bitmap);
+      renderBitmapSleepScreen(bitmap, false);
       file.close();
       return;
     }
@@ -137,7 +140,7 @@ void SleepActivity::renderDefaultSleepScreen() const {
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 }
 
-void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
+void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, bool forceContrast = false) const {
   int x, y;
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -191,7 +194,7 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
 
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 
-  if (hasGreyscale) {
+  if (hasGreyscale && !forceContrast) {
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
@@ -280,7 +283,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap);
+      renderBitmapSleepScreen(bitmap, false);
       file.close();
       return;
     }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -113,7 +113,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
-      renderBitmapSleepScreen(bitmap, false);
+      renderBitmapSleepScreen(bitmap);
       file.close();
       return;
     }
@@ -140,7 +140,7 @@ void SleepActivity::renderDefaultSleepScreen() const {
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 }
 
-void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, bool forceContrast = false) const {
+void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, bool forceContrast) const {
   int x, y;
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -283,7 +283,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap, false);
+      renderBitmapSleepScreen(bitmap);
       file.close();
       return;
     }

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -13,6 +13,6 @@ class SleepActivity final : public Activity {
   void renderDefaultSleepScreen() const;
   void renderCustomSleepScreen() const;
   void renderCoverSleepScreen() const;
-  void renderBitmapSleepScreen(const Bitmap& bitmap) const;
+  void renderBitmapSleepScreen(const Bitmap& bitmap, bool forceContrast) const;
   void renderBlankSleepScreen() const;
 };

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -13,6 +13,6 @@ class SleepActivity final : public Activity {
   void renderDefaultSleepScreen() const;
   void renderCustomSleepScreen() const;
   void renderCoverSleepScreen() const;
-  void renderBitmapSleepScreen(const Bitmap& bitmap, bool forceContrast) const;
+  void renderBitmapSleepScreen(const Bitmap& bitmap, bool forceContrast = false) const;
   void renderBlankSleepScreen() const;
 };


### PR DESCRIPTION
## Summary

I have a mix of sleep screens, some of which benefit from the grayscale rendering, and some simpler ones that look washed out with it.

In order to have best of both, this change checks if the filename contains the word `contrast` and acts as if I have set the sleep screen filter "contrast"  for this particular image. 

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
