### PR TITLE
feat: smooth battery percentage for x4

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -113,8 +113,14 @@ uint16_t HalPowerManager::getBatteryPercentage() const {
     return _batteryCachedPercent;
   }
   static const BatteryMonitor battery = BatteryMonitor(BAT_GPIO0);
-  _batteryCachedPercent = battery.readPercentage();
-  return _batteryCachedPercent;
+
+  // smooth the battery %.
+  if (_batteryCachedPercent == 0) {
+    _batteryCachedPercent = 10 * battery.readPercentage();
+  } else {
+    _batteryCachedPercent = (_batteryCachedPercent * 9 + battery.readPercentage() * 10) / 10;
+  }
+  return _batteryCachedPercent / 10;
 }
 
 HalPowerManager::Lock::Lock() {


### PR DESCRIPTION
## Summary

Battery percentage is calculated from the voltage, which is not totally stable. We smooth the battery percentage using a moving average.

## Additional Context
issue discussion: https://github.com/crosspoint-reader/crosspoint-reader/issues/1444

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? 
PARTIALLY 
