### PR TITLE
docs: Update README with firmware flashing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ back to the other partition using the "Swap boot partition" button here https://
 To revert back to the official firmware, you can flash the latest official firmware from https://xteink.dve.al/, or swap
 back to the other partition using the "Swap boot partition" button here https://xteink.dve.al/debug.
 
+### Command line (specific firmware version)
+
+1. Install [`esptool`](https://github.com/espressif/esptool) :
+```bash
+pip install esptool
+```
+2. Download the `firmware.bin` file from the release of your choice via the [releases page](https://github.com/crosspoint-reader/crosspoint-reader/releases)
+3. Connect your Xteink X4 to your computer via USB-C.
+4. Note the device location. On Linux, run `dmesg` after connecting. On MacOS, run :
+```bash
+log stream --predicate 'subsystem == "com.apple.iokit"' --info
+```
+5. Flash the firmware :
+```bash
+esptool.py --chip esp32c3 --port /dev/ttyACM0 --baud 921600 write_flash 0x10000 /path/to/firmware.bin
+```
+Change `/dev/ttyACM0` to the device for your system.
+
 ### Manual
 
 See [Development](#development) below.


### PR DESCRIPTION
Added instructions for flashing firmware using esptool.

## Summary

Instructions for flashing a specific firmware from the terminal using `esptool.py`.

## Additional Context

Not everyone has Chrome or Chromium installed. An alternative to the web-based firmware utility shouldn't be hard to find.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_ : `dmesg` command analog for MacOS