### PR TITLE
fix: Accumulate glyph positions in fixed-point for smoother text spacing

### DIFF
--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -15,10 +15,9 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
     return;
   }
 
-  int lastBaseX = startX;
-  int lastBaseAdvanceFP = 0;  // 12.4 fixed-point
+  int32_t cursorFP = fp4::fromPixel(startX);  // accumulate in 12.4 fixed-point
+  int lastBaseAdvanceFP = 0;                  // 12.4 fixed-point (for combining mark centering)
   int lastBaseTop = 0;
-  int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
   constexpr int MIN_COMBINING_GAP_PX = 1;
   uint32_t cp;
   uint32_t prevCp = 0;
@@ -31,9 +30,7 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
 
     const EpdGlyph* glyph = getGlyph(cp);
     if (!glyph) {
-      lastBaseX += fp4::toPixel(prevAdvanceFP);  // flush pending advance before resetting
       prevCp = 0;
-      prevAdvanceFP = 0;
       continue;
     }
 
@@ -45,12 +42,14 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
       }
     }
 
+    // Add kerning to the accumulator (no rounding yet)
     if (!isCombining && prevCp != 0) {
       const auto kernFP = getKerning(prevCp, cp);  // 4.4 fixed-point kern
-      lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);
+      cursorFP += kernFP;
     }
 
-    const int glyphBaseX = isCombining ? (lastBaseX + fp4::toPixel(lastBaseAdvanceFP / 2)) : lastBaseX;
+    const int snapX = fp4::toPixel(cursorFP);
+    const int glyphBaseX = isCombining ? fp4::toPixel(cursorFP + lastBaseAdvanceFP / 2) : snapX;
     const int glyphBaseY = startY - raiseBy;
 
     *minX = std::min(*minX, glyphBaseX + glyph->left);
@@ -61,7 +60,7 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
     if (!isCombining) {
       lastBaseAdvanceFP = glyph->advanceX;  // 12.4 fixed-point
       lastBaseTop = glyph->top;
-      prevAdvanceFP = lastBaseAdvanceFP;
+      cursorFP += lastBaseAdvanceFP;  // advance accumulator without rounding
       prevCp = cp;
     }
   }

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1011,8 +1011,7 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
 
   uint32_t cp;
   uint32_t prevCp = 0;
-  int widthPx = 0;
-  int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
+  int32_t cursorFP = 0;  // accumulate in 12.4 fixed-point, matching drawText
   const auto& font = fontIt->second;
   while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&text)))) {
     if (utf8IsCombiningMark(cp)) {
@@ -1020,19 +1019,16 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
     }
     cp = font.applyLigatures(cp, text, style);
 
-    // Differential rounding: snap (previous advance + current kern) together,
-    // matching drawText so measurement and rendering agree exactly.
     if (prevCp != 0) {
-      const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
-      widthPx += fp4::toPixel(prevAdvanceFP + kernFP);         // snap 12.4 fixed-point to nearest pixel
+      const auto kernFP = font.getKerning(prevCp, cp, style);
+      cursorFP += kernFP;
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);
-    prevAdvanceFP = glyph ? glyph->advanceX : 0;
+    cursorFP += glyph ? glyph->advanceX : 0;
     prevCp = cp;
   }
-  widthPx += fp4::toPixel(prevAdvanceFP);  // final glyph's advance
-  return widthPx;
+  return fp4::toPixel(cursorFP);
 }
 
 int GfxRenderer::getFontAscenderSize(const int fontId) const {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -215,10 +215,9 @@ void GfxRenderer::drawCenteredText(const int fontId, const int y, const char* te
 void GfxRenderer::drawText(const int fontId, const int x, const int y, const char* text, const bool black,
                            const EpdFontFamily::Style style) const {
   const int yPos = y + getFontAscenderSize(fontId);
-  int lastBaseX = x;
-  int lastBaseAdvanceFP = 0;  // 12.4 fixed-point
+  int32_t cursorFP = fp4::fromPixel(x);  // accumulate position in 12.4 fixed-point
+  int lastBaseAdvanceFP = 0;             // 12.4 fixed-point (for combining mark centering)
   int lastBaseTop = 0;
-  int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
 
   // cannot draw a NULL / empty string
   if (text == nullptr || *text == '\0') {
@@ -251,7 +250,7 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
         }
       }
 
-      const int combiningX = lastBaseX + fp4::toPixel(lastBaseAdvanceFP / 2);
+      const int combiningX = fp4::toPixel(cursorFP + lastBaseAdvanceFP / 2);
       const int combiningY = yPos - raiseBy;
       renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, combiningX, combiningY, black, style);
       continue;
@@ -259,21 +258,23 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
 
     cp = font.applyLigatures(cp, text, style);
 
-    // Differential rounding: snap (previous advance + current kern) as one unit so
-    // identical character pairs always produce the same pixel step regardless of
-    // where they fall on the line.
+    // Add kerning to the accumulator (no rounding yet)
     if (prevCp != 0) {
       const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
-      lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
+      cursorFP += kernFP;
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);
 
     lastBaseAdvanceFP = glyph ? glyph->advanceX : 0;
     lastBaseTop = glyph ? glyph->top : 0;
-    prevAdvanceFP = lastBaseAdvanceFP;
 
-    renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, lastBaseX, yPos, black, style);
+    // Snap to pixel only for rendering; accumulator retains fractional precision
+    const int snapX = fp4::toPixel(cursorFP);
+    renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, snapX, yPos, black, style);
+
+    // Advance the accumulator in fixed-point (no rounding loss)
+    cursorFP += lastBaseAdvanceFP;
     prevCp = cp;
   }
 }
@@ -1078,10 +1079,9 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
 
   const auto& font = fontIt->second;
 
-  int lastBaseY = y;
-  int lastBaseAdvanceFP = 0;  // 12.4 fixed-point
+  int32_t cursorFP = fp4::fromPixel(y);  // accumulate in 12.4 fixed-point (Y axis, decreasing)
+  int lastBaseAdvanceFP = 0;             // 12.4 fixed-point (for combining mark centering)
   int lastBaseTop = 0;
-  int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
   constexpr int MIN_COMBINING_GAP_PX = 1;
 
   uint32_t cp;
@@ -1098,27 +1098,30 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
       }
 
       const int combiningX = x - raiseBy;
-      const int combiningY = lastBaseY - fp4::toPixel(lastBaseAdvanceFP / 2);
+      const int combiningY = fp4::toPixel(cursorFP - lastBaseAdvanceFP / 2);
       renderCharImpl<TextRotation::Rotated90CW>(*this, renderMode, font, cp, combiningX, combiningY, black, style);
       continue;
     }
 
     cp = font.applyLigatures(cp, text, style);
 
-    // Differential rounding: snap (previous advance + current kern) as one unit,
-    // subtracting for the rotated coordinate direction.
+    // Add kerning to the accumulator (no rounding yet)
     if (prevCp != 0) {
       const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
-      lastBaseY -= fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
+      cursorFP -= kernFP;                                      // subtract for rotated direction
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);
 
     lastBaseAdvanceFP = glyph ? glyph->advanceX : 0;  // 12.4 fixed-point
     lastBaseTop = glyph ? glyph->top : 0;
-    prevAdvanceFP = lastBaseAdvanceFP;
 
-    renderCharImpl<TextRotation::Rotated90CW>(*this, renderMode, font, cp, x, lastBaseY, black, style);
+    // Snap to pixel only for rendering
+    const int snapY = fp4::toPixel(cursorFP);
+    renderCharImpl<TextRotation::Rotated90CW>(*this, renderMode, font, cp, x, snapY, black, style);
+
+    // Advance the accumulator in fixed-point (no rounding loss)
+    cursorFP -= lastBaseAdvanceFP;
     prevCp = cp;
   }
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  Complete the fix for #1182 — eliminate remaining character spacing unevenness that persisted after #1168 introduced fixed-point advances.
* **What changes are included?**
  - `drawText()`, `drawTextRotated90CW()`, and `getTextBounds()` now accumulate the cursor position in 12.4 fixed-point and only snap to integer pixels at render time
  - Previously, each glyph advance was rounded to the nearest pixel before being added to the cursor, discarding fractional precision at every step

## Background                                             
                                                                                                                                                         
PR #1168 by @znelson introduced 12.4 fixed-point advances and differential rounding, which was a significant improvement. However, as @jonasdiemer noted in #1182:

  > On Small (just tried recently), I still feel there's room for improvement, but can't pinpoint it yet                                                 
  
He attributed the remaining unevenness to screen resolution limits, but it was actually residual rounding error from the differential rounding approach, which still discarded the fractional remainder at each step.

## How it works

The old code rounded and added each step:
`cursor (int) += round(advance + kern)   // fraction lost every character
`
The new code accumulates without rounding:
```
cursor (fixed-point) += advance + kern  // no precision loss
snapX = round(cursor)                   // snap only for rendering

```
This ensures each glyph is placed at the rounded version of its true cumulative position, rather than a chain of individually rounded steps. The fractional error never compounds.

## Impact

- **6,030 pixels shifted** on a single test page (Bookerly 14pt, justified text)
- Zero performance cost — same number of operations, same types
- Binary is 12 bytes smaller (removed a `toPixel()` call from the advance step)
- Measurement (`getTextBounds`) updated to match, so line breaks stay consistent

Tested on X4 hardware. 

Side-by-side with highlights (left = old/red, right = new/blue):

<img width="964" height="800" alt="font-diff-highlighted" src="https://github.com/user-attachments/assets/0492b7ed-fcf9-4075-be9a-a20323afc059" />

Fixes #1182
---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

The fix was developed collaboratively with Claude Code (Opus 4.6). The approach (fixed-point accumulator vs per-step rounding) is a well-known technique in text rendering — Claude identified the rounding pattern in the existing code and implemented the fix.

