### PR TITLE
fix: footnote link text

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -714,6 +714,11 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       --end;
     }
 
+    // Make sure that it fit into link text string
+    if (end - start > sizeof(self->currentFootnoteLinkText) - 2) {
+        end = start + sizeof(self->currentFootnoteLinkText) - 2;
+    }
+
     // Extract footnote link text
     for (int i = start; i <= end; ++i) {
       self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = s[i];

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -714,13 +714,8 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       --end;
     }
 
-    // Make sure that it fit into link text string
-    if (end - start > sizeof(self->currentFootnoteLinkText) - 2) {
-        end = start + sizeof(self->currentFootnoteLinkText) - 2;
-    }
-
     // Extract footnote link text
-    for (int i = start; i <= end; ++i) {
+    for (int i = start; (self->currentFootnoteLinkTextLen < sizeof(self->currentFootnoteLinkText) - 1) && (i <= end); ++i) {
       self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = s[i];
     }
     self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -697,14 +697,28 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
   // Collect footnote link display text (for the number label)
   // Skip whitespace and brackets to normalize noterefs like "[1]" → "1"
   if (self->insideFootnoteLink) {
-    for (int i = 0; i < len; i++) {
-      unsigned char c = static_cast<unsigned char>(s[i]);
-      if (isWhitespace(c) || c == '[' || c == ']') continue;
-      if (self->currentFootnoteLinkTextLen < static_cast<int>(sizeof(self->currentFootnoteLinkText)) - 1) {
-        self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = c;
-        self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';
-      }
+    int start = 0;
+    int end = len - 1;
+
+    // Example input and output texts:
+    // "     [  12  ]   " => "12"
+    // "   turn to 256  " => "turn to 256"
+
+    // Ignore leading whitespaces and left square brackets
+    while (start < len && (isWhitespace(s[start]) || (s[start] == '['))) {
+      ++start;
     }
+
+    // Ignore trailing whitespaces and right square brackets
+    while (end >= start && (isWhitespace(s[end]) || (s[end] == ']'))) {
+      --end;
+    }
+
+    // Extract footnote link text
+    for (int i = start; i <= end; ++i) {
+      self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = s[i];
+    }
+    self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';
   }
 
   for (int i = 0; i < len; i++) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -715,7 +715,8 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     }
 
     // Extract footnote link text
-    for (int i = start; (self->currentFootnoteLinkTextLen < sizeof(self->currentFootnoteLinkText) - 1) && (i <= end); ++i) {
+    for (int i = start; (self->currentFootnoteLinkTextLen < sizeof(self->currentFootnoteLinkText) - 1) && (i <= end);
+         ++i) {
       self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = s[i];
     }
     self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';


### PR DESCRIPTION
## Summary

Previouls where ALL whitespace (and square brackes) removed from the footnote link text, however some link texts are multiworded, like "`turn to 252`" which were truncated into "`turnto252`", (an example from the first book "Flight from the Dark" of the Lone Wolf book series by Joe Dever, see [link](https://www.projectaon.org/en/Main/FlightFromTheDark))

* This change will only remove whitespaces from the beginning and end of the string
so "`   [  12  ]   `" will become "`12`" just like before, and "`   turn to 252   `" will become "`turn to 252`".

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
