### PR TITLE
fix: pluralize folder/file counts correctly in file list summary

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1875,7 +1875,10 @@
       totalSize += file.size;
     });
 
-    document.getElementById('folder-summary').innerHTML = `${folderCount} folders, ${files.length - folderCount} files, ${formatFileSize(totalSize)}`;
+    const fileCount = files.length - folderCount;
+    const folderLabel = folderCount === 1 ? 'folder' : 'folders';
+    const fileLabel = fileCount === 1 ? 'file' : 'files';
+    document.getElementById('folder-summary').innerHTML = `${folderCount} ${folderLabel}, ${fileCount} ${fileLabel}, ${formatFileSize(totalSize)}`;
 
     if (files.length === 0) {
       fileTable.innerHTML = '<div class="no-files">This folder is empty</div>';


### PR DESCRIPTION
## Summary

* **Goal**: Fix incorrect pluralization in the file manager web UI summary line.
* **Changes**: `FilesPage.html` always rendered the plural forms ("folders"/"files") regardless of count. The summary now selects singular or plural based on each count.

Example:
- Before: `1 folders, 1 files, 12 KB`
- After: `1 folder, 1 file, 12 KB`

## Additional Context

* Cosmetic-only fix — no behavior, performance, or memory impact.
* Change is fully client-side (JavaScript inside a single HTML template).
* English-only; web UI localization is out of scope here.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_