### PR TITLE
style: put page name first in browser titles

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CrossPoint Reader - Files</title>
+  <title>Files - CrossPoint Reader</title>
   <script src="/js/jszip.min.js"></script>
   <style>
     :root {
@@ -1734,6 +1734,11 @@
 <script>
   // get current path from query parameter
   const currentPath = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
+
+  if (currentPath !== '/') {
+    const leaf = currentPath.split('/').filter(Boolean).pop();
+    if (leaf) document.title = leaf + ' - Files - CrossPoint Reader';
+  }
 
   // Network status monitoring
   let isNetworkOnline = navigator.onLine;

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CrossPoint Reader - Settings</title>
+  <title>Settings - CrossPoint Reader</title>
   <style>
     :root {
       --font-color: #333;


### PR DESCRIPTION
## Summary

* **Goal**: Make browser tab titles, bookmarks, and history entries distinguishable across pages (including individual folders in the File Manager).
* **Changes**:
  - Reordered `<title>` so the page name comes first, followed by `CrossPoint Reader`. Browser tabs usually truncate titles from the right, and bookmark/history lists are sorted alphabetically by title — putting the differentiating part first keeps it visible in both cases, instead of every entry starting with `CrossPoint Reader - …`.
  - On `FilesPage`, added a small JS hook that updates `document.title` with the current subfolder leaf when a `path` query parameter is present — previously all folders shared the same title.

| URL | Title before | Title after |
|-----|--------------|-------------|
| `/` | `CrossPoint Reader` | `CrossPoint Reader` _(unchanged)_ |
| `/settings` | `CrossPoint Reader - Settings` | `Settings - CrossPoint Reader` |
| `/files` | `CrossPoint Reader - Files` | `Files - CrossPoint Reader` |
| `/files?path=/Books` | `CrossPoint Reader - Files` | `Books - Files - CrossPoint Reader` |
| `/files?path=/Books/Fantasy` | `CrossPoint Reader - Files` | `Fantasy - Files - CrossPoint Reader` |

## Additional Context

* Pure client-side change: `<title>` tags plus ~3 lines of JavaScript on FilesPage. No network, behavior, or memory impact.
* The static `<title>` tag remains as a fallback if JS fails.
* `HomePage` title left as-is since the app name alone is the standard convention for a root/home page.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_