### PR TITLE
fix: preserve grapheme clusters when reversing RTL words

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -1,6 +1,7 @@
 #include "ParsedText.h"
 
 #include <GfxRenderer.h>
+#include <ScriptDetector.h>
 #include <Utf8.h>
 
 #include <algorithm>
@@ -18,6 +19,10 @@ namespace {
 // Soft hyphen byte pattern used throughout EPUBs (UTF-8 for U+00AD).
 constexpr char SOFT_HYPHEN_UTF8[] = "\xC2\xAD";
 constexpr size_t SOFT_HYPHEN_BYTES = 2;
+constexpr int RTL_DETECTION_SCAN_LETTERS = 5;
+constexpr size_t RTL_DETECTION_SCAN_WORDS = 3;
+
+enum class WordDirection { Neutral, Ltr, Rtl };
 
 // Returns the first rendered codepoint of a word (skipping leading soft hyphens).
 uint32_t firstCodepoint(const std::string& word) {
@@ -49,6 +54,22 @@ void stripSoftHyphensInPlace(std::string& word) {
   while ((pos = word.find(SOFT_HYPHEN_UTF8, pos)) != std::string::npos) {
     word.erase(pos, SOFT_HYPHEN_BYTES);
   }
+}
+
+WordDirection classifyWordDirection(const std::string& word) {
+  auto* p = reinterpret_cast<const unsigned char*>(word.c_str());
+  while (*p) {
+    uint32_t cp = utf8NextCodepoint(&p);
+    if (cp == 0 || cp == REPLACEMENT_GLYPH) break;
+    if (!ScriptDetector::isLetterCodepoint(cp)) continue;
+    return ScriptDetector::isRtlCodepoint(cp) ? WordDirection::Rtl : WordDirection::Ltr;
+  }
+  return WordDirection::Neutral;
+}
+
+bool isNaturalAlignment(const BlockStyle& blockStyle) {
+  return blockStyle.alignment == CssTextAlign::Justify ||
+         (blockStyle.isRtl ? blockStyle.alignment == CssTextAlign::Right : blockStyle.alignment == CssTextAlign::Left);
 }
 
 // Returns the advance width for a word while ignoring soft hyphen glyphs and optionally appending a visible hyphen.
@@ -97,6 +118,19 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     return;
   }
 
+  // Per-paragraph RTL auto-detection: only when CSS/HTML didn't explicitly set direction.
+  // Explicit dir="ltr" must be respected and not overridden by content heuristic.
+  if (!blockStyle.directionDefined) {
+    // Check the first few words for RTL letter codepoints (no heap allocation).
+    const size_t wordsToScan = std::min(words.size(), RTL_DETECTION_SCAN_WORDS);
+    for (size_t i = 0; i < wordsToScan; ++i) {
+      if (ScriptDetector::startsWithRtl(words[i].c_str(), RTL_DETECTION_SCAN_LETTERS)) {
+        blockStyle.isRtl = true;
+        break;
+      }
+    }
+  }
+
   // Apply fixed transforms before any per-line layout work.
   applyParagraphIndent();
 
@@ -142,13 +176,14 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
     return {};
   }
 
-  // Calculate first line indent (only for left/justified text).
+  // Calculate first line indent (only for naturally-aligned text).
   // Positive text-indent (paragraph indent) is suppressed when extraParagraphSpacing is on.
   // Negative text-indent (hanging indent, e.g. margin-left:3em; text-indent:-1em) always applies —
   // it is structural (positions the bullet/marker), not decorative.
+  // For RTL, natural alignment is Right/Justify; for LTR, it is Left/Justify.
+  const bool isNaturalAlign = isNaturalAlignment(blockStyle);
   const int firstLineIndent =
-      blockStyle.textIndentDefined && (blockStyle.textIndent < 0 || !extraParagraphSpacing) &&
-              (blockStyle.alignment == CssTextAlign::Justify || blockStyle.alignment == CssTextAlign::Left)
+      blockStyle.textIndentDefined && (blockStyle.textIndent < 0 || !extraParagraphSpacing) && isNaturalAlign
           ? blockStyle.textIndent
           : 0;
 
@@ -261,10 +296,13 @@ void ParsedText::applyParagraphIndent() {
     return;
   }
 
+  // For LTR, indent applies to Left/Justify; for RTL, indent applies to Right/Justify
+  const bool isNaturalAlign = isNaturalAlignment(blockStyle);
+
   if (blockStyle.textIndentDefined) {
     // CSS text-indent is explicitly set (even if 0) - don't use fallback EmSpace
     // The actual indent positioning is handled in extractLine()
-  } else if (blockStyle.alignment == CssTextAlign::Justify || blockStyle.alignment == CssTextAlign::Left) {
+  } else if (isNaturalAlign) {
     // No CSS text-indent defined - use EmSpace fallback for visual indent
     words.front().insert(0, "\xe2\x80\x83");
   }
@@ -274,13 +312,14 @@ void ParsedText::applyParagraphIndent() {
 std::vector<size_t> ParsedText::computeHyphenatedLineBreaks(const GfxRenderer& renderer, const int fontId,
                                                             const int pageWidth, std::vector<uint16_t>& wordWidths,
                                                             std::vector<bool>& continuesVec) {
-  // Calculate first line indent (only for left/justified text).
+  // Calculate first line indent (only for naturally-aligned text).
   // Positive text-indent (paragraph indent) is suppressed when extraParagraphSpacing is on.
   // Negative text-indent (hanging indent, e.g. margin-left:3em; text-indent:-1em) always applies —
   // it is structural (positions the bullet/marker), not decorative.
+  // For RTL, natural alignment is Right/Justify; for LTR, it is Left/Justify.
+  const bool isNaturalAlign = isNaturalAlignment(blockStyle);
   const int firstLineIndent =
-      blockStyle.textIndentDefined && (blockStyle.textIndent < 0 || !extraParagraphSpacing) &&
-              (blockStyle.alignment == CssTextAlign::Justify || blockStyle.alignment == CssTextAlign::Left)
+      blockStyle.textIndentDefined && (blockStyle.textIndent < 0 || !extraParagraphSpacing) && isNaturalAlign
           ? blockStyle.textIndent
           : 0;
 
@@ -443,16 +482,17 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
 
-  // Calculate first line indent (only for left/justified text).
+  // Calculate first line indent (only for naturally-aligned text).
   // Positive text-indent (paragraph indent) is suppressed when extraParagraphSpacing is on.
   // Negative text-indent (hanging indent, e.g. margin-left:3em; text-indent:-1em) always applies —
   // it is structural (positions the bullet/marker), not decorative.
+  // For RTL, natural alignment is Right/Justify; for LTR, it is Left/Justify.
   const bool isFirstLine = breakIndex == 0;
-  const int firstLineIndent =
-      isFirstLine && blockStyle.textIndentDefined && (blockStyle.textIndent < 0 || !extraParagraphSpacing) &&
-              (blockStyle.alignment == CssTextAlign::Justify || blockStyle.alignment == CssTextAlign::Left)
-          ? blockStyle.textIndent
-          : 0;
+  const bool isNaturalAlign = isNaturalAlignment(blockStyle);
+  const int firstLineIndent = isFirstLine && blockStyle.textIndentDefined &&
+                                      (blockStyle.textIndent < 0 || !extraParagraphSpacing) && isNaturalAlign
+                                  ? blockStyle.textIndent
+                                  : 0;
 
   // Calculate total word width for this line, count actual word gaps,
   // and accumulate total natural gap widths (including space kerning adjustments).
@@ -480,48 +520,89 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   const int effectivePageWidth = pageWidth - firstLineIndent;
   const bool isLastLine = breakIndex == lineBreakIndices.size() - 1;
 
+  // For RTL, implicit/default Left alignment becomes Right alignment.
+  // Explicit text-align:left must remain left for CSS correctness.
+  const CssTextAlign effectiveAlignment =
+      (blockStyle.isRtl && !blockStyle.textAlignDefined && blockStyle.alignment == CssTextAlign::Left)
+          ? CssTextAlign::Right
+          : blockStyle.alignment;
+
   // For justified text, compute per-gap extra to distribute remaining space evenly
   const int spareSpace = effectivePageWidth - lineWordWidthSum - totalNaturalGaps;
-  const int justifyExtra = (blockStyle.alignment == CssTextAlign::Justify && !isLastLine && actualGapCount >= 1)
+  const int justifyExtra = (effectiveAlignment == CssTextAlign::Justify && !isLastLine && actualGapCount >= 1)
                                ? spareSpace / static_cast<int>(actualGapCount)
                                : 0;
-
-  // Calculate initial x position (first line starts at indent for left/justified text;
-  // may be negative for hanging indents, e.g. margin-left:3em; text-indent:-1em).
-  auto xpos = static_cast<int16_t>(firstLineIndent);
-  if (blockStyle.alignment == CssTextAlign::Right) {
-    xpos = effectivePageWidth - lineWordWidthSum - totalNaturalGaps;
-  } else if (blockStyle.alignment == CssTextAlign::Center) {
-    xpos = (effectivePageWidth - lineWordWidthSum - totalNaturalGaps) / 2;
-  }
 
   // Pre-calculate X positions for words
   // Continuation words attach to the previous word with no space before them
   std::vector<int16_t> lineXPos;
   lineXPos.reserve(lineWordCount);
 
-  for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {
-    lineXPos.push_back(xpos);
+  if (blockStyle.isRtl) {
+    // RTL: position words from right to left
+    auto xpos = static_cast<int>(effectivePageWidth);
+    if (effectiveAlignment == CssTextAlign::Left) {
+      // Explicit left alignment in RTL context
+      xpos = lineWordWidthSum + totalNaturalGaps;
+    } else if (effectiveAlignment == CssTextAlign::Center) {
+      xpos = (effectivePageWidth + lineWordWidthSum + totalNaturalGaps) / 2;
+    }
+    // For Right and Justify, start from right edge (xpos = effectivePageWidth)
 
-    const bool nextIsContinuation = wordIdx + 1 < lineWordCount && continuesVec[lastBreakAt + wordIdx + 1];
-    if (nextIsContinuation) {
-      int advance = wordWidths[lastBreakAt + wordIdx];
-      // Cross-boundary kerning for continuation words (e.g. nonbreaking spaces, attached punctuation)
-      advance +=
-          renderer.getKerning(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
-                              firstCodepoint(words[lastBreakAt + wordIdx + 1]), wordStyles[lastBreakAt + wordIdx]);
-      xpos += advance;
-    } else {
-      int gap = 0;
-      if (wordIdx + 1 < lineWordCount) {
-        gap = renderer.getSpaceAdvance(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
-                                       firstCodepoint(words[lastBreakAt + wordIdx + 1]),
-                                       wordStyles[lastBreakAt + wordIdx]);
+    for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {
+      xpos -= wordWidths[lastBreakAt + wordIdx];
+      lineXPos.push_back(static_cast<int16_t>(xpos < 0 ? 0 : xpos));
+
+      const bool nextIsContinuation = wordIdx + 1 < lineWordCount && continuesVec[lastBreakAt + wordIdx + 1];
+      if (nextIsContinuation) {
+        // Cross-boundary kerning for continuation words
+        xpos -=
+            renderer.getKerning(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
+                                firstCodepoint(words[lastBreakAt + wordIdx + 1]), wordStyles[lastBreakAt + wordIdx]);
+      } else {
+        int gap = 0;
+        if (wordIdx + 1 < lineWordCount) {
+          gap = renderer.getSpaceAdvance(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
+                                         firstCodepoint(words[lastBreakAt + wordIdx + 1]),
+                                         wordStyles[lastBreakAt + wordIdx]);
+        }
+        if (effectiveAlignment == CssTextAlign::Justify && !isLastLine) {
+          gap += justifyExtra;
+        }
+        xpos -= gap;
       }
-      if (blockStyle.alignment == CssTextAlign::Justify && !isLastLine) {
-        gap += justifyExtra;
+    }
+  } else {
+    // LTR: position words from left to right
+    auto xpos = static_cast<int16_t>(firstLineIndent);
+    if (effectiveAlignment == CssTextAlign::Right) {
+      xpos = effectivePageWidth - lineWordWidthSum - totalNaturalGaps;
+    } else if (effectiveAlignment == CssTextAlign::Center) {
+      xpos = (effectivePageWidth - lineWordWidthSum - totalNaturalGaps) / 2;
+    }
+
+    for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {
+      lineXPos.push_back(xpos);
+
+      const bool nextIsContinuation = wordIdx + 1 < lineWordCount && continuesVec[lastBreakAt + wordIdx + 1];
+      if (nextIsContinuation) {
+        int advance = wordWidths[lastBreakAt + wordIdx];
+        advance +=
+            renderer.getKerning(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
+                                firstCodepoint(words[lastBreakAt + wordIdx + 1]), wordStyles[lastBreakAt + wordIdx]);
+        xpos += advance;
+      } else {
+        int gap = 0;
+        if (wordIdx + 1 < lineWordCount) {
+          gap = renderer.getSpaceAdvance(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
+                                         firstCodepoint(words[lastBreakAt + wordIdx + 1]),
+                                         wordStyles[lastBreakAt + wordIdx]);
+        }
+        if (effectiveAlignment == CssTextAlign::Justify && !isLastLine) {
+          gap += justifyExtra;
+        }
+        xpos += wordWidths[lastBreakAt + wordIdx] + gap;
       }
-      xpos += wordWidths[lastBreakAt + wordIdx] + gap;
     }
   }
 
@@ -533,6 +614,66 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {
       stripSoftHyphensInPlace(word);
+    }
+  }
+
+  // BiDi processing: reorder opposite-direction runs
+  // RTL paragraphs have LTR runs that need left-to-right order
+  // LTR paragraphs have RTL runs that need right-to-left order
+  const size_t n = lineWords.size();
+  size_t runStart = 0;
+  while (runStart < n) {
+    const WordDirection runDirection = classifyWordDirection(lineWords[runStart]);
+    const bool isOppositeDir = (blockStyle.isRtl && runDirection == WordDirection::Ltr) ||
+                               (!blockStyle.isRtl && runDirection == WordDirection::Rtl);
+
+    if (isOppositeDir) {
+      size_t runEnd = runStart + 1;
+      while (runEnd < n) {
+        const WordDirection nextDirection = classifyWordDirection(lineWords[runEnd]);
+        if (nextDirection != runDirection && nextDirection != WordDirection::Neutral) {
+          break;
+        }
+        runEnd++;
+      }
+
+      if (runEnd - runStart > 1) {
+        // Calculate average gap from original positions
+        int totalGap = 0;
+        for (size_t i = runStart; i < runEnd - 1; i++) {
+          int gap;
+          if (blockStyle.isRtl) {
+            // RTL paragraph: positions decrease, next word is at lower X
+            gap = lineXPos[i] - lineXPos[i + 1] - wordWidths[lastBreakAt + i + 1];
+          } else {
+            // LTR paragraph: positions increase, next word is at higher X
+            gap = lineXPos[i + 1] - lineXPos[i] - wordWidths[lastBreakAt + i];
+          }
+          totalGap += gap;
+        }
+        int avgGap = totalGap / static_cast<int>(runEnd - runStart - 1);
+
+        if (blockStyle.isRtl) {
+          // LTR run in RTL paragraph: recalculate left-to-right from leftmost position
+          int xpos = lineXPos[runEnd - 1];  // Leftmost position
+          for (size_t i = runStart; i < runEnd; i++) {
+            lineXPos[i] = static_cast<int16_t>(xpos);
+            xpos += wordWidths[lastBreakAt + i] + avgGap;
+          }
+        } else {
+          // RTL run in LTR paragraph: recalculate right-to-left from rightmost position
+          // rightmost = pos[runEnd-1] + width[runEnd-1]
+          int xpos = lineXPos[runEnd - 1] + wordWidths[lastBreakAt + runEnd - 1];
+          for (size_t i = runStart; i < runEnd; i++) {
+            xpos -= wordWidths[lastBreakAt + i];
+            lineXPos[i] = static_cast<int16_t>(xpos);
+            xpos -= avgGap;
+          }
+        }
+      }
+      runStart = runEnd;
+    } else {
+      runStart++;
     }
   }
 

--- a/lib/Epub/Epub/blocks/BlockStyle.h
+++ b/lib/Epub/Epub/blocks/BlockStyle.h
@@ -22,6 +22,8 @@ struct BlockStyle {
   int16_t textIndent = 0;
   bool textIndentDefined = false;  // true if text-indent was explicitly set in CSS
   bool textAlignDefined = false;   // true if text-align was explicitly set in CSS
+  bool isRtl = false;              // true if resolved direction is RTL
+  bool directionDefined = false;   // true if direction was explicitly set in CSS/HTML
 
   // Combined horizontal insets (margin + padding)
   [[nodiscard]] int16_t leftInset() const { return marginLeft + paddingLeft; }
@@ -58,6 +60,14 @@ struct BlockStyle {
       combinedBlockStyle.alignment = alignment;
       combinedBlockStyle.textAlignDefined = textAlignDefined;
     }
+    // Direction: use child's if defined, otherwise inherit parent
+    if (child.directionDefined) {
+      combinedBlockStyle.isRtl = child.isRtl;
+      combinedBlockStyle.directionDefined = true;
+    } else {
+      combinedBlockStyle.isRtl = isRtl;
+      combinedBlockStyle.directionDefined = directionDefined;
+    }
     return combinedBlockStyle;
   }
 
@@ -91,6 +101,11 @@ struct BlockStyle {
       blockStyle.alignment = blockStyle.textAlignDefined ? cssStyle.textAlign : CssTextAlign::Justify;
     } else {
       blockStyle.alignment = paragraphAlignment;
+    }
+    // RTL direction from CSS/HTML
+    if (cssStyle.hasDirection()) {
+      blockStyle.isRtl = (cssStyle.direction == CssTextDirection::Rtl);
+      blockStyle.directionDefined = true;
     }
     return blockStyle;
   }

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -67,6 +67,8 @@ bool TextBlock::serialize(FsFile& file) const {
   serialization::writePod(file, blockStyle.paddingRight);
   serialization::writePod(file, blockStyle.textIndent);
   serialization::writePod(file, blockStyle.textIndentDefined);
+  serialization::writePod(file, blockStyle.isRtl);
+  serialization::writePod(file, blockStyle.directionDefined);
 
   return true;
 }
@@ -108,6 +110,8 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   serialization::readPod(file, blockStyle.paddingRight);
   serialization::readPod(file, blockStyle.textIndent);
   serialization::readPod(file, blockStyle.textIndentDefined);
+  serialization::readPod(file, blockStyle.isRtl);
+  serialization::readPod(file, blockStyle.directionDefined);
 
   return std::unique_ptr<TextBlock>(
       new TextBlock(std::move(words), std::move(wordXpos), std::move(wordStyles), blockStyle));

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -344,6 +344,15 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
     const std::string_view displayValue = stripTrailingImportant(propValueBuf);
     style.display = (displayValue == "none") ? CssDisplay::None : CssDisplay::Block;
     style.defined.display = 1;
+  } else if (propNameBuf == "direction") {
+    const std::string_view directionValue = stripTrailingImportant(propValueBuf);
+    if (directionValue == "rtl") {
+      style.direction = CssTextDirection::Rtl;
+      style.defined.direction = 1;
+    } else if (directionValue == "ltr") {
+      style.direction = CssTextDirection::Ltr;
+      style.defined.direction = 1;
+    }
   }
 }
 

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -5,6 +5,7 @@
 // Matches order of PARAGRAPH_ALIGNMENT in CrossPointSettings
 enum class CssTextAlign : uint8_t { Justify = 0, Left = 1, Center = 2, Right = 3, None = 4 };
 enum class CssUnit : uint8_t { Pixels = 0, Em = 1, Rem = 2, Points = 3, Percent = 4 };
+enum class CssTextDirection : uint8_t { Ltr = 0, Rtl = 1 };
 
 // Represents a CSS length value with its unit, allowing deferred resolution to pixels
 struct CssLength {
@@ -75,6 +76,7 @@ struct CssPropertyFlags {
   uint16_t imageHeight : 1;
   uint16_t imageWidth : 1;
   uint16_t display : 1;
+  uint16_t direction : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -92,19 +94,20 @@ struct CssPropertyFlags {
         paddingRight(0),
         imageHeight(0),
         imageWidth(0),
-        display(0) {}
+        display(0),
+        direction(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display;
+           imageWidth || display || direction;
   }
 
   void clearAll() {
     textAlign = fontStyle = fontWeight = textDecoration = textIndent = 0;
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
-    imageHeight = imageWidth = display = 0;
+    imageHeight = imageWidth = display = direction = 0;
   }
 };
 
@@ -116,6 +119,7 @@ struct CssStyle {
   CssFontStyle fontStyle = CssFontStyle::Normal;
   CssFontWeight fontWeight = CssFontWeight::Normal;
   CssTextDecoration textDecoration = CssTextDecoration::None;
+  CssTextDirection direction = CssTextDirection::Ltr;
 
   CssLength textIndent;     // First-line indent (deferred resolution)
   CssLength marginTop;      // Vertical spacing before block
@@ -199,6 +203,10 @@ struct CssStyle {
       display = base.display;
       defined.display = 1;
     }
+    if (base.hasDirection()) {
+      direction = base.direction;
+      defined.direction = 1;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -217,12 +225,14 @@ struct CssStyle {
   [[nodiscard]] bool hasImageHeight() const { return defined.imageHeight; }
   [[nodiscard]] bool hasImageWidth() const { return defined.imageWidth; }
   [[nodiscard]] bool hasDisplay() const { return defined.display; }
+  [[nodiscard]] bool hasDirection() const { return defined.direction; }
 
   void reset() {
     textAlign = CssTextAlign::Left;
     fontStyle = CssFontStyle::Normal;
     fontWeight = CssFontWeight::Normal;
     textDecoration = CssTextDecoration::None;
+    direction = CssTextDirection::Ltr;
     textIndent = CssLength{};
     marginTop = marginBottom = marginLeft = marginRight = CssLength{};
     paddingTop = paddingBottom = paddingLeft = paddingRight = CssLength{};

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -163,9 +163,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     return;
   }
 
-  // Extract class, style, and id attributes
+  // Extract class, style, id, and dir attributes for CSS/RTL processing
   std::string classAttr;
   std::string styleAttr;
+  std::string dirAttr;
   if (atts != nullptr) {
     for (int i = 0; atts[i]; i += 2) {
       if (strcmp(atts[i], "class") == 0) {
@@ -175,6 +176,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       } else if (strcmp(atts[i], "id") == 0) {
         // Defer recording until startNewTextBlock, after previous block is flushed to pages
         self->pendingAnchorId = atts[i + 1];
+      } else if (strcmp(atts[i], "dir") == 0) {
+        dirAttr = atts[i + 1];
       }
     }
   }
@@ -191,6 +194,17 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (!styleAttr.empty()) {
       CssStyle inlineStyle = CssParser::parseInlineStyle(styleAttr);
       cssStyle.applyOver(inlineStyle);
+    }
+  }
+
+  // HTML dir attribute overrides CSS direction (case-insensitive per HTML spec)
+  if (!dirAttr.empty()) {
+    if (strcasecmp(dirAttr.c_str(), "rtl") == 0) {
+      cssStyle.direction = CssTextDirection::Rtl;
+      cssStyle.defined.direction = 1;
+    } else if (strcasecmp(dirAttr.c_str(), "ltr") == 0) {
+      cssStyle.direction = CssTextDirection::Ltr;
+      cssStyle.defined.direction = 1;
     }
   }
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -3,9 +3,18 @@
 #include <FontDecompressor.h>
 #include <HalGPIO.h>
 #include <Logging.h>
+#include <ScriptDetector.h>
 #include <Utf8.h>
 
+#include <cctype>
+
 #include "FontCacheManager.h"
+
+namespace {
+bool hasRtlCodepoint(const char* text);
+std::string buildVisualRtlText(const char* text);
+const char* resolveVisualText(const char* text, std::string& visualBuffer);
+}  // namespace
 
 const uint8_t* GfxRenderer::getGlyphBitmap(const EpdFontData* fontData, const EpdGlyph* glyph) const {
   if (fontData->groups != nullptr) {
@@ -195,14 +204,21 @@ void GfxRenderer::drawPixel(const int x, const int y, const bool state) const {
 }
 
 int GfxRenderer::getTextWidth(const int fontId, const char* text, const EpdFontFamily::Style style) const {
+  if (text == nullptr || *text == '\0') {
+    return 0;
+  }
+
   const auto fontIt = fontMap.find(fontId);
   if (fontIt == fontMap.end()) {
     LOG_ERR("GFX", "Font %d not found", fontId);
     return 0;
   }
 
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual);
+
   int w = 0, h = 0;
-  fontIt->second.getTextDimensions(text, &w, &h, style);
+  fontIt->second.getTextDimensions(renderedText, &w, &h, style);
   return w;
 }
 
@@ -214,6 +230,14 @@ void GfxRenderer::drawCenteredText(const int fontId, const int y, const char* te
 
 void GfxRenderer::drawText(const int fontId, const int x, const int y, const char* text, const bool black,
                            const EpdFontFamily::Style style) const {
+  // cannot draw a NULL / empty string
+  if (text == nullptr || *text == '\0') {
+    return;
+  }
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual);
+
   const int yPos = y + getFontAscenderSize(fontId);
   int lastBaseX = x;
   int lastBaseLeft = 0;
@@ -221,13 +245,8 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
   int lastBaseTop = 0;
   int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
 
-  // cannot draw a NULL / empty string
-  if (text == nullptr || *text == '\0') {
-    return;
-  }
-
   if (fontCacheManager_ && fontCacheManager_->isScanning()) {
-    fontCacheManager_->recordText(text, fontId, style);
+    fontCacheManager_->recordText(renderedText, fontId, style);
     return;
   }
 
@@ -238,9 +257,16 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
   }
   const auto& font = fontIt->second;
 
+  const char* textCursor = renderedText;
   uint32_t cp;
   uint32_t prevCp = 0;
-  while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&text)))) {
+  while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&textCursor)))) {
+    // Skip Hebrew Niqqud (vowel marks)
+    // Temporary: avoid adding Niqqud to built-in fonts. Remove when custom fonts are supported.
+    if (cp >= 0x0591 && cp <= 0x05C7) {
+      continue;
+    }
+
     if (utf8IsCombiningMark(cp)) {
       const EpdGlyph* combiningGlyph = font.getGlyph(cp, style);
       if (!combiningGlyph) continue;
@@ -251,7 +277,7 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
       continue;
     }
 
-    cp = font.applyLigatures(cp, text, style);
+    cp = font.applyLigatures(cp, textCursor, style);
 
     // Differential rounding: snap (previous advance + current kern) as one unit so
     // identical character pairs always produce the same pixel step regardless of
@@ -271,6 +297,104 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, lastBaseX, yPos, black, style);
     prevCp = cp;
   }
+}
+
+namespace {
+bool hasRtlCodepoint(const char* text) {
+  if (!text) return false;
+
+  // Fast path for common ASCII-only strings.
+  auto* bytes = reinterpret_cast<const unsigned char*>(text);
+  bool hasNonAscii = false;
+  for (const unsigned char* q = bytes; *q; ++q) {
+    if ((*q & 0x80) != 0) {
+      hasNonAscii = true;
+      break;
+    }
+  }
+  if (!hasNonAscii) return false;
+
+  auto* p = bytes;
+  while (*p) {
+    uint32_t cp = utf8NextCodepoint(&p);
+    if (cp == 0 || cp == REPLACEMENT_GLYPH) break;
+    if (ScriptDetector::isRtlCodepoint(cp)) return true;
+  }
+  return false;
+}
+
+std::string buildVisualRtlText(const char* text) {
+  if (!text || *text == '\0') return {};
+
+  std::string visual;
+  const size_t textLen = strlen(text);
+  visual.reserve(textLen);
+
+  std::string segment;
+  segment.reserve(32);
+
+  auto isWhitespace = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  const bool lineStartsRtl = ScriptDetector::startsWithRtl(text, 5);
+
+  if (lineStartsRtl) {
+    // RTL-base line: walk runs from end to start so word order is visually right-to-left.
+    const char* runEnd = text + textLen;
+    while (runEnd > text) {
+      const bool isSpaceRun = isWhitespace(static_cast<unsigned char>(*(runEnd - 1)));
+      const char* runStart = runEnd - 1;
+      while (runStart > text && isWhitespace(static_cast<unsigned char>(*(runStart - 1))) == isSpaceRun) {
+        runStart--;
+      }
+
+      if (isSpaceRun) {
+        visual.append(runStart, static_cast<size_t>(runEnd - runStart));
+      } else {
+        segment.assign(runStart, static_cast<size_t>(runEnd - runStart));
+        ScriptDetector::reverseIfRtl(segment);
+        visual += segment;
+      }
+
+      runEnd = runStart;
+    }
+    return visual;
+  }
+
+  // LTR-base line: keep run order and only flip RTL glyph order per run.
+  const char* runStart = text;
+  while (*runStart) {
+    const bool isSpaceRun = isWhitespace(static_cast<unsigned char>(*runStart));
+    const char* runEnd = runStart + 1;
+    while (*runEnd && isWhitespace(static_cast<unsigned char>(*runEnd)) == isSpaceRun) {
+      runEnd++;
+    }
+
+    if (isSpaceRun) {
+      visual.append(runStart, static_cast<size_t>(runEnd - runStart));
+    } else {
+      segment.assign(runStart, static_cast<size_t>(runEnd - runStart));
+      ScriptDetector::reverseIfRtl(segment);
+      visual += segment;
+    }
+
+    runStart = runEnd;
+  }
+  return visual;
+}
+
+const char* resolveVisualText(const char* text, std::string& visualBuffer) {
+  if (!text || *text == '\0' || !hasRtlCodepoint(text)) {
+    return text;
+  }
+  visualBuffer = buildVisualRtlText(text);
+  return visualBuffer.c_str();
+}
+}  // namespace
+
+void GfxRenderer::drawTextRtl(const int fontId, const int rightX, const int y, const char* text, const bool black,
+                              const EpdFontFamily::Style style) const {
+  if (!text || *text == '\0') return;
+  const int width = getTextWidth(fontId, text, style);
+  drawText(fontId, rightX - width, y, text, black, style);
 }
 
 void GfxRenderer::drawLine(int x1, int y1, int x2, int y2, const bool state) const {
@@ -1129,6 +1253,12 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
   uint32_t cp;
   uint32_t prevCp = 0;
   while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&text)))) {
+    // Skip Hebrew Niqqud (vowel marks)
+    // Temporary: avoid adding Niqqud to built-in fonts. Remove when custom fonts are supported.
+    if (cp >= 0x0591 && cp <= 0x05C7) {
+      continue;
+    }
+
     if (utf8IsCombiningMark(cp)) {
       const EpdGlyph* combiningGlyph = font.getGlyph(cp, style);
       if (!combiningGlyph) continue;

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -118,6 +118,8 @@ class GfxRenderer {
                         EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   void drawText(int fontId, int x, int y, const char* text, bool black = true,
                 EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+  void drawTextRtl(int fontId, int rightX, int y, const char* text, bool black = true,
+                   EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   int getSpaceWidth(int fontId, EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   /// Returns the total inter-word advance: fp4::toPixel(spaceAdvance + kern(leftCp,' ') + kern(' ',rightCp)).
   /// Using a single snap avoids the +/-1 px rounding error that arises when space advance and kern are

--- a/lib/ScriptDetector/ScriptDetector.cpp
+++ b/lib/ScriptDetector/ScriptDetector.cpp
@@ -1,0 +1,109 @@
+#include "ScriptDetector.h"
+
+#include <Utf8.h>
+
+#include <algorithm>
+
+namespace ScriptDetector {
+
+bool startsWithRtl(const char* text, int maxLetters) {
+  if (!text || maxLetters <= 0) return false;
+  auto* p = reinterpret_cast<const unsigned char*>(text);
+  int letterCount = 0;
+  while (*p && letterCount < maxLetters) {
+    uint32_t cp = utf8NextCodepoint(&p);
+    if (cp == 0 || cp == REPLACEMENT_GLYPH) break;
+    // Skip whitespace and combining marks
+    if (cp <= 0x20) continue;
+    if (utf8IsCombiningMark(cp)) continue;
+    // Only count letter codepoints — digits and punctuation don't indicate direction
+    if (!isLetterCodepoint(cp)) continue;
+    letterCount++;
+    return isRtlCodepoint(cp);
+  }
+  return false;
+}
+
+// Encode a single Unicode codepoint as UTF-8, appending to `out`.
+static void utf8Encode(uint32_t cp, std::string& out) {
+  if (cp < 0x80) {
+    out += static_cast<char>(cp);
+  } else if (cp < 0x800) {
+    out += static_cast<char>(0xC0 | (cp >> 6));
+    out += static_cast<char>(0x80 | (cp & 0x3F));
+  } else if (cp < 0x10000) {
+    out += static_cast<char>(0xE0 | (cp >> 12));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+    out += static_cast<char>(0x80 | (cp & 0x3F));
+  } else {
+    out += static_cast<char>(0xF0 | (cp >> 18));
+    out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+    out += static_cast<char>(0x80 | (cp & 0x3F));
+  }
+}
+
+void reverseIfRtl(std::string& word) {
+  if (word.empty()) return;
+
+  // Stack buffer — words longer than 64 codepoints are not expected for our supported languages.
+  uint32_t codepoints[64];
+  size_t count = 0;
+  bool hasRtl = false;
+
+  auto* p = reinterpret_cast<const unsigned char*>(word.c_str());
+  while (*p && count < 64) {
+    uint32_t cp = utf8NextCodepoint(&p);
+    if (cp == 0 || cp == REPLACEMENT_GLYPH) break;
+    if (isRtlCodepoint(cp)) hasRtl = true;
+    codepoints[count++] = cp;
+  }
+
+  if (!hasRtl || count <= 1) return;
+
+  // Reverse the codepoints array
+  std::reverse(codepoints, codepoints + count);
+
+  // Mirror brackets after reversal (only check ASCII range 0x28-0x7D)
+  for (size_t i = 0; i < count; i++) {
+    const uint32_t cp = codepoints[i];
+    if (cp >= 0x28 && cp <= 0x7D) {  // Fast range check covers all ASCII brackets
+      switch (cp) {
+        case '(':
+          codepoints[i] = ')';
+          break;
+        case ')':
+          codepoints[i] = '(';
+          break;
+        case '[':
+          codepoints[i] = ']';
+          break;
+        case ']':
+          codepoints[i] = '[';
+          break;
+        case '{':
+          codepoints[i] = '}';
+          break;
+        case '}':
+          codepoints[i] = '{';
+          break;
+        case '<':
+          codepoints[i] = '>';
+          break;
+        case '>':
+          codepoints[i] = '<';
+          break;
+      }
+    }
+  }
+
+  // Re-encode to UTF-8
+  std::string reversed;
+  reversed.reserve(word.size());
+  for (size_t i = 0; i < count; i++) {
+    utf8Encode(codepoints[i], reversed);
+  }
+  word = std::move(reversed);
+}
+
+}  // namespace ScriptDetector

--- a/lib/ScriptDetector/ScriptDetector.cpp
+++ b/lib/ScriptDetector/ScriptDetector.cpp
@@ -61,49 +61,76 @@ void reverseIfRtl(std::string& word) {
 
   if (!hasRtl || count <= 1) return;
 
-  // Reverse the codepoints array
-  std::reverse(codepoints, codepoints + count);
+  // Reverse grapheme clusters (base char + combining marks as a unit).
+  // A naive codepoint-level reverse detaches Hebrew nikkud/cantillation
+  // marks from their base letters (e.g. shin+qamats becomes qamats+shin).
 
-  // Mirror brackets after reversal (only check ASCII range 0x28-0x7D)
-  for (size_t i = 0; i < count; i++) {
-    const uint32_t cp = codepoints[i];
-    if (cp >= 0x28 && cp <= 0x7D) {  // Fast range check covers all ASCII brackets
+  // Step 1: collect cluster ranges (start index, length).
+  // Each cluster is a base codepoint followed by zero or more combining marks.
+  struct Cluster {
+    size_t start;
+    size_t len;
+  };
+  Cluster clusters[64];
+  size_t clusterCount = 0;
+  size_t ci = 0;
+  while (ci < count) {
+    size_t start = ci;
+    ci++;
+    while (ci < count && utf8IsCombiningMark(codepoints[ci])) ci++;
+    clusters[clusterCount++] = {start, ci - start};
+  }
+
+  // Step 2: build reversed output by iterating clusters in reverse order,
+  // preserving codepoint order within each cluster (base + marks stay together).
+  uint32_t reversed[64];
+  size_t revIdx = 0;
+  for (size_t c = clusterCount; c-- > 0;) {
+    for (size_t j = 0; j < clusters[c].len; j++) {
+      reversed[revIdx++] = codepoints[clusters[c].start + j];
+    }
+  }
+
+  // Step 3: mirror brackets after reversal (only check ASCII range 0x28-0x7D)
+  for (size_t idx = 0; idx < revIdx; idx++) {
+    const uint32_t cp = reversed[idx];
+    if (cp >= 0x28 && cp <= 0x7D) {
       switch (cp) {
         case '(':
-          codepoints[i] = ')';
+          reversed[idx] = ')';
           break;
         case ')':
-          codepoints[i] = '(';
+          reversed[idx] = '(';
           break;
         case '[':
-          codepoints[i] = ']';
+          reversed[idx] = ']';
           break;
         case ']':
-          codepoints[i] = '[';
+          reversed[idx] = '[';
           break;
         case '{':
-          codepoints[i] = '}';
+          reversed[idx] = '}';
           break;
         case '}':
-          codepoints[i] = '{';
+          reversed[idx] = '{';
           break;
         case '<':
-          codepoints[i] = '>';
+          reversed[idx] = '>';
           break;
         case '>':
-          codepoints[i] = '<';
+          reversed[idx] = '<';
           break;
       }
     }
   }
 
   // Re-encode to UTF-8
-  std::string reversed;
-  reversed.reserve(word.size());
-  for (size_t i = 0; i < count; i++) {
-    utf8Encode(codepoints[i], reversed);
+  std::string result;
+  result.reserve(word.size());
+  for (size_t idx = 0; idx < revIdx; idx++) {
+    utf8Encode(reversed[idx], result);
   }
-  word = std::move(reversed);
+  word = std::move(result);
 }
 
 }  // namespace ScriptDetector

--- a/lib/ScriptDetector/ScriptDetector.h
+++ b/lib/ScriptDetector/ScriptDetector.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace ScriptDetector {
+
+/// Check if a codepoint is a Hebrew consonant (U+05D0–U+05EA).
+inline bool isHebrewCodepoint(uint32_t cp) { return cp >= 0x05D0 && cp <= 0x05EA; }
+
+/// Check if a codepoint is RTL (Hebrew block for now; extend for Arabic later).
+inline bool isRtlCodepoint(uint32_t cp) { return isHebrewCodepoint(cp); }
+
+/// Check if a codepoint is a Unicode letter (Latin, Hebrew, or other alphabetic scripts).
+/// Used to distinguish letters from digits/punctuation in RTL detection.
+inline bool isLetterCodepoint(uint32_t cp) {
+  if (cp >= 'A' && cp <= 'Z') return true;
+  if (cp >= 'a' && cp <= 'z') return true;
+  if (cp >= 0x00C0 && cp <= 0x024F) return true;  // Latin Extended
+  if (cp >= 0x05D0 && cp <= 0x05EA) return true;  // Hebrew
+  if (cp >= 0x0600 && cp <= 0x06FF) return true;  // Arabic (future-proof)
+  return false;
+}
+
+/// Scan text for the first strong directional letter codepoint.
+/// Skips whitespace, combining marks, digits, and punctuation — only letters count.
+/// Returns true if the first letter found is RTL.
+/// `maxLetters` limits how many letter codepoints to inspect before giving up.
+bool startsWithRtl(const char* text, int maxLetters = 5);
+
+/// Reverse the UTF-8 codepoints of a word in-place if it contains any RTL characters.
+/// Leaves pure-LTR words (Latin, numbers, punctuation-only) untouched.
+void reverseIfRtl(std::string& word);
+
+}  // namespace ScriptDetector

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -4,6 +4,7 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
+#include <ScriptDetector.h>
 #include <Serialization.h>
 #include <Utf8.h>
 
@@ -17,6 +18,7 @@
 
 namespace {
 constexpr size_t CHUNK_SIZE = 8 * 1024;  // 8KB chunk for reading
+constexpr int RTL_DETECTION_SCAN_LETTERS = 5;
 // Cache file magic and version
 constexpr uint32_t CACHE_MAGIC = 0x54585449;  // "TXTI"
 constexpr uint8_t CACHE_VERSION = 2;          // Increment when cache format changes
@@ -340,20 +342,25 @@ void TxtReaderActivity::renderPage() {
     for (const auto& line : currentPageLines) {
       if (!line.empty()) {
         int x = cachedOrientedMarginLeft;
+        const bool lineIsRtl = ScriptDetector::startsWithRtl(line.c_str(), RTL_DETECTION_SCAN_LETTERS);
+        uint8_t effectiveAlignment = cachedParagraphAlignment;
+        if (lineIsRtl && (effectiveAlignment == CrossPointSettings::LEFT_ALIGN ||
+                          effectiveAlignment == CrossPointSettings::JUSTIFIED)) {
+          effectiveAlignment = CrossPointSettings::RIGHT_ALIGN;
+        }
+        const int textWidth = renderer.getTextWidth(cachedFontId, line.c_str());
 
         // Apply text alignment
-        switch (cachedParagraphAlignment) {
+        switch (effectiveAlignment) {
           case CrossPointSettings::LEFT_ALIGN:
           default:
             // x already set to left margin
             break;
           case CrossPointSettings::CENTER_ALIGN: {
-            int textWidth = renderer.getTextWidth(cachedFontId, line.c_str());
             x = cachedOrientedMarginLeft + (contentWidth - textWidth) / 2;
             break;
           }
           case CrossPointSettings::RIGHT_ALIGN: {
-            int textWidth = renderer.getTextWidth(cachedFontId, line.c_str());
             x = cachedOrientedMarginLeft + contentWidth - textWidth;
             break;
           }


### PR DESCRIPTION
Hey @Uri-Tauber — you mentioned your BiDi implementation could use improvement. Here's a fix for a combining mark issue in `reverseIfRtl()`.

> **AI Disclosure:** This PR was developed with the assistance of Claude (Anthropic).

---

## Problem

`ScriptDetector::reverseIfRtl()` reverses individual codepoints, which detaches Hebrew combining marks (nikkud, cantillation) from their base letters.

For example, the word `שָׁלוֹם` (shin + qamats + shin-dot + lamed + vav + holam + final-mem) after naive reversal becomes:

```
Before: [shin, qamats, shin-dot, lamed, vav, holam, mem]
After:  [mem, holam, vav, lamed, shin-dot, qamats, shin]
```

Now `holam` is on `mem` instead of `vav`, and `shin-dot` is on `lamed` instead of `shin`.

## Fix

Reverse **grapheme clusters** (base character + its combining marks as a unit) instead of individual codepoints. Each cluster stays intact during reversal:

```
Clusters: [shin+qamats+shin-dot], [lamed], [vav+holam], [mem]
Reversed: [mem], [vav+holam], [lamed], [shin+qamats+shin-dot]
```

Nikkud stays attached to the correct base letter.

## Dependencies

- Depends on #1700 (RTL reader support) being merged first

## Implementation

- Uses stack-allocated arrays (no heap) — same constraint-friendly approach as the original
- Identifies clusters by checking `utf8IsCombiningMark()` for each codepoint
- Bracket mirroring still applied after cluster reversal

## Test plan
- [x] Build succeeds
- [ ] Test with vocalized Hebrew EPUB text on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)