### PR TITLE
fix(sleep): correctly crop/scale sleep bitmap on X3 panel

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -633,10 +633,13 @@ void GfxRenderer::drawIcon(const uint8_t bitmap[], const int x, const int y, con
 }
 
 void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, const int maxWidth, const int maxHeight,
-                             const float cropX, const float cropY) const {
+                             const float cropX, const float cropY, const bool allowUpscale) const {
   if (fontCacheManager_ && fontCacheManager_->isScanning()) return;
-  // For 1-bit bitmaps, use optimized 1-bit rendering path (no crop support for 1-bit)
-  if (bitmap.is1Bit() && cropX == 0.0f && cropY == 0.0f) {
+  // For 1-bit bitmaps, use optimized 1-bit rendering path (no crop support for 1-bit).
+  // Skip the fast path when the caller opts in to upscaling, since drawBitmap1Bit() only
+  // downscales; falling through to the span-aware 2-bit path here lets 1-bit sleep images
+  // authored for a different panel size fill the screen.
+  if (bitmap.is1Bit() && cropX == 0.0f && cropY == 0.0f && !allowUpscale) {
     drawBitmap1Bit(bitmap, x, y, maxWidth, maxHeight);
     return;
   }
@@ -664,9 +667,15 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
     hasTargetBounds = true;
   }
 
-  if (hasTargetBounds && fitScale < 1.0f) {
-    scale = fitScale;
-    isScaled = true;
+  // Downscale whenever the cropped bitmap overflows the target bounds (pre-existing behavior).
+  // Upscale is opt-in via `allowUpscale`: callers with CONTAIN/COVER semantics (SleepActivity)
+  // set the flag so an X4-sized sleep image on an X3 panel fills the screen in CROP mode, while
+  // callers like BmpViewer keep native-size rendering for undersized bitmaps.
+  if (hasTargetBounds) {
+    if (fitScale < 1.0f || (allowUpscale && fitScale > 1.0f)) {
+      scale = fitScale;
+      isScaled = true;
+    }
   }
   LOG_DBG("GFX", "Scaling by %f - %s", scale, isScaled ? "scaled" : "not scaled");
 
@@ -683,18 +692,9 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
     return;
   }
 
+  // When upscaling, each source pixel must cover multiple dest pixels or we leave gap-lines.
+  // We compute a dest-span per source pixel so both downscale and upscale render correctly.
   for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
-    // The BMP's (0, 0) is the bottom-left corner (if the height is positive, top-left if negative).
-    // Screen's (0, 0) is the top-left corner.
-    int screenY = -cropPixY + (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY);
-    if (isScaled) {
-      screenY = std::floor(screenY * scale);
-    }
-    screenY += y;  // the offset should not be scaled
-    if (screenY >= getScreenHeight()) {
-      break;
-    }
-
     if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
       LOG_ERR("GFX", "Failed to read row %d from bitmap", bmpY);
       free(outputRow);
@@ -702,36 +702,68 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
       return;
     }
 
-    if (screenY < 0) {
-      continue;
-    }
-
     if (bmpY < cropPixY) {
       // Skip the row if it's outside the crop area
       continue;
     }
 
+    // The BMP's (0, 0) is the bottom-left corner (if the height is positive, top-left if negative).
+    // Screen's (0, 0) is the top-left corner.
+    const int bmpRowFromTop = (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY) - cropPixY;
+    int screenYStart, screenYEnd;
+    if (isScaled) {
+      screenYStart = y + static_cast<int>(std::floor(bmpRowFromTop * scale));
+      screenYEnd = y + static_cast<int>(std::floor((bmpRowFromTop + 1) * scale)) - 1;
+      if (screenYEnd < screenYStart) screenYEnd = screenYStart;
+    } else {
+      screenYStart = y + bmpRowFromTop;
+      screenYEnd = screenYStart;
+    }
+
+    if (screenYStart >= getScreenHeight()) {
+      if (bitmap.isTopDown()) break;
+      continue;
+    }
+    if (screenYEnd < 0) {
+      continue;
+    }
+
+    const int yLo = std::max(screenYStart, 0);
+    const int yHi = std::min(screenYEnd, getScreenHeight() - 1);
+
     for (int bmpX = cropPixX; bmpX < bitmap.getWidth() - cropPixX; bmpX++) {
-      int screenX = bmpX - cropPixX;
+      const int bmpColFromLeft = bmpX - cropPixX;
+      int screenXStart, screenXEnd;
       if (isScaled) {
-        screenX = std::floor(screenX * scale);
+        screenXStart = x + static_cast<int>(std::floor(bmpColFromLeft * scale));
+        screenXEnd = x + static_cast<int>(std::floor((bmpColFromLeft + 1) * scale)) - 1;
+        if (screenXEnd < screenXStart) screenXEnd = screenXStart;
+      } else {
+        screenXStart = x + bmpColFromLeft;
+        screenXEnd = screenXStart;
       }
-      screenX += x;  // the offset should not be scaled
-      if (screenX >= getScreenWidth()) {
+      if (screenXStart >= getScreenWidth()) {
         break;
       }
-      if (screenX < 0) {
+      if (screenXEnd < 0) {
         continue;
       }
 
+      const int xLo = std::max(screenXStart, 0);
+      const int xHi = std::min(screenXEnd, getScreenWidth() - 1);
+
       const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
 
-      if (renderMode == BW && val < 3) {
-        drawPixel(screenX, screenY);
-      } else if (renderMode == GRAYSCALE_MSB && (val == 1 || val == 2)) {
-        drawPixel(screenX, screenY, false);
-      } else if (renderMode == GRAYSCALE_LSB && val == 1) {
-        drawPixel(screenX, screenY, false);
+      for (int sy = yLo; sy <= yHi; sy++) {
+        for (int sx = xLo; sx <= xHi; sx++) {
+          if (renderMode == BW && val < 3) {
+            drawPixel(sx, sy);
+          } else if (renderMode == GRAYSCALE_MSB && (val == 1 || val == 2)) {
+            drawPixel(sx, sy, false);
+          } else if (renderMode == GRAYSCALE_LSB && val == 1) {
+            drawPixel(sx, sy, false);
+          }
+        }
       }
     }
   }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -107,8 +107,12 @@ class GfxRenderer {
                        bool roundBottomLeft, bool roundBottomRight, Color color) const;
   void drawImage(const uint8_t bitmap[], int x, int y, int width, int height) const;
   void drawIcon(const uint8_t bitmap[], int x, int y, int width, int height) const;
-  void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0,
-                  float cropY = 0) const;
+  // allowUpscale: when true, bitmaps smaller than the target bounds are enlarged to fit/cover;
+  // when false (default), undersized bitmaps are rendered at their native size within the bounds,
+  // preserving the pre-existing 1:1 centering behavior for BmpViewer and cover thumbnails. Only
+  // callers that explicitly want CONTAIN/COVER semantics (e.g. SleepActivity) should opt in.
+  void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0, float cropY = 0,
+                  bool allowUpscale = false) const;
   void drawBitmap1Bit(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight) const;
   void fillPolygon(const int* xPoints, const int* yPoints, int numPoints, bool state = true) const;
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -148,7 +148,11 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
   float cropX = 0, cropY = 0;
 
   LOG_DBG("SLP", "bitmap %d x %d, screen %d x %d", bitmap.getWidth(), bitmap.getHeight(), pageWidth, pageHeight);
-  if (bitmap.getWidth() > pageWidth || bitmap.getHeight() > pageHeight) {
+  // Always run scale/crop branch when dimensions differ (covers upscale case too, e.g. X4-sized
+  // sleep bitmaps on X3's 528x792 panel). Previously this only triggered when the bitmap exceeded
+  // the screen in either dimension, so smaller X4 images rendered at 1:1 with letterbox offsets.
+  const bool exactFit = (bitmap.getWidth() == pageWidth && bitmap.getHeight() == pageHeight);
+  if (!exactFit) {
     // image will scale, make sure placement is right
     float ratio = static_cast<float>(bitmap.getWidth()) / static_cast<float>(bitmap.getHeight());
     const float screenRatio = static_cast<float>(pageWidth) / static_cast<float>(pageHeight);
@@ -187,7 +191,9 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
   const bool hasGreyscale = bitmap.hasGreyscale() &&
                             SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  // allowUpscale=true: sleep images authored for a different panel size (e.g. X4 480x800 on X3
+  // 528x792) should be scaled up to fill the screen in CONTAIN/CROP modes, not left at 1:1.
+  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, /*allowUpscale=*/true);
 
   if (SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
     renderer.invertScreen();
@@ -199,13 +205,13 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, /*allowUpscale=*/true);
     renderer.copyGrayscaleLsbBuffers();
 
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, /*allowUpscale=*/true);
     renderer.copyGrayscaleMsbBuffers();
 
     renderer.displayGrayBuffer();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix sleep screen bitmap not filling the panel correctly when the bitmap size does not match the screen, specifically when a sleep image is smaller than the screen in one or both dimensions (e.g. an X4-styled `sleep.bmp` at 480×800 rendered on an X3 panel at 528×792).
* **What changes are included?**

On X3 (528×792 portrait) an X4-styled sleep image (480×800) used to render at 1:1 in the top-left corner of the screen with ~48px blank on the right and ~72px blank on the bottom, even when `sleepScreenCoverMode=CROP`. Four interacting issues in the bitmap rendering path were responsible:

1. `SleepActivity::renderBitmapSleepScreen()` only entered the scale/crop branch when the bitmap was **strictly larger** than the screen in either dimension. Bitmaps smaller than the screen fell through to a center-only path that never computed a scale.

2. `GfxRenderer::drawBitmap()` only applied the computed fit scale when `fitScale < 1.0f` (downscale only). Upscale requests were silently dropped, so the branch in (1) — even when reached — produced a 1:1 render.

3. The per-pixel render loop iterated source pixels and mapped each to a single destination pixel. When scaling is applied, that leaves gap rows/cols between source rows/cols (an upscale artifact; no issue at 1:1 or downscale).

4. The 1-bit fast path at the top of `drawBitmap()` unconditionally routed uncropped 1-bit bitmaps through `drawBitmap1Bit()`, whose scaling logic only downscales. Undersized 1-bit sleep images would therefore still render at native size even when `SleepActivity` opted in to upscaling.

### Fixes

* Trigger the scale/crop branch in `SleepActivity` whenever the bitmap size differs from the screen size, not only when it exceeds it.
* Add an **opt-in `allowUpscale` flag** to `GfxRenderer::drawBitmap()` (defaults to `false`). With the default, the pre-existing downscale-only behavior is preserved for all other callers (`BmpViewerActivity`, `BaseTheme` cover thumbnails, Lyra themes), so undersized bitmaps continue to render at their native size within the target bounds. `SleepActivity` opts in, since its CONTAIN/CROP semantics deliberately want the sleep image to fill the screen.
* Bypass the 1-bit fast path when `allowUpscale=true` so 1-bit sleep bitmaps authored for a different panel size go through the span-aware 2-bit code and are scaled up to fill the screen. When `allowUpscale=false` (default) the fast path is unchanged — `drawBitmap1Bit` and all its existing callers keep their current behavior.
* Replace the 1:1 source-pixel loop with a **dest-span fill** (nearest-neighbor block) so every destination pixel is covered on upscale. Each source pixel now writes to the span
  `[floor(idx * scale), floor((idx + 1) * scale) - 1]`,
  which collapses to a single pixel when `scale ≤ 1.0`, so downscale and no-scale behavior are bit-for-bit identical to master.

### Why opt-in upscale rather than always upscale

Earlier revision of this PR made `drawBitmap()` upscale whenever `fitScale != 1.0f`. CodeRabbit correctly flagged that this silently changed behavior for callers like `BmpViewerActivity` that pass page/tile dimensions as bounds and relied on 1:1 rendering for undersized bitmaps. Moving the upscale decision to an explicit flag keeps the fix surgical: only `SleepActivity` gets the new behavior, all other callers — including the 1-bit fast path — are unchanged at the API default.

### Test case

X4-styled `sleep.bmp` (480×800) dropped onto an X3 device at 528×792 with `sleepScreenCoverMode=CROP`:

* **Before:** image rendered at 480×800 in the top-left of the screen with blank strips on the right and bottom; at 1:1 pixel mapping.
* **After:** image is scaled by `max(528/480, 792/800) ≈ 1.1` and cropped around the scale-locked axis, filling the full 528×792 panel, same visual model as `CROP` on larger-than-screen bitmaps. Tested with both 2-bit greyscale and 1-bit monochrome source BMPs.

Downscale (bitmap larger than screen) renders identically to master; other callers (`BmpViewer`, cover thumbnails) are unchanged at the API-default `allowUpscale = false`.

## Additional Context

* The new loop body is `O(src_w * src_h * scale²)`; scale is typically very close to 1 in practice, so the runtime cost is negligible. For 1:1 or downscale the behavior is bit-for-bit identical to the old loop since `dest_span` collapses to 1.
* API-level default is source-compatible — the new `allowUpscale` parameter has a default that matches the previous (downscale-only) behavior, so existing callers compile unchanged.
* Release-notes-worthy behavior change: users whose custom `/sleep/*.bmp` wallpapers were intentionally smaller than the panel and relied on native-size centering will now see them scaled up in CONTAIN/CROP modes. This is consistent with those modes' documented semantics, but is worth mentioning for anyone tracking 1:1-centered sleep image behavior.
* Originally discovered and fixed against a downstream X3 fork (`crosspoint-reader-x3-vi`) while shipping an X3 build using an X4-styled sleep image; cleaned up and cherry-picked here against upstream `master` with no fork-specific content.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_

The diagnosis of the three underlying issues and the structure of the dest-span fix were proposed with the help of an AI assistant; the final code, validation, and testing on the target device were done by me. The `allowUpscale` opt-in refactor and the 1-bit fast-path bypass were prompted by CodeRabbit's review of earlier revisions and were written and verified by me.
