### PR TITLE
feat: show long branch names

### DIFF
--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -35,7 +35,6 @@ constexpr int cornerRadius = 6;
 constexpr int topHintButtonY = 345;
 constexpr int popupMarginX = 16;
 constexpr int popupMarginY = 12;
-constexpr int maxSubtitleWidth = 100;
 constexpr int maxListValueWidth = 200;
 constexpr int mainMenuIconSize = 32;
 constexpr int listIconSize = 24;
@@ -150,8 +149,15 @@ void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
                    Rect{batteryX, rect.y + 5, LyraMetrics::values.batteryWidth, LyraMetrics::values.batteryHeight},
                    showBatteryPercentage);
 
-  int maxTitleWidth =
-      rect.width - LyraMetrics::values.contentSidePadding * 2 - (subtitle != nullptr ? maxSubtitleWidth : 0);
+  int maxTitleWidth = title != nullptr ? renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD) : 0;
+  int maxSubtitleWidth = subtitle != nullptr ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
+  if (maxTitleWidth + maxSubtitleWidth > rect.width - LyraMetrics::values.contentSidePadding * 3) {
+    if (maxTitleWidth > maxSubtitleWidth) {
+      maxTitleWidth = rect.width - LyraMetrics::values.contentSidePadding * 3 - maxSubtitleWidth;
+    } else {
+      maxSubtitleWidth = rect.width - LyraMetrics::values.contentSidePadding * 3 - maxTitleWidth;
+    }
+  }
 
   if (title) {
     auto truncatedTitle = renderer.truncatedText(UI_12_FONT_ID, title, maxTitleWidth, EpdFontFamily::BOLD);

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -152,11 +152,22 @@ void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
   int maxTitleWidth = title != nullptr ? renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD) : 0;
   int maxSubtitleWidth =
       subtitle != nullptr ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
-  if (maxTitleWidth + maxSubtitleWidth > rect.width - LyraMetrics::values.contentSidePadding * 3) {
-    if (maxTitleWidth > maxSubtitleWidth) {
-      maxTitleWidth = rect.width - LyraMetrics::values.contentSidePadding * 3 - maxSubtitleWidth;
+
+  // Available space is the distance between the side paddings, and a with side padding between title and subtitle.
+  const int availableSpace = rect.width - LyraMetrics::values.contentSidePadding * 3;
+
+  if (maxTitleWidth + maxSubtitleWidth > availableSpace) {
+    if ((maxTitleWidth > availableSpace / 2) && (maxSubtitleWidth > availableSpace / 2)) {
+      // Both are wider then half the space, truncate both.
+      maxTitleWidth = availableSpace / 2;
+      maxSubtitleWidth = availableSpace / 2;
     } else {
-      maxSubtitleWidth = rect.width - LyraMetrics::values.contentSidePadding * 3 - maxTitleWidth;
+      // Truncate the the longest one
+      if (maxTitleWidth > maxSubtitleWidth) {
+        maxTitleWidth = availableSpace - maxSubtitleWidth;
+      } else {
+        maxSubtitleWidth = availableSpace - maxTitleWidth;
+      }
     }
   }
 

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -150,7 +150,8 @@ void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
                    showBatteryPercentage);
 
   int maxTitleWidth = title != nullptr ? renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD) : 0;
-  int maxSubtitleWidth = subtitle != nullptr ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
+  int maxSubtitleWidth =
+      subtitle != nullptr ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
   if (maxTitleWidth + maxSubtitleWidth > rect.width - LyraMetrics::values.contentSidePadding * 3) {
     if (maxTitleWidth > maxSubtitleWidth) {
       maxTitleWidth = rect.width - LyraMetrics::values.contentSidePadding * 3 - maxSubtitleWidth;


### PR DESCRIPTION
## Summary

* This change will make better use of the space available for Title and Subtitle in the Settings (Theme: Lyra).
Instead of having a fixed maxwidth in pixels for subtitle, it will use the whole line and shorten the longest one if needed.

So instead of: <img width="480" height="140" alt="image" src="https://github.com/user-attachments/assets/67e4777b-10d0-4a05-b5c7-fb775776c186" />

It will now show: <img width="480" height="142" alt="image" src="https://github.com/user-attachments/assets/2f143f4e-75d7-45c4-b61a-aad56bdf39fb" />


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
