### PR TITLE
feat: Add royalty.dev funding integration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 github: [daveallie]
 ko_fi: daveallie
+custom: ["https://app.royalty.dev/crosspoint-reader/crosspoint-reader"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CrossPoint Reader
 
+[![Fund contributors](https://img.shields.io/badge/%F0%9F%91%91_Fund_contributors-royalty.dev-BB953A?style=for-the-badge&labelColor=1a1a1a)](https://app.royalty.dev/crosspoint-reader/crosspoint-reader)
+
 Firmware for the **Xteink X4** e-paper display reader (unaffiliated with Xteink).
 Built using **PlatformIO** and targeting the **ESP32-C3** microcontroller.
 


### PR DESCRIPTION
Adds royalty.dev as a funding platform for contributors by adding custom funding link and badge to README

A maintainer would need to click the "Are you the maintainer?" button on https://app.royalty.dev/crosspoint-reader/crosspoint-reader to install the github app which pulls the PRs in and ranks them. 

(Disclosure, Royalty is a product I've recently built and am using for my own OSS and currently gating custom font builds and nightlys on crosspointreader.com)

This page currently can collect donations but without the integration it wont notify contributors and it wont rescore fresh PRs. 