### PR TITLE
Revert "feat: Add royalty.dev funding integration"

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
 github: [daveallie]
 ko_fi: daveallie
-custom: ["https://app.royalty.dev/crosspoint-reader/crosspoint-reader"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # CrossPoint Reader
 
-[![Fund contributors](https://img.shields.io/badge/%F0%9F%91%91_Fund_contributors-royalty.dev-BB953A?style=for-the-badge&labelColor=1a1a1a)](https://app.royalty.dev/crosspoint-reader/crosspoint-reader)
-
 Firmware for the **Xteink X4** e-paper display reader (unaffiliated with Xteink).
 Built using **PlatformIO** and targeting the **ESP32-C3** microcontroller.
 


### PR DESCRIPTION
Reverts crosspoint-reader/crosspoint-reader#1741

I don't entirely understand Royalty.dev and want to vet this further.