### PR TITLE
style: align action buttons vertically with page title

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -44,7 +44,7 @@
     }
     h2 {
       color: var(--title-color);
-      margin-top: 0;
+      margin: 0;
     }
     .card {
       background: var(--card-bg);
@@ -63,7 +63,7 @@
     }
     .page-header-left {
       display: flex;
-      align-items: baseline;
+      align-items: center;
       gap: 12px;
       flex-wrap: wrap;
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the vertical misalignment between the "File Manager" title and the action buttons (Upload / New Folder / Delete Selected).
* **What changes are included?**
  - `h2`: `margin-top: 0` → `margin: 0` — removes the default browser `margin-bottom` that was inflating the height of the header-left flex container, pushing the calculated flex center below the visual midpoint of the title text
  - `.page-header-left`: `align-items: baseline` → `align-items: center` — ensures the title and breadcrumbs are center-aligned with each other and with the buttons

### Before
<img width="1198" height="560" alt="Screenshot From 2026-04-30 22-29-28" src="https://github.com/user-attachments/assets/b9a43069-cd93-4028-ab21-75be253ed1f0" />

### After
<img width="1198" height="560" alt="Screenshot From 2026-04-30 22-48-49" src="https://github.com/user-attachments/assets/b9977c65-e479-4490-8ec3-15ae99cfccd7" />


## Additional Context

Small CSS-only change, no JavaScript or HTML structure touched.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_