### PR TITLE
fix: prevent chapter skipping after taking a screenshot

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -203,12 +203,6 @@ void EpubReaderActivity::loop() {
   }
 
   const bool skipChapter = !fromTilt && SETTINGS.longPressChapterSkip && mappedInput.getHeldTime() > skipChapterMs;
-
-  // Don't skip chapter after screenshot
-  if (gpio.wasReleased(HalGPIO::BTN_POWER) && gpio.wasReleased(HalGPIO::BTN_DOWN)) {
-    return;
-  }
-
   if (skipChapter) {
     lastPageTurnTime = millis();
     // We don't want to delete the section mid-render, so grab the semaphore

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,6 +371,8 @@ void loop() {
     if (!gpio.isPressed(HalGPIO::BTN_POWER) && !gpio.isPressed(HalGPIO::BTN_DOWN)) {
       screenshotButtonsReleased = true;
     }
+    // prevent a tight spin
+    yield();
     // If the screenshot combination is being pressed,
     // skip the rest of the loop to avoid any chance of triggering sleep or skipping chapter
     return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -367,7 +367,7 @@ void loop() {
     }
   }
 
-  if(!screenshotButtonsReleased) {
+  if (!screenshotButtonsReleased) {
     if (!gpio.isPressed(HalGPIO::BTN_POWER) && !gpio.isPressed(HalGPIO::BTN_DOWN)) {
       screenshotButtonsReleased = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,9 +365,15 @@ void loop() {
         ScreenshotUtil::takeScreenshot(renderer);
       }
     }
+  }
+
+  if(!screenshotButtonsReleased) {
+    if (!gpio.isPressed(HalGPIO::BTN_POWER) && !gpio.isPressed(HalGPIO::BTN_DOWN)) {
+      screenshotButtonsReleased = true;
+    }
+    // If the screenshot combination is being pressed,
+    // skip the rest of the loop to avoid any chance of triggering sleep or skipping chapter
     return;
-  } else {
-    screenshotButtonsReleased = true;
   }
 
   const unsigned long sleepTimeoutMs = SETTINGS.getSleepTimeoutMs();
@@ -379,10 +385,6 @@ void loop() {
   }
 
   if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getHeldTime() > SETTINGS.getPowerButtonDuration()) {
-    // If the screenshot combination is potentially being pressed, don't sleep
-    if (gpio.isPressed(HalGPIO::BTN_DOWN)) {
-      return;
-    }
     enterDeepSleep();
     // This should never be hit as `enterDeepSleep` calls esp_deep_sleep_start
     return;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Fix the bug where the chapter skip action could still trigger after taking a screenshot.

* **What changes are included?**
  - .Updated `main.cpp` so the screenshot-button combo now fully blocks the rest of the main loop until both buttons are released, preventing sleep or other button actions from firing.
  - Removed the redundant screenshot-specific skip guard in `EpubReaderActivity.cpp` and let the new main-loop handling prevent the issue at the source.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
