### PR TITLE
feat: render <sup> tags as ^ prefix in EPUB parser

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -655,6 +655,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
     self->inlineStyleStack.push_back(entry);
     self->updateEffectiveInlineStyle();
+  } else if (strcmp(name, "sup") == 0) {
+    self->flushPartWordBuffer();
+    self->nextWordContinues = true;
+    self->characterData(userData, "^", 1);
   } else if (strcmp(name, "span") == 0 || !isHeaderOrBlock(name)) {
     // Handle span and other inline elements for CSS styling
     if (cssStyle.hasFontWeight() || cssStyle.hasFontStyle() || cssStyle.hasTextDecoration()) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -656,8 +656,28 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->inlineStyleStack.push_back(entry);
     self->updateEffectiveInlineStyle();
   } else if (strcmp(name, "sup") == 0) {
-    self->flushPartWordBuffer();
-    self->nextWordContinues = true;
+    if (self->partWordBufferIndex > 0) {
+      self->flushPartWordBuffer();
+      self->nextWordContinues = true;
+    }
+    if (cssStyle.hasFontWeight() || cssStyle.hasFontStyle() || cssStyle.hasTextDecoration()) {
+      StyleStackEntry entry;
+      entry.depth = self->depth;
+      if (cssStyle.hasFontWeight()) {
+        entry.hasBold = true;
+        entry.bold = cssStyle.fontWeight == CssFontWeight::Bold;
+      }
+      if (cssStyle.hasFontStyle()) {
+        entry.hasItalic = true;
+        entry.italic = cssStyle.fontStyle == CssFontStyle::Italic;
+      }
+      if (cssStyle.hasTextDecoration()) {
+        entry.hasUnderline = true;
+        entry.underline = cssStyle.textDecoration == CssTextDecoration::Underline;
+      }
+      self->inlineStyleStack.push_back(entry);
+      self->updateEffectiveInlineStyle();
+    }
     self->characterData(userData, "^", 1);
   } else if (strcmp(name, "span") == 0 || !isHeaderOrBlock(name)) {
     // Handle span and other inline elements for CSS styling


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
Improve readability of EPUB content that uses the `<sup>` tag, which is currently ignored causing superscript text to merge with the surrounding text (e.g. `1015` instead of `10^15`). 
Fixes #1696.
* **What changes are included?**
 In `ChapterHtmlSlimParser::startElement()`, added handling for the `<sup>` tag: when the opening tag is encountered, a `^` character is injected into the text stream, maintaining visual continuity with the preceding word via `nextWordContinues = true`.

## Alternatives Considered

* **No handling (status quo):** 
text inside `<sup>` is emitted inline without any separator, making the content unreadable (e.g. `1015`).
* **Reduced font size without vertical offset:** 
recognise `<sup>` and select a smaller font size, but the text would still sit on the same baseline — visually incorrect and potentially misleading.
* **Full implementation (reduced font + raised baseline):** 
would require changes to the layout engine to handle mixed-baseline lines, per-word-token overhead, and a non-trivial refactor.
* **Square brackets `[N]`:** 
considered for footnote references (Markdown/Wikipedia convention), rejected because `^` is more universal and works for both footnotes and mathematical expressions. Footnote links are already visually distinguished by their underline styling.

## Additional Context

* No changes to the layout engine, CSS parser, or font system — zero RAM impact.
* Text inside `<sup>` is already handled by the existing character data flow; no `endElement` handler is needed.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKExZQDqyed89pkESmybCr)_