### PR TITLE
refactor: Simplify isReaderActivity bookkeeping

### DIFF
--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -2,6 +2,8 @@
 
 #include <HalPowerManager.h>
 
+#include <algorithm>
+
 #include "OpdsServerStore.h"
 #include "boot_sleep/BootActivity.h"
 #include "boot_sleep/SleepActivity.h"
@@ -230,7 +232,11 @@ void ActivityManager::popActivity() {
 
 bool ActivityManager::preventAutoSleep() const { return currentActivity && currentActivity->preventAutoSleep(); }
 
-bool ActivityManager::isReaderActivity() const { return currentActivity && currentActivity->isReaderActivity(); }
+bool ActivityManager::isReaderActivity() const {
+  return std::any_of(stackActivities.begin(), stackActivities.end(),
+                     [](const auto& activity) { return activity->isReaderActivity(); }) ||
+         (currentActivity && currentActivity->isReaderActivity());
+}
 
 bool ActivityManager::skipLoopDelay() const { return currentActivity && currentActivity->skipLoopDelay(); }
 

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.h
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.h
@@ -32,5 +32,4 @@ class EpubReaderChapterSelectionActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
 };

--- a/src/activities/reader/EpubReaderFootnotesActivity.h
+++ b/src/activities/reader/EpubReaderFootnotesActivity.h
@@ -19,7 +19,6 @@ class EpubReaderFootnotesActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
 
  private:
   const std::vector<FootnoteEntry>& footnotes;

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -32,7 +32,6 @@ class EpubReaderMenuActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
 
  private:
   struct MenuItem {

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.h
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.h
@@ -15,7 +15,6 @@ class EpubReaderPercentSelectionActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
 
  private:
   // Current percent value (0-100) shown on the slider.

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -41,7 +41,6 @@ class KOReaderSyncActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool preventAutoSleep() override { return state == CONNECTING || state == SYNCING; }
-  bool isReaderActivity() const override { return true; }
 
  private:
   enum State {

--- a/src/activities/reader/QrDisplayActivity.h
+++ b/src/activities/reader/QrDisplayActivity.h
@@ -14,7 +14,6 @@ class QrDisplayActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
 
  private:
   std::string textPayload;

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.h
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.h
@@ -23,5 +23,4 @@ class XtcReaderChapterSelectionActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
 };


### PR DESCRIPTION
## Summary

Before, any sub-activity of a reader activity needed to override `isReaderActivity` to maintain correct bookkeeping through `ActivityManager::isReaderActivity`. We could easily miss this in any new sub-activities. Instead, simplify so each reader activity correctly reports and then `ActivityManager` checks for any reader activity in its stack.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
