### PR TITLE
refactor: Use fixed-size integers for BookMetadataCache data

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -18,11 +18,11 @@ class BookMetadataCache {
 
   struct SpineEntry {
     std::string href;
-    size_t cumulativeSize;
+    uint32_t cumulativeSize;
     int16_t tocIndex;
 
     SpineEntry() : cumulativeSize(0), tocIndex(-1) {}
-    SpineEntry(std::string href, const size_t cumulativeSize, const int16_t tocIndex)
+    SpineEntry(std::string href, const uint32_t cumulativeSize, const int16_t tocIndex)
         : href(std::move(href)), cumulativeSize(cumulativeSize), tocIndex(tocIndex) {}
   };
 
@@ -44,7 +44,7 @@ class BookMetadataCache {
 
  private:
   std::string cachePath;
-  size_t lutOffset;
+  uint32_t lutOffset;
   uint16_t spineCount;
   uint16_t tocCount;
   bool loaded;


### PR DESCRIPTION
## Summary

Serialization for `BookMetadataCache` data should specify the exact integer size it expects. `size_t` varies depending on the platform. @uxjulia's crosspoint-simulator needs to patch these values to work correctly on 64-bit systems.

https://github.com/uxjulia/crosspoint-simulator/blob/9a90b6eef00cb910fae3768c575f33a50fcb75d2/run_simulator.py#L57-L68

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
