### PR TITLE
fix: Roundraff theme home menu offset with no recent books

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -235,7 +235,7 @@ void HomeActivity::render(RenderLock&&) {
     menuIcons.insert(menuIcons.begin() + 2, Library);
   }
 
-  if (metrics.homeContinueReadingInMenu) {
+  if (metrics.homeContinueReadingInMenu && !recentBooks.empty()) {
     // Insert Continue Reading at the top if enabled in theme
     menuItems.insert(menuItems.begin(), tr(STR_CONTINUE_READING));
     menuIcons.insert(menuIcons.begin(), Book);


### PR DESCRIPTION
## Summary

With the Roundraff theme selected and no recent books, the home screen menu shows a "Continue Reading" option and menu handling is offset by one ("Continue Reading" actually does "Browse Files", "File Transfer" actually does "Settings", etc.) Simple fix here is to omit the "Continue Reading" menu item when there are no recent books.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
