### PR TITLE
fix: short-press power action triggered after screenshot combo release

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,12 +394,13 @@ void loop() {
     return;
   }
   if (screenshotComboActive) {
-    screenshotButtonsReleased = true;
     if (gpio.isPressed(HalGPIO::BTN_POWER)) return;
     if (gpio.wasReleased(HalGPIO::BTN_POWER)) {
+      screenshotButtonsReleased = true;
       screenshotComboActive = false;
       return;
     }
+    screenshotButtonsReleased = true;
     screenshotComboActive = false;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -381,7 +381,9 @@ void loop() {
   }
 
   static bool screenshotButtonsReleased = true;
+  static bool screenshotComboActive = false;
   if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.isPressed(HalGPIO::BTN_DOWN)) {
+    screenshotComboActive = true;
     if (screenshotButtonsReleased) {
       screenshotButtonsReleased = false;
       {
@@ -390,8 +392,15 @@ void loop() {
       }
     }
     return;
-  } else {
+  }
+  if (screenshotComboActive) {
     screenshotButtonsReleased = true;
+    if (gpio.isPressed(HalGPIO::BTN_POWER)) return;
+    if (gpio.wasReleased(HalGPIO::BTN_POWER)) {
+      screenshotComboActive = false;
+      return;
+    }
+    screenshotComboActive = false;
   }
 
   const unsigned long sleepTimeoutMs = SETTINGS.getSleepTimeoutMs();


### PR DESCRIPTION
When Power+Down is released with a slight stagger (Down before Power), the Power release event leaked through to the activity loop, triggering short-press Power actions like clip selection. Add a screenshotComboActive flag that suppresses all input processing until Power is fully released after a screenshot combo.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
