### PR TITLE
fix: free Epub RAM before KOSync TLS handshake to prevent OOM

### DIFF
--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -22,6 +22,13 @@ constexpr char DEVICE_ID[] = "crosspoint-reader";
 // Default 16KB buffers cause OOM during TLS handshake.
 constexpr int HTTP_BUF_SIZE = 2048;
 
+// Cloudflare tunnels send a 3-cert Google Trust Services chain. During the TLS handshake
+// mbedTLS makes many small allocations that collectively consume ~48KB of heap. With only
+// ~50KB free after WiFi connects, the session drove min-free-ever down to 2600 bytes before
+// failing with MBEDTLS_ERR_X509_ALLOC_FAILED (-0x2880). Check total free heap (not max
+// contiguous block) because the failure mode is aggregate exhaustion, not one large alloc.
+constexpr uint32_t MIN_HEAP_FOR_TLS = 55000;
+
 // Response buffer for reading HTTP body
 struct ResponseBuffer {
   char* data = nullptr;
@@ -102,11 +109,23 @@ KOReaderSyncClient::Error KOReaderSyncClient::authenticate() {
   }
 
   std::string url = KOREADER_STORE.getBaseUrl() + "/users/auth";
-  LOG_DBG("KOSync", "Authenticating: %s (heap: %u)", url.c_str(), (unsigned)ESP.getFreeHeap());
+  const uint32_t freeHeap = ESP.getFreeHeap();
+  LOG_DBG("KOSync", "Authenticating: %s (heap: %u)", url.c_str(), (unsigned)freeHeap);
+  if (freeHeap < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("KOSync", "Insufficient heap for TLS handshake: %u bytes free (need %u)", freeHeap, MIN_HEAP_FOR_TLS);
+    return LOW_MEMORY;
+  }
 
   ResponseBuffer buf;
   esp_http_client_handle_t client = createClient(url.c_str(), &buf);
   if (!client) return NETWORK_ERROR;
+
+  const uint32_t heapBeforeAuth = ESP.getFreeHeap();
+  if (heapBeforeAuth < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("KOSync", "Heap dropped before auth perform: %u bytes (need %u)", heapBeforeAuth, MIN_HEAP_FOR_TLS);
+    esp_http_client_cleanup(client);
+    return LOW_MEMORY;
+  }
 
   esp_err_t err = esp_http_client_perform(client);
   const int httpCode = esp_http_client_get_status_code(client);
@@ -130,11 +149,23 @@ KOReaderSyncClient::Error KOReaderSyncClient::getProgress(const std::string& doc
   }
 
   std::string url = KOREADER_STORE.getBaseUrl() + "/syncs/progress/" + documentHash;
-  LOG_DBG("KOSync", "Getting progress: %s (heap: %u)", url.c_str(), (unsigned)ESP.getFreeHeap());
+  const uint32_t freeHeap = ESP.getFreeHeap();
+  LOG_DBG("KOSync", "Getting progress: %s (heap: %u)", url.c_str(), (unsigned)freeHeap);
+  if (freeHeap < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("KOSync", "Insufficient heap for TLS handshake: %u bytes free (need %u)", freeHeap, MIN_HEAP_FOR_TLS);
+    return LOW_MEMORY;
+  }
 
   ResponseBuffer buf;
   esp_http_client_handle_t client = createClient(url.c_str(), &buf);
   if (!client) return NETWORK_ERROR;
+
+  const uint32_t heapBeforeGet = ESP.getFreeHeap();
+  if (heapBeforeGet < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("KOSync", "Heap dropped before get perform: %u bytes (need %u)", heapBeforeGet, MIN_HEAP_FOR_TLS);
+    esp_http_client_cleanup(client);
+    return LOW_MEMORY;
+  }
 
   esp_err_t err = esp_http_client_perform(client);
   const int httpCode = esp_http_client_get_status_code(client);
@@ -178,7 +209,12 @@ KOReaderSyncClient::Error KOReaderSyncClient::updateProgress(const KOReaderProgr
   }
 
   std::string url = KOREADER_STORE.getBaseUrl() + "/syncs/progress";
-  LOG_DBG("KOSync", "Updating progress: %s (heap: %u)", url.c_str(), (unsigned)ESP.getFreeHeap());
+  const uint32_t freeHeap = ESP.getFreeHeap();
+  LOG_DBG("KOSync", "Updating progress: %s (heap: %u)", url.c_str(), (unsigned)freeHeap);
+  if (freeHeap < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("KOSync", "Insufficient heap for TLS handshake: %u bytes free (need %u)", freeHeap, MIN_HEAP_FOR_TLS);
+    return LOW_MEMORY;
+  }
 
   // Build JSON body
   JsonDocument doc;
@@ -202,6 +238,13 @@ KOReaderSyncClient::Error KOReaderSyncClient::updateProgress(const KOReaderProgr
     LOG_ERR("KOSync", "Failed to set request body");
     esp_http_client_cleanup(client);
     return NETWORK_ERROR;
+  }
+
+  const uint32_t heapBeforeUpdate = ESP.getFreeHeap();
+  if (heapBeforeUpdate < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("KOSync", "Heap dropped before update perform: %u bytes (need %u)", heapBeforeUpdate, MIN_HEAP_FOR_TLS);
+    esp_http_client_cleanup(client);
+    return LOW_MEMORY;
   }
 
   esp_err_t err = esp_http_client_perform(client);
@@ -233,6 +276,8 @@ const char* KOReaderSyncClient::errorString(Error error) {
       return "JSON parse error";
     case NOT_FOUND:
       return "No progress found";
+    case LOW_MEMORY:
+      return "Not enough memory for sync — please retry";
     default:
       return "Unknown error";
   }

--- a/lib/KOReaderSync/KOReaderSyncClient.h
+++ b/lib/KOReaderSync/KOReaderSyncClient.h
@@ -29,7 +29,7 @@ struct KOReaderProgress {
  */
 class KOReaderSyncClient {
  public:
-  enum Error { OK = 0, NO_CREDENTIALS, NETWORK_ERROR, AUTH_FAILED, SERVER_ERROR, JSON_ERROR, NOT_FOUND };
+  enum Error { OK = 0, NO_CREDENTIALS, NETWORK_ERROR, AUTH_FAILED, SERVER_ERROR, JSON_ERROR, NOT_FOUND, LOW_MEMORY };
 
   /**
    * Authenticate with the sync server (validate credentials).

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -21,6 +21,7 @@
 #include "KOReaderCredentialStore.h"
 #include "KOReaderSyncActivity.h"
 #include "MappedInputManager.h"
+#include "ProgressMapper.h"
 #include "QrDisplayActivity.h"
 #include "ReaderUtils.h"
 #include "RecentBooksStore.h"
@@ -418,22 +419,62 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
             paragraphIndex = *pIdx;
           }
         }
+
+        // Pre-compute local KO position and chapter name while Epub is still in RAM.
+        CrossPointPosition localPos = {currentSpineIndex, currentPage, totalPages};
+        if (paragraphIndex.has_value()) {
+          localPos.paragraphIndex = *paragraphIndex;
+          localPos.hasParagraphIndex = true;
+        }
+        KOReaderPosition localKoPos = ProgressMapper::toKOReader(epub, localPos);
+        const int tocIdx = epub->getTocIndexForSpineIndex(currentSpineIndex);
+        std::string localChapterName = (tocIdx >= 0) ? epub->getTocItem(tocIdx).title : "";
+        const std::string savedEpubPath = epub->getPath();
+
+        // Release Epub and Section under RenderLock (same pattern as applyOrientation/pageTurn)
+        // to avoid racing with the render thread. Also persists currentPage before section drops.
+        LOG_DBG("KOSync", "Releasing epub for sync (heap before: %u)", (unsigned)ESP.getFreeHeap());
+        {
+          RenderLock lock(*this);
+          if (section) {
+            nextPageNumber = section->currentPage;
+          }
+          section.reset();
+          epub.reset();
+        }
+        LOG_DBG("KOSync", "Epub released (heap after: %u)", (unsigned)ESP.getFreeHeap());
+
         startActivityForResult(
-            std::make_unique<KOReaderSyncActivity>(renderer, mappedInput, epub, epub->getPath(), currentSpineIndex,
-                                                   currentPage, totalPages, paragraphIndex),
-            [this](const ActivityResult& result) {
-              if (!result.isCancelled) {
-                const auto& sync = std::get<SyncResult>(result.data);
-                if (currentSpineIndex != sync.spineIndex || (section && section->currentPage != sync.page)) {
-                  RenderLock lock(*this);
-                  currentSpineIndex = sync.spineIndex;
-                  nextPageNumber = sync.page;
-                  cachedChapterTotalPageCount = 0;  // Prevent rescaling sync page
-                  pendingPageJump.reset();
-                  saveProgress(currentSpineIndex, nextPageNumber, 0);
-                  section.reset();
+            std::make_unique<KOReaderSyncActivity>(renderer, mappedInput, savedEpubPath, currentSpineIndex, currentPage,
+                                                   totalPages, std::move(localKoPos), std::move(localChapterName),
+                                                   paragraphIndex),
+            [this, savedEpubPath](const ActivityResult& result) {
+              // Reload Epub and apply any position change under a single RenderLock so render()
+              // cannot dereference epub while it is being constructed or partially loaded.
+              LOG_DBG("KOSync", "Reloading epub after sync (heap before: %u)", (unsigned)ESP.getFreeHeap());
+              {
+                RenderLock lock(*this);
+                epub = std::make_shared<Epub>(savedEpubPath, "/.crosspoint");
+                epub->setupCacheDir();
+                if (!epub->load(true, SETTINGS.embeddedStyle == 0)) {
+                  LOG_ERR("KOSync", "Failed to reload epub after sync");
+                  epub.reset();
+                }
+
+                if (!result.isCancelled) {
+                  const auto& sync = std::get<SyncResult>(result.data);
+                  // section is null here (released before launch), so compare nextPageNumber
+                  // directly rather than section->currentPage.
+                  if (currentSpineIndex != sync.spineIndex || nextPageNumber != sync.page) {
+                    currentSpineIndex = sync.spineIndex;
+                    nextPageNumber = sync.page;
+                    cachedChapterTotalPageCount = 0;  // Prevent rescaling sync page
+                    pendingPageJump.reset();
+                    saveProgress(currentSpineIndex, nextPageNumber, 0);
+                  }
                 }
               }
+              LOG_DBG("KOSync", "Epub reloaded (heap after: %u)", (unsigned)ESP.getFreeHeap());
             });
       }
       break;

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -6,6 +6,8 @@
 #include <WiFi.h>
 #include <esp_sntp.h>
 
+#include <cassert>
+
 #include "Epub/Section.h"
 #include "KOReaderCredentialStore.h"
 #include "KOReaderDocumentId.h"
@@ -15,16 +17,6 @@
 #include "fontIds.h"
 
 namespace {
-CrossPointPosition makeLocalPositionWithParagraph(const int spineIndex, const int page, const int totalPages,
-                                                  const std::optional<uint16_t>& paragraphIndex) {
-  CrossPointPosition pos = {spineIndex, page, totalPages};
-  if (paragraphIndex.has_value()) {
-    pos.paragraphIndex = *paragraphIndex;
-    pos.hasParagraphIndex = true;
-  }
-  return pos;
-}
-
 void syncTimeWithNTP() {
   // Stop SNTP if already running (can't reconfigure while running)
   if (esp_sntp_enabled()) {
@@ -60,6 +52,17 @@ void wifiOff() {
   delay(100);
 }
 }  // namespace
+
+void KOReaderSyncActivity::ensureEpubLoaded() {
+  if (!epub) {
+    LOG_DBG("KOSync", "Loading epub for progress mapping (heap: %u)", (unsigned)ESP.getFreeHeap());
+    epub = std::make_shared<Epub>(epubPath, "/.crosspoint");
+    epub->setupCacheDir();
+    // Load metadata only (no CSS needed for progress mapping, don't rebuild if cache is missing).
+    epub->load(false, true);
+    LOG_DBG("KOSync", "Epub loaded (heap: %u)", (unsigned)ESP.getFreeHeap());
+  }
+}
 
 void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   if (!success) {
@@ -141,8 +144,10 @@ void KOReaderSyncActivity::performSync() {
     return;
   }
 
-  // Convert remote progress to CrossPoint position
+  // Epub was released before sync to free RAM for the TLS handshake — reload it now.
   hasRemoteProgress = true;
+  ensureEpubLoaded();
+
   KOReaderPosition koPos = {remoteProgress.progress, remoteProgress.percentage};
   remotePosition = ProgressMapper::toCrossPoint(epub, koPos, currentSpineIndex, totalPagesInSpine);
 
@@ -157,11 +162,7 @@ void KOReaderSyncActivity::performSync() {
       remotePosition.pageNumber = *paragraphPage;
     }
   }
-
-  // Calculate local progress in KOReader format (for display)
-  CrossPointPosition localPos =
-      makeLocalPositionWithParagraph(currentSpineIndex, currentPage, totalPagesInSpine, currentParagraphIndex);
-  localProgress = ProgressMapper::toKOReader(epub, localPos);
+  // localProgress was pre-computed in EpubReaderActivity before the Epub was released.
 
   {
     RenderLock lock(*this);
@@ -185,15 +186,11 @@ void KOReaderSyncActivity::performUpload() {
   }
   requestUpdateAndWait();
 
-  // Convert current position to KOReader format
-  CrossPointPosition localPos =
-      makeLocalPositionWithParagraph(currentSpineIndex, currentPage, totalPagesInSpine, currentParagraphIndex);
-  KOReaderPosition koPos = ProgressMapper::toKOReader(epub, localPos);
-
+  // localProgress was pre-computed in EpubReaderActivity before the Epub was released.
   KOReaderProgress progress;
   progress.document = documentHash;
-  progress.progress = koPos.xpath;
-  progress.percentage = koPos.percentage;
+  progress.progress = localProgress.xpath;
+  progress.percentage = localProgress.percentage;
 
   const auto result = KOReaderSyncClient::updateProgress(progress);
 
@@ -271,15 +268,16 @@ void KOReaderSyncActivity::render(RenderLock&&) {
     // Show comparison
     renderer.drawCenteredText(UI_10_FONT_ID, 120, tr(STR_PROGRESS_FOUND), true, EpdFontFamily::BOLD);
 
-    // Get chapter names from TOC
+    // Remote chapter name requires Epub (loaded lazily in performSync before this state).
+    assert(epub);
     const int remoteTocIndex = epub->getTocIndexForSpineIndex(remotePosition.spineIndex);
-    const int localTocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
     const std::string remoteChapter =
         (remoteTocIndex >= 0) ? epub->getTocItem(remoteTocIndex).title
                               : (std::string(tr(STR_SECTION_PREFIX)) + std::to_string(remotePosition.spineIndex + 1));
+    // Local chapter name was pre-computed before Epub was released.
     const std::string localChapter =
-        (localTocIndex >= 0) ? epub->getTocItem(localTocIndex).title
-                             : (std::string(tr(STR_SECTION_PREFIX)) + std::to_string(currentSpineIndex + 1));
+        !localChapterName.empty() ? localChapterName
+                                  : (std::string(tr(STR_SECTION_PREFIX)) + std::to_string(currentSpineIndex + 1));
 
     // Remote progress - chapter and page
     renderer.drawText(UI_10_FONT_ID, 20, 160, tr(STR_REMOTE_LABEL), true);

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -21,20 +21,20 @@
  */
 class KOReaderSyncActivity final : public Activity {
  public:
-  explicit KOReaderSyncActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                const std::shared_ptr<Epub>& epub, const std::string& epubPath, int currentSpineIndex,
-                                int currentPage, int totalPagesInSpine,
+  explicit KOReaderSyncActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& epubPath,
+                                int currentSpineIndex, int currentPage, int totalPagesInSpine,
+                                KOReaderPosition localKoPos, std::string localChapterName,
                                 std::optional<uint16_t> currentParagraphIndex = std::nullopt)
       : Activity("KOReaderSync", renderer, mappedInput),
-        epub(epub),
         epubPath(epubPath),
         currentSpineIndex(currentSpineIndex),
         currentPage(currentPage),
         totalPagesInSpine(totalPagesInSpine),
         currentParagraphIndex(currentParagraphIndex),
+        localChapterName(std::move(localChapterName)),
         remoteProgress{},
         remotePosition{},
-        localProgress{} {}
+        localProgress(std::move(localKoPos)) {}
 
   void onEnter() override;
   void onExit() override;
@@ -55,8 +55,9 @@ class KOReaderSyncActivity final : public Activity {
     NO_CREDENTIALS
   };
 
-  std::shared_ptr<Epub> epub;
+  std::shared_ptr<Epub> epub;  // null until lazy-loaded after TLS in performSync()
   std::string epubPath;
+  std::string localChapterName;
   int currentSpineIndex;
   int currentPage;
   int totalPagesInSpine;
@@ -80,4 +81,5 @@ class KOReaderSyncActivity final : public Activity {
   void onWifiSelectionComplete(bool success);
   void performSync();
   void performUpload();
+  void ensureEpubLoaded();
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix KOSync failing with \"Network error\" on large/complex EPUBs due to TLS heap exhaustion.

* **What changes are included?**
  - **Free Epub RAM before TLS handshake** — `EpubReaderActivity` now pre-computes the local KOReader position and chapter name, then explicitly releases `epub` and `section` before launching `KOReaderSyncActivity`. This frees ~65KB measured on device, giving the TLS handshake sufficient heap. `KOReaderSyncActivity` no longer receives a `shared_ptr<Epub>`; it lazy-loads the Epub after TLS only if remote progress is found.
  - **Heap guard** — Added `MIN_HEAP_FOR_TLS = 55000` in `KOReaderSyncClient` using `ESP.getFreeHeap()` (not `getMaxAllocHeap()`, since the failure mode is aggregate exhaustion across many small mbedTLS allocations). Added new `LOW_MEMORY` error code and user-facing message — these did not exist in the base source.

## Additional Context

Root cause: `MBEDTLS_ERR_X509_ALLOC_FAILED` (-0x2880). A custom hosted sync server using a 3-cert Google Trust Services chain requires ~48KB of heap in aggregate during the TLS handshake. With the Epub in RAM only ~50KB was free, driving min-free-ever to 2,600 bytes before the handshake failed. The user could not work around it because sync is launched from inside the book — there is no way to close the book first.

| Metric | Before | After |
|---|---|---|
| Heap before Epub release | 88,156 bytes | — |
| Heap after Epub release | — | 153,892 bytes (+65,736) |
| Heap at TLS handshake | ~50,000 bytes (fails) | ~116,384 bytes (passes) |
| Min-free-ever during sync session | 2,600 bytes | 33,052 bytes |
| TLS result | `MBEDTLS_ERR_X509_ALLOC_FAILED` | HTTP 200 |

**Test checklist:**
- [ ] Trigger KOSync from inside a large/complex EPUB that previously failed with "Network error"
- [ ] Verify sync completes and remote progress is shown
- [ ] Cancel sync — confirm book resumes at the correct page
- [ ] Apply remote progress — confirm book jumps to the correct position
- [ ] Upload local progress — confirm server receives the correct XPath/percentage

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_