### PR TITLE
feat: add native emulator target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 .history/
 /.venv
 *.local*
+/emu_sd/

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -6,6 +6,7 @@ It is written for software developers who may be new to embedded development.
 - [Getting Started](./getting-started.md)
 - [Architecture Overview](./architecture.md)
 - [Development Workflow](./development-workflow.md)
+- [Native Emulator](./native-emulator.md)
 - [Testing and Debugging](./testing-debugging.md)
 
 If you are new, start with [Getting Started](./getting-started.md).

--- a/docs/contributing/native-emulator.md
+++ b/docs/contributing/native-emulator.md
@@ -1,0 +1,69 @@
+# Native Emulator
+
+The native emulator builds a desktop SDL app for fast local testing of UI and reader changes without flashing a device.
+It is intended as a development aid, not a replacement for hardware validation.
+
+## Prerequisites
+
+- PlatformIO Core
+- SDL2 development files
+
+On macOS with Homebrew:
+
+```sh
+brew install sdl2
+```
+
+## Build
+
+```sh
+pio run -e emulator
+```
+
+The emulator binary is written to:
+
+```sh
+.pio/build/emulator/program
+```
+
+## Run
+
+The emulator maps the SD card to a local directory. By default it uses `./emu_sd`.
+You can also pass an explicit path:
+
+```sh
+CROSSPOINT_EMU_SD="$PWD/emu_sd" .pio/build/emulator/program
+```
+
+The helper script creates the expected SD folders and runs the emulator with the local SD root:
+
+```sh
+scripts/run_emulator.sh
+```
+
+## Add Books
+
+Put books under the `books` directory inside the emulated SD root:
+
+```sh
+mkdir -p emu_sd/books
+cp /path/to/book.epub emu_sd/books/
+```
+
+Then start the emulator and open the book from the Books screen.
+
+## Controls
+
+- Arrow keys: directional buttons
+- Enter or Space: confirm
+- Escape or Backspace: back
+- Tab or `p`: power button
+
+Press and release Tab to enter the sleep screen. Press and release Tab again to wake back to the home screen.
+
+## Current Limitations
+
+- Wi-Fi, OPDS, OTA update, browser, and file-transfer flows are stubbed.
+- The emulator renders a monochrome approximation of the e-paper framebuffer.
+- Grayscale refresh is not fully simulated yet.
+- Final validation should still be done on Xteink X4 hardware.

--- a/docs/contributing/testing-debugging.md
+++ b/docs/contributing/testing-debugging.md
@@ -1,6 +1,8 @@
 # Testing and Debugging
 
 CrossPoint runs on real hardware, so debugging usually combines local build checks and on-device logs.
+For UI and reader flow changes, the native emulator can provide a faster first pass before hardware testing:
+[Native Emulator](./native-emulator.md).
 
 ## Local checks
 

--- a/lib/Serialization/ObfuscationUtils.cpp
+++ b/lib/Serialization/ObfuscationUtils.cpp
@@ -1,5 +1,20 @@
 #include "ObfuscationUtils.h"
 
+#if CROSSPOINT_EMULATED
+
+namespace obfuscation {
+void xorTransform(std::string&) {}
+void xorTransform(std::string&, const uint8_t*, size_t) {}
+String obfuscateToBase64(const std::string& plaintext) { return String(plaintext); }
+std::string deobfuscateFromBase64(const char* encoded, bool* ok) {
+  if (ok) *ok = encoded != nullptr;
+  return encoded ? encoded : "";
+}
+void selfTest() {}
+}  // namespace obfuscation
+
+#else
+
 #include <Logging.h>
 #include <base64.h>
 #include <esp_mac.h>
@@ -96,3 +111,4 @@ void selfTest() {
 }
 
 }  // namespace obfuscation
+#endif

--- a/lib/emulator/Arduino.h
+++ b/lib/emulator/Arduino.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <chrono>
+#include <cassert>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#define PROGMEM
+#define F(x) x
+#define HIGH 1
+#define LOW 0
+#define INPUT 0
+#define OUTPUT 1
+#define INPUT_PULLUP 2
+#define A0 0
+#define RTC_NOINIT_ATTR
+#define DRAM_ATTR
+#define IRAM_ATTR
+
+class String {
+  std::string value;
+
+ public:
+  String() = default;
+  String(const char* s) : value(s ? s : "") {}
+  explicit String(const std::string& s) : value(s) {}
+  explicit String(std::string&& s) : value(std::move(s)) {}
+  String(char c) : value(1, c) {}
+  String(int n) : value(std::to_string(n)) {}
+  String(unsigned int n) : value(std::to_string(n)) {}
+  String(long n) : value(std::to_string(n)) {}
+  String(unsigned long n) : value(std::to_string(n)) {}
+
+  const char* c_str() const { return value.c_str(); }
+  bool isEmpty() const { return value.empty(); }
+  size_t length() const { return value.length(); }
+  void trim() {
+    const auto first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+      value.clear();
+      return;
+    }
+    const auto last = value.find_last_not_of(" \t\r\n");
+    value = value.substr(first, last - first + 1);
+  }
+  bool startsWith(const char* prefix) const { return value.rfind(prefix ? prefix : "", 0) == 0; }
+  String substring(size_t start) const { return String(start < value.size() ? value.substr(start) : std::string()); }
+  String substring(size_t start, size_t end) const {
+    if (start >= value.size()) return {};
+    return String(value.substr(start, end > start ? end - start : 0));
+  }
+  int indexOf(char c) const {
+    const auto pos = value.find(c);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+  char charAt(size_t i) const { return i < value.size() ? value[i] : '\0'; }
+  void reserve(size_t n) { value.reserve(n); }
+  size_t write(uint8_t c) {
+    value.push_back(static_cast<char>(c));
+    return 1;
+  }
+  size_t write(const uint8_t* data, size_t n) {
+    value.append(reinterpret_cast<const char*>(data), n);
+    return n;
+  }
+  size_t write(const char* data, size_t n) {
+    value.append(data, n);
+    return n;
+  }
+  void remove(size_t index) {
+    if (index < value.size()) value.erase(index);
+  }
+  void replace(const char* from, const char* to) {
+    const std::string f = from ? from : "";
+    const std::string t = to ? to : "";
+    if (f.empty()) return;
+    size_t pos = 0;
+    while ((pos = value.find(f, pos)) != std::string::npos) {
+      value.replace(pos, f.size(), t);
+      pos += t.size();
+    }
+  }
+  operator const char*() const { return value.c_str(); }
+  char operator[](size_t i) const { return value[i]; }
+  String& operator+=(const String& other) {
+    value += other.value;
+    return *this;
+  }
+  String& operator+=(const char* other) {
+    value += other ? other : "";
+    return *this;
+  }
+  String& operator+=(char c) {
+    value += c;
+    return *this;
+  }
+  friend String operator+(const String& a, const String& b) { return String(a.value + b.value); }
+  friend String operator+(const String& a, const char* b) { return String(a.value + (b ? b : "")); }
+  friend String operator+(const char* a, const String& b) { return String((a ? a : "") + b.value); }
+  friend bool operator==(const String& a, const String& b) { return a.value == b.value; }
+  friend bool operator!=(const String& a, const String& b) { return !(a == b); }
+};
+
+class Print {
+ public:
+  virtual ~Print() = default;
+  virtual size_t write(uint8_t b) { return write(&b, 1); }
+  virtual size_t write(const uint8_t* buffer, size_t size) {
+    return fwrite(buffer, 1, size, stdout);
+  }
+  size_t write(const char* s) { return write(reinterpret_cast<const uint8_t*>(s), strlen(s)); }
+  size_t print(const char* s) { return write(s ? s : ""); }
+  size_t print(const String& s) { return print(s.c_str()); }
+  size_t println(const char* s = "") {
+    size_t n = print(s);
+    n += print("\n");
+    return n;
+  }
+  virtual void flush() { fflush(stdout); }
+  virtual int available() { return 0; }
+  virtual String readStringUntil(char) { return {}; }
+  size_t printf(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    const int n = vprintf(format, args);
+    va_end(args);
+    return n < 0 ? 0 : static_cast<size_t>(n);
+  }
+};
+
+class HWCDC : public Print {
+ public:
+  void begin(unsigned long) {}
+  operator bool() const { return true; }
+};
+
+extern HWCDC Serial;
+
+class ESPClass {
+ public:
+  uint32_t getFreeHeap() const { return 1024 * 1024 * 64; }
+  uint32_t getHeapSize() const { return 1024 * 1024 * 64; }
+  uint32_t getMinFreeHeap() const { return 1024 * 1024 * 64; }
+  uint32_t getMaxAllocHeap() const { return 1024 * 1024 * 32; }
+  void restart() const { std::exit(0); }
+};
+
+extern ESPClass ESP;
+
+inline unsigned long millis() {
+  static const auto start = std::chrono::steady_clock::now();
+  return static_cast<unsigned long>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count());
+}
+inline unsigned long micros() {
+  static const auto start = std::chrono::steady_clock::now();
+  return static_cast<unsigned long>(
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count());
+}
+inline void delay(unsigned long ms) { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
+inline void yield() { std::this_thread::yield(); }
+inline void pinMode(int, int) {}
+inline int digitalRead(int) { return HIGH; }
+inline void digitalWrite(int, int) {}
+inline int analogRead(int) { return 2048; }
+inline int getCpuFrequencyMhz() { return 160; }
+inline bool setCpuFrequencyMhz(int) { return true; }
+inline long random(long max) { return max <= 0 ? 0 : std::rand() % max; }
+inline long random(long min, long max) { return min + random(max - min); }

--- a/lib/emulator/EmulatorGlobals.cpp
+++ b/lib/emulator/EmulatorGlobals.cpp
@@ -1,0 +1,12 @@
+#include "Arduino.h"
+#include "SPI.h"
+#include "Wire.h"
+#include "WiFi.h"
+
+HWCDC Serial;
+ESPClass ESP;
+WiFiClass WiFi;
+SPIClass SPI;
+TwoWire Wire;
+
+uint32_t esp_get_free_heap_size() { return ESP.getFreeHeap(); }

--- a/lib/emulator/HardwareSerial.h
+++ b/lib/emulator/HardwareSerial.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Arduino.h"

--- a/lib/emulator/Print.h
+++ b/lib/emulator/Print.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Arduino.h"

--- a/lib/emulator/SPI.h
+++ b/lib/emulator/SPI.h
@@ -1,0 +1,6 @@
+#pragma once
+class SPIClass {
+ public:
+  void begin(int = 0, int = 0, int = 0, int = 0) {}
+};
+extern SPIClass SPI;

--- a/lib/emulator/WString.h
+++ b/lib/emulator/WString.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Arduino.h"

--- a/lib/emulator/WiFi.h
+++ b/lib/emulator/WiFi.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "Arduino.h"
+
+enum wl_status_t { WL_IDLE_STATUS = 0, WL_CONNECTED = 3, WL_DISCONNECTED = 6 };
+enum WiFiMode_t { WIFI_OFF = 0, WIFI_STA = 1, WIFI_AP = 2, WIFI_AP_STA = 3, WIFI_MODE_NULL = 0 };
+
+class IPAddress {
+  uint8_t bytes[4] = {0, 0, 0, 0};
+
+ public:
+  IPAddress() = default;
+  IPAddress(uint8_t a, uint8_t b, uint8_t c, uint8_t d) : bytes{a, b, c, d} {}
+  bool operator!=(const IPAddress& other) const { return memcmp(bytes, other.bytes, sizeof(bytes)) != 0; }
+  String toString() const {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%u.%u.%u.%u", bytes[0], bytes[1], bytes[2], bytes[3]);
+    return String(buf);
+  }
+};
+
+class WiFiClass {
+ public:
+  void mode(WiFiMode_t) {}
+  WiFiMode_t getMode() const { return WIFI_OFF; }
+  wl_status_t status() const { return WL_DISCONNECTED; }
+  IPAddress localIP() const { return IPAddress(); }
+  void disconnect(bool = true) {}
+};
+
+extern WiFiClass WiFi;

--- a/lib/emulator/Wire.h
+++ b/lib/emulator/Wire.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstdint>
+
+class TwoWire {
+ public:
+  void begin(int = 0, int = 0, int = 0) {}
+  void end() {}
+  void setTimeOut(int) {}
+  void beginTransmission(uint8_t) {}
+  void write(uint8_t) {}
+  int endTransmission(bool = true) { return 1; }
+  int requestFrom(uint8_t, uint8_t, uint8_t = true) { return 0; }
+  int available() { return 0; }
+  uint8_t read() { return 0; }
+};
+extern TwoWire Wire;

--- a/lib/emulator/common/FsApiConstants.h
+++ b/lib/emulator/common/FsApiConstants.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <fcntl.h>
+
+using oflag_t = int;
+
+#ifndef O_READ
+#define O_READ O_RDONLY
+#endif
+#ifndef O_WRITE
+#define O_WRITE O_WRONLY
+#endif

--- a/lib/emulator/esp_system.h
+++ b/lib/emulator/esp_system.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "Arduino.h"
+
+inline uint32_t esp_get_free_heap_size() { return ESP.getFreeHeap(); }

--- a/lib/emulator/freertos/FreeRTOS.h
+++ b/lib/emulator/freertos/FreeRTOS.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Arduino.h>
+#include <mutex>
+
+#define pdTRUE 1
+#define pdFALSE 0
+#define portMAX_DELAY 0xffffffffUL
+
+using TaskHandle_t = void*;
+using SemaphoreHandle_t = std::recursive_mutex*;
+
+inline SemaphoreHandle_t xSemaphoreCreateMutex() { return new std::recursive_mutex(); }
+inline int xSemaphoreTake(SemaphoreHandle_t sem, unsigned long) {
+  sem->lock();
+  return pdTRUE;
+}
+inline int xSemaphoreGive(SemaphoreHandle_t sem) {
+  sem->unlock();
+  return pdTRUE;
+}
+inline void* xSemaphoreGetMutexHolder(SemaphoreHandle_t) { return nullptr; }
+inline int xQueuePeek(SemaphoreHandle_t, void*, int) { return pdTRUE; }
+
+inline TaskHandle_t xTaskGetCurrentTaskHandle() { return nullptr; }
+inline int xTaskCreate(void (*)(void*), const char*, uint32_t, void*, uint32_t, TaskHandle_t* handle) {
+  if (handle) *handle = reinterpret_cast<TaskHandle_t>(1);
+  return pdTRUE;
+}
+enum eNotifyAction { eIncrement };
+inline int xTaskNotify(TaskHandle_t, uint32_t, eNotifyAction) { return pdTRUE; }
+inline uint32_t ulTaskNotifyTake(int, unsigned long) { return 1; }
+inline void vTaskDelay(uint32_t ms) { delay(ms); }
+inline void taskENTER_CRITICAL(void*) {}
+inline void taskEXIT_CRITICAL(void*) {}

--- a/lib/emulator/freertos/semphr.h
+++ b/lib/emulator/freertos/semphr.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "FreeRTOS.h"

--- a/lib/emulator/freertos/task.h
+++ b/lib/emulator/freertos/task.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "FreeRTOS.h"

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -1,6 +1,106 @@
 #include <HalDisplay.h>
 #include <HalGPIO.h>
 
+#if CROSSPOINT_EMULATED
+#include <SDL.h>
+
+// Global HalDisplay instance
+HalDisplay display;
+
+namespace {
+uint8_t frameBuffer[HalDisplay::BUFFER_SIZE];
+SDL_Window* window = nullptr;
+SDL_Renderer* sdlRenderer = nullptr;
+SDL_Texture* texture = nullptr;
+constexpr uint16_t WINDOW_WIDTH = HalDisplay::DISPLAY_HEIGHT;
+constexpr uint16_t WINDOW_HEIGHT = HalDisplay::DISPLAY_WIDTH;
+
+void ensureSdl() {
+  if (window) return;
+  SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
+  window = SDL_CreateWindow("CrossPoint Reader Emulator", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, WINDOW_WIDTH,
+                            WINDOW_HEIGHT, SDL_WINDOW_SHOWN);
+  sdlRenderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+  texture = SDL_CreateTexture(sdlRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, WINDOW_WIDTH,
+                              WINDOW_HEIGHT);
+}
+}  // namespace
+
+HalDisplay::HalDisplay() { memset(frameBuffer, 0xFF, sizeof(frameBuffer)); }
+HalDisplay::~HalDisplay() {}
+void HalDisplay::begin() { ensureSdl(); }
+void HalDisplay::clearScreen(uint8_t color) const { memset(frameBuffer, color, sizeof(frameBuffer)); }
+void HalDisplay::drawImage(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                           bool fromProgmem) const {
+  (void)fromProgmem;
+  for (uint16_t yy = 0; yy < h; yy++) {
+    if (y + yy >= DISPLAY_HEIGHT) break;
+    const uint16_t srcBytes = (w + 7) / 8;
+    const uint16_t dstBytes = DISPLAY_WIDTH_BYTES;
+    if (x == 0 && w == DISPLAY_WIDTH) {
+      memcpy(frameBuffer + (y + yy) * dstBytes, imageData + yy * srcBytes, std::min<uint16_t>(srcBytes, dstBytes));
+    } else {
+      for (uint16_t xx = 0; xx < w; xx++) {
+        if (x + xx >= DISPLAY_WIDTH) break;
+        const bool black = (imageData[yy * srcBytes + (xx >> 3)] & (0x80 >> (xx & 7))) == 0;
+        uint8_t& b = frameBuffer[(y + yy) * dstBytes + ((x + xx) >> 3)];
+        const uint8_t mask = 0x80 >> ((x + xx) & 7);
+        if (black)
+          b &= ~mask;
+        else
+          b |= mask;
+      }
+    }
+  }
+}
+void HalDisplay::drawImageTransparent(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                                      bool fromProgmem) const {
+  drawImage(imageData, x, y, w, h, fromProgmem);
+}
+void HalDisplay::displayBuffer(HalDisplay::RefreshMode, bool) {
+  ensureSdl();
+  uint32_t* pixels = nullptr;
+  int pitch = 0;
+  if (SDL_LockTexture(texture, nullptr, reinterpret_cast<void**>(&pixels), &pitch) == 0) {
+    for (uint16_t y = 0; y < WINDOW_HEIGHT; y++) {
+      auto* row = reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(pixels) + y * pitch);
+      for (uint16_t x = 0; x < WINDOW_WIDTH; x++) {
+        const uint16_t physicalX = y;
+        const uint16_t physicalY = DISPLAY_HEIGHT - 1 - x;
+        const bool white =
+            (frameBuffer[physicalY * DISPLAY_WIDTH_BYTES + (physicalX >> 3)] & (0x80 >> (physicalX & 7))) != 0;
+        row[x] = white ? 0xFFFFFFFF : 0xFF111111;
+      }
+    }
+    SDL_UnlockTexture(texture);
+  }
+  SDL_RenderClear(sdlRenderer);
+  SDL_RenderCopy(sdlRenderer, texture, nullptr, nullptr);
+  SDL_RenderPresent(sdlRenderer);
+}
+void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  displayBuffer(mode, turnOffScreen);
+}
+void HalDisplay::deepSleep() {}
+uint8_t* HalDisplay::getFrameBuffer() const { return frameBuffer; }
+void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t*) {
+  memcpy(frameBuffer, lsbBuffer, BUFFER_SIZE);
+}
+void HalDisplay::copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer) { memcpy(frameBuffer, lsbBuffer, BUFFER_SIZE); }
+void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { memcpy(frameBuffer, msbBuffer, BUFFER_SIZE); }
+void HalDisplay::cleanupGrayscaleBuffers(const uint8_t*) {}
+void HalDisplay::displayGrayBuffer(bool) {
+  // The firmware uses display-specific grayscale planes/LUTs here. In the emulator,
+  // showing either plane directly looks like a black mask with dotted text, so keep
+  // the already-presented BW frame until we emulate grayscale composition properly.
+}
+uint16_t HalDisplay::getDisplayWidth() const { return DISPLAY_WIDTH; }
+uint16_t HalDisplay::getDisplayHeight() const { return DISPLAY_HEIGHT; }
+uint16_t HalDisplay::getDisplayWidthBytes() const { return DISPLAY_WIDTH_BYTES; }
+uint32_t HalDisplay::getBufferSize() const { return BUFFER_SIZE; }
+
+#else
+
 // Global HalDisplay instance
 HalDisplay display;
 
@@ -89,3 +189,4 @@ uint16_t HalDisplay::getDisplayHeight() const { return einkDisplay.getDisplayHei
 uint16_t HalDisplay::getDisplayWidthBytes() const { return einkDisplay.getDisplayWidthBytes(); }
 
 uint32_t HalDisplay::getBufferSize() const { return einkDisplay.getBufferSize(); }
+#endif

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <Arduino.h>
+#if CROSSPOINT_EMULATED
+#include <cstdint>
+#else
 #include <EInkDisplay.h>
+#endif
 
 class HalDisplay {
  public:
@@ -17,12 +21,16 @@ class HalDisplay {
     FAST_REFRESH   // Fast refresh using custom LUT
   };
 
+#if CROSSPOINT_EMULATED
+  static constexpr uint16_t DISPLAY_WIDTH = 800;
+  static constexpr uint16_t DISPLAY_HEIGHT = 480;
+#else
   // Initialize the display hardware and driver
-  void begin();
-
   // Display dimensions
   static constexpr uint16_t DISPLAY_WIDTH = EInkDisplay::DISPLAY_WIDTH;
   static constexpr uint16_t DISPLAY_HEIGHT = EInkDisplay::DISPLAY_HEIGHT;
+#endif
+  void begin();
   static constexpr uint16_t DISPLAY_WIDTH_BYTES = DISPLAY_WIDTH / 8;
   static constexpr uint32_t BUFFER_SIZE = DISPLAY_WIDTH_BYTES * DISPLAY_HEIGHT;
 
@@ -56,7 +64,9 @@ class HalDisplay {
   uint32_t getBufferSize() const;
 
  private:
+#if !CROSSPOINT_EMULATED
   EInkDisplay einkDisplay;
+#endif
 };
 
 extern HalDisplay display;

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -1,4 +1,98 @@
 #include <HalGPIO.h>
+
+#if CROSSPOINT_EMULATED
+#include <SDL.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+
+HalGPIO gpio;
+
+namespace {
+std::array<bool, 7> currentButtons{};
+std::array<bool, 7> previousButtons{};
+std::array<unsigned long, 7> pressedAt{};
+unsigned long heldTime = 0;
+
+void setButton(SDL_Keycode key, bool down) {
+  int button = -1;
+  switch (key) {
+    case SDLK_ESCAPE:
+    case SDLK_BACKSPACE:
+      button = HalGPIO::BTN_BACK;
+      break;
+    case SDLK_RETURN:
+    case SDLK_SPACE:
+      button = HalGPIO::BTN_CONFIRM;
+      break;
+    case SDLK_LEFT:
+      button = HalGPIO::BTN_LEFT;
+      break;
+    case SDLK_RIGHT:
+      button = HalGPIO::BTN_RIGHT;
+      break;
+    case SDLK_UP:
+      button = HalGPIO::BTN_UP;
+      break;
+    case SDLK_DOWN:
+      button = HalGPIO::BTN_DOWN;
+      break;
+    case SDLK_TAB:
+    case SDLK_p:
+      button = HalGPIO::BTN_POWER;
+      break;
+    default:
+      break;
+  }
+  if (button >= 0) {
+    currentButtons[button] = down;
+    if (down && !previousButtons[button]) pressedAt[button] = millis();
+  }
+}
+}  // namespace
+
+void HalGPIO::begin() { _deviceType = DeviceType::X4; }
+void HalGPIO::update() {
+  previousButtons = currentButtons;
+  SDL_Event event;
+  while (SDL_PollEvent(&event)) {
+    if (event.type == SDL_QUIT) std::_Exit(0);
+    if (event.type == SDL_KEYDOWN && !event.key.repeat) setButton(event.key.keysym.sym, true);
+    if (event.type == SDL_KEYUP) setButton(event.key.keysym.sym, false);
+  }
+  heldTime = 0;
+  for (size_t i = 0; i < currentButtons.size(); i++) {
+    if (currentButtons[i]) heldTime = std::max(heldTime, millis() - pressedAt[i]);
+  }
+}
+bool HalGPIO::isPressed(uint8_t buttonIndex) const {
+  return buttonIndex < currentButtons.size() && currentButtons[buttonIndex];
+}
+bool HalGPIO::wasPressed(uint8_t buttonIndex) const {
+  return buttonIndex < currentButtons.size() && currentButtons[buttonIndex] && !previousButtons[buttonIndex];
+}
+bool HalGPIO::wasAnyPressed() const {
+  for (size_t i = 0; i < currentButtons.size(); i++)
+    if (currentButtons[i] && !previousButtons[i]) return true;
+  return false;
+}
+bool HalGPIO::wasReleased(uint8_t buttonIndex) const {
+  return buttonIndex < currentButtons.size() && !currentButtons[buttonIndex] && previousButtons[buttonIndex];
+}
+bool HalGPIO::wasAnyReleased() const {
+  for (size_t i = 0; i < currentButtons.size(); i++)
+    if (!currentButtons[i] && previousButtons[i]) return true;
+  return false;
+}
+unsigned long HalGPIO::getHeldTime() const { return heldTime; }
+void HalGPIO::startDeepSleep() {}
+void HalGPIO::verifyPowerButtonWakeup(uint16_t, bool) {}
+bool HalGPIO::isUsbConnected() const { return true; }
+bool HalGPIO::wasUsbStateChanged() const { return false; }
+HalGPIO::WakeupReason HalGPIO::getWakeupReason() const { return WakeupReason::Other; }
+
+#else
 #include <Logging.h>
 #include <Preferences.h>
 #include <SPI.h>
@@ -302,3 +396,4 @@ HalGPIO::WakeupReason HalGPIO::getWakeupReason() const {
   }
   return WakeupReason::Other;
 }
+#endif

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Arduino.h>
+#if !CROSSPOINT_EMULATED
 #include <InputManager.h>
+#endif
 
 // Display SPI pins (custom pins for XteinkX4, not hardware SPI defaults)
 #define EPD_SCLK 8   // SPI Clock

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -1,5 +1,21 @@
 #include "HalPowerManager.h"
 
+#if CROSSPOINT_EMULATED
+
+HalPowerManager powerManager;
+
+void HalPowerManager::begin() {
+  normalFreq = 160;
+  modeMutex = xSemaphoreCreateMutex();
+}
+void HalPowerManager::setPowerSaving(bool) {}
+void HalPowerManager::startDeepSleep(HalGPIO&) const {}
+uint16_t HalPowerManager::getBatteryPercentage() const { return 80; }
+HalPowerManager::Lock::Lock() { valid = true; }
+HalPowerManager::Lock::~Lock() {}
+
+#else
+
 #include <Logging.h>
 #include <WiFi.h>
 #include <esp_sleep.h>
@@ -147,3 +163,4 @@ HalPowerManager::Lock::~Lock() {
   }
   xSemaphoreGive(powerManager.modeMutex);
 }
+#endif

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <Arduino.h>
+#if !CROSSPOINT_EMULATED
 #include <BatteryMonitor.h>
+#endif
+#if !CROSSPOINT_EMULATED
 #include <InputManager.h>
+#endif
 #include <Logging.h>
 #include <Wire.h>
 #include <freertos/semphr.h>

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -1,6 +1,262 @@
 #define HAL_STORAGE_IMPL
 #include "HalStorage.h"
 
+#if CROSSPOINT_EMULATED
+#include <Logging.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+HalStorage HalStorage::instance;
+
+namespace {
+fs::path rootPath() {
+  const char* env = std::getenv("CROSSPOINT_EMU_SD");
+  return env ? fs::path(env) : fs::current_path() / "emu_sd";
+}
+
+fs::path mapPath(const char* path) {
+  std::string p = path ? path : "/";
+  while (!p.empty() && p.front() == '/') p.erase(p.begin());
+  return rootPath() / p;
+}
+}  // namespace
+
+HalStorage::HalStorage() {}
+bool HalStorage::begin() {
+  fs::create_directories(rootPath() / ".crosspoint");
+  initialized = true;
+  return true;
+}
+bool HalStorage::ready() const { return initialized; }
+std::vector<String> HalStorage::listFiles(const char* path, int maxFiles) {
+  std::vector<String> out;
+  const fs::path dir = mapPath(path);
+  if (!fs::exists(dir) || !fs::is_directory(dir)) return out;
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    if (static_cast<int>(out.size()) >= maxFiles) break;
+    out.emplace_back(entry.path().filename().string());
+  }
+  return out;
+}
+String HalStorage::readFile(const char* path) {
+  std::ifstream in(mapPath(path), std::ios::binary);
+  if (!in) return {};
+  return String(std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()));
+}
+bool HalStorage::readFileToStream(const char* path, Print& out, size_t chunkSize) {
+  std::ifstream in(mapPath(path), std::ios::binary);
+  if (!in) return false;
+  std::vector<uint8_t> buf(chunkSize);
+  while (in) {
+    in.read(reinterpret_cast<char*>(buf.data()), buf.size());
+    const auto n = in.gcount();
+    if (n > 0) out.write(buf.data(), static_cast<size_t>(n));
+  }
+  return true;
+}
+size_t HalStorage::readFileToBuffer(const char* path, char* buffer, size_t bufferSize, size_t maxBytes) {
+  if (!buffer || bufferSize == 0) return 0;
+  std::ifstream in(mapPath(path), std::ios::binary);
+  if (!in) {
+    buffer[0] = '\0';
+    return 0;
+  }
+  const size_t limit = std::min(bufferSize - 1, maxBytes ? maxBytes : bufferSize - 1);
+  in.read(buffer, limit);
+  const size_t n = static_cast<size_t>(in.gcount());
+  buffer[n] = '\0';
+  return n;
+}
+bool HalStorage::writeFile(const char* path, const String& content) {
+  fs::create_directories(mapPath(path).parent_path());
+  std::ofstream out(mapPath(path), std::ios::binary | std::ios::trunc);
+  if (!out) return false;
+  out.write(content.c_str(), content.length());
+  return true;
+}
+bool HalStorage::ensureDirectoryExists(const char* path) {
+  return fs::create_directories(mapPath(path)) || fs::exists(mapPath(path));
+}
+
+class HalFile::Impl {
+ public:
+  fs::path path;
+  std::fstream stream;
+  std::vector<fs::directory_entry> entries;
+  size_t entryIndex = 0;
+  bool directory = false;
+  bool readable = false;
+  bool writable = false;
+};
+
+HalFile::HalFile() = default;
+HalFile::HalFile(std::unique_ptr<Impl> impl) : impl(std::move(impl)) {}
+HalFile::~HalFile() = default;
+HalFile::HalFile(HalFile&&) = default;
+HalFile& HalFile::operator=(HalFile&&) = default;
+
+HalFile HalStorage::open(const char* path, const oflag_t oflag) {
+  auto impl = std::make_unique<HalFile::Impl>();
+  impl->path = mapPath(path);
+  impl->directory = fs::is_directory(impl->path);
+  if (impl->directory) {
+    for (const auto& entry : fs::directory_iterator(impl->path)) impl->entries.push_back(entry);
+    return HalFile(std::move(impl));
+  }
+  fs::create_directories(impl->path.parent_path());
+  std::ios::openmode mode = std::ios::binary;
+  if (oflag & O_RDWR)
+    mode |= std::ios::in | std::ios::out;
+  else if (oflag & O_WRONLY)
+    mode |= std::ios::out;
+  else
+    mode |= std::ios::in;
+  if (oflag & O_TRUNC) mode |= std::ios::trunc;
+  if (oflag & O_CREAT) mode |= std::ios::out;
+  impl->readable = (mode & std::ios::in) != 0;
+  impl->writable = (mode & std::ios::out) != 0;
+  impl->stream.open(impl->path, mode);
+  return HalFile(std::move(impl));
+}
+bool HalStorage::mkdir(const char* path, const bool) {
+  return fs::create_directories(mapPath(path)) || fs::exists(mapPath(path));
+}
+bool HalStorage::exists(const char* path) { return fs::exists(mapPath(path)); }
+bool HalStorage::remove(const char* path) { return fs::remove(mapPath(path)); }
+bool HalStorage::rename(const char* oldPath, const char* newPath) {
+  fs::create_directories(mapPath(newPath).parent_path());
+  std::error_code ec;
+  fs::rename(mapPath(oldPath), mapPath(newPath), ec);
+  return !ec;
+}
+bool HalStorage::rmdir(const char* path) { return fs::remove(mapPath(path)); }
+bool HalStorage::openFileForRead(const char*, const char* path, HalFile& file) {
+  file = open(path, O_RDONLY);
+  return file;
+}
+bool HalStorage::openFileForRead(const char* moduleName, const std::string& path, HalFile& file) {
+  return openFileForRead(moduleName, path.c_str(), file);
+}
+bool HalStorage::openFileForRead(const char* moduleName, const String& path, HalFile& file) {
+  return openFileForRead(moduleName, path.c_str(), file);
+}
+bool HalStorage::openFileForWrite(const char*, const char* path, HalFile& file) {
+  file = open(path, O_CREAT | O_TRUNC | O_WRONLY);
+  return file;
+}
+bool HalStorage::openFileForWrite(const char* moduleName, const std::string& path, HalFile& file) {
+  return openFileForWrite(moduleName, path.c_str(), file);
+}
+bool HalStorage::openFileForWrite(const char* moduleName, const String& path, HalFile& file) {
+  return openFileForWrite(moduleName, path.c_str(), file);
+}
+bool HalStorage::removeDir(const char* path) { return fs::remove_all(mapPath(path)) > 0; }
+void HalFile::flush() {
+  if (impl) impl->stream.flush();
+}
+size_t HalFile::getName(char* name, size_t len) {
+  if (!impl || !name || len == 0) return 0;
+  const auto s = impl->path.filename().string();
+  snprintf(name, len, "%s", s.c_str());
+  return std::min(len - 1, s.size());
+}
+size_t HalFile::size() { return fileSize(); }
+size_t HalFile::fileSize() {
+  if (!impl || impl->directory) return 0;
+  impl->stream.clear();
+  if (impl->writable) impl->stream.flush();
+  if (fs::exists(impl->path)) return fs::file_size(impl->path);
+  return 0;
+}
+uint64_t HalFile::fileSize64() { return fileSize(); }
+bool HalFile::seek(size_t pos) { return seekSet(pos); }
+bool HalFile::seek64(uint64_t pos) { return seekSet(static_cast<size_t>(pos)); }
+bool HalFile::seekCur(int64_t offset) {
+  if (!impl) return false;
+  impl->stream.clear();
+  if (impl->readable) impl->stream.seekg(offset, std::ios::cur);
+  if (impl->writable) impl->stream.seekp(offset, std::ios::cur);
+  return !impl->stream.fail();
+}
+bool HalFile::seekSet(size_t offset) {
+  if (!impl) return false;
+  impl->stream.clear();
+  if (impl->readable) impl->stream.seekg(offset);
+  if (impl->writable) impl->stream.seekp(offset);
+  return !impl->stream.fail();
+}
+int HalFile::available() const {
+  if (!impl || impl->directory || !impl->readable) return 0;
+  impl->stream.clear();
+  auto pos = impl->stream.tellg();
+  impl->stream.seekg(0, std::ios::end);
+  auto end = impl->stream.tellg();
+  impl->stream.seekg(pos);
+  if (pos < 0 || end < pos) return 0;
+  return static_cast<int>(end - pos);
+}
+size_t HalFile::position() const {
+  if (!impl) return 0;
+  impl->stream.clear();
+  const auto pos = impl->writable ? impl->stream.tellp() : impl->stream.tellg();
+  return pos < 0 ? 0 : static_cast<size_t>(pos);
+}
+int HalFile::read(void* buf, size_t count) {
+  if (!impl || !buf || !impl->readable) return -1;
+  impl->stream.clear();
+  impl->stream.read(static_cast<char*>(buf), count);
+  return static_cast<int>(impl->stream.gcount());
+}
+int HalFile::read() {
+  char c = 0;
+  return read(&c, 1) == 1 ? static_cast<unsigned char>(c) : -1;
+}
+size_t HalFile::write(const void* buf, size_t count) {
+  if (!impl || !buf || !impl->writable) return 0;
+  impl->stream.clear();
+  impl->stream.write(static_cast<const char*>(buf), count);
+  return impl->stream.fail() ? 0 : count;
+}
+size_t HalFile::write(const uint8_t* buf, size_t count) { return write(static_cast<const void*>(buf), count); }
+size_t HalFile::write(uint8_t b) { return write(&b, 1); }
+bool HalFile::rename(const char* newPath) {
+  if (!impl) return false;
+  std::error_code ec;
+  fs::rename(impl->path, mapPath(newPath), ec);
+  if (!ec) impl->path = mapPath(newPath);
+  return !ec;
+}
+bool HalFile::isDirectory() const { return impl && impl->directory; }
+void HalFile::rewindDirectory() {
+  if (impl) impl->entryIndex = 0;
+}
+bool HalFile::close() {
+  if (!impl) return false;
+  if (impl->stream.is_open()) impl->stream.close();
+  impl.reset();
+  return true;
+}
+HalFile HalFile::openNextFile() {
+  if (!impl || impl->entryIndex >= impl->entries.size()) return {};
+  auto child = std::make_unique<Impl>();
+  child->path = impl->entries[impl->entryIndex++].path();
+  child->directory = fs::is_directory(child->path);
+  if (child->directory) {
+    for (const auto& entry : fs::directory_iterator(child->path)) child->entries.push_back(entry);
+  } else {
+    child->stream.open(child->path, std::ios::binary | std::ios::in);
+    child->readable = true;
+  }
+  return HalFile(std::move(child));
+}
+bool HalFile::isOpen() const { return impl && (impl->directory || impl->stream.is_open()); }
+HalFile::operator bool() const { return isOpen(); }
+
+#else
+
 #include <FS.h>  // need to be included before SdFat.h for compatibility with FS.h's File class
 #include <Logging.h>
 #include <SDCardManager.h>
@@ -147,6 +403,7 @@ size_t HalFile::position() const { HAL_FILE_WRAPPED_CALL(position, ); }
 int HalFile::read(void* buf, size_t count) { HAL_FILE_WRAPPED_CALL(read, buf, count); }
 int HalFile::read() { HAL_FILE_WRAPPED_CALL(read, ); }
 size_t HalFile::write(const void* buf, size_t count) { HAL_FILE_WRAPPED_CALL(write, buf, count); }
+size_t HalFile::write(const uint8_t* buf, size_t count) { return write(static_cast<const void*>(buf), count); }
 size_t HalFile::write(uint8_t b) { HAL_FILE_WRAPPED_CALL(write, b); }
 bool HalFile::rename(const char* newPath) { HAL_FILE_WRAPPED_CALL(rename, newPath); }
 bool HalFile::isDirectory() const { HAL_FILE_FORWARD_CALL(isDirectory, ); }  // already thread-safe, no need to wrap
@@ -159,3 +416,4 @@ HalFile HalFile::openNextFile() {
 }
 bool HalFile::isOpen() const { return impl != nullptr && impl->file.isOpen(); }  // already thread-safe, no need to wrap
 HalFile::operator bool() const { return isOpen(); }
+#endif

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -72,7 +72,7 @@ class HalFile : public Print {
   HalFile(const HalFile&) = delete;
   HalFile& operator=(const HalFile&) = delete;
 
-  void flush();
+  void flush() override;
   size_t getName(char* name, size_t len);
   size_t size();
   size_t fileSize();
@@ -86,6 +86,7 @@ class HalFile : public Print {
   int read(void* buf, size_t count);
   int read();  // read a single byte
   size_t write(const void* buf, size_t count);
+  size_t write(const uint8_t* buf, size_t count) override;
   size_t write(uint8_t b) override;
   bool rename(const char* newPath);
   bool isDirectory() const;

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -1,5 +1,18 @@
 #include "HalSystem.h"
 
+#if CROSSPOINT_EMULATED
+#include "Logging.h"
+
+namespace HalSystem {
+void begin() { clearLastLogs(); }
+void checkPanic() {}
+void clearPanic() { clearLastLogs(); }
+std::string getPanicInfo(bool) { return {}; }
+bool isRebootFromPanic() { return false; }
+}  // namespace HalSystem
+
+#else
+
 #include <string>
 
 #include "Arduino.h"
@@ -146,3 +159,4 @@ bool isRebootFromPanic() {
 }
 
 }  // namespace HalSystem
+#endif

--- a/lib/hal/HalTiltSensor.cpp
+++ b/lib/hal/HalTiltSensor.cpp
@@ -1,5 +1,20 @@
 #include "HalTiltSensor.h"
 
+#if CROSSPOINT_EMULATED
+
+HalTiltSensor halTiltSensor;
+
+void HalTiltSensor::begin() { _available = false; }
+bool HalTiltSensor::wake() { return false; }
+bool HalTiltSensor::deepSleep() { return false; }
+void HalTiltSensor::update(const uint8_t, const uint8_t, const bool) {}
+bool HalTiltSensor::wasTiltedForward() { return false; }
+bool HalTiltSensor::wasTiltedBack() { return false; }
+bool HalTiltSensor::hadActivity() { return false; }
+void HalTiltSensor::clearPendingEvents() {}
+
+#else
+
 #include <Logging.h>
 
 HalTiltSensor halTiltSensor;  // Singleton instance
@@ -232,3 +247,4 @@ void HalTiltSensor::clearPendingEvents() {
   _hadActivity = false;
   // Intentionally preserve _inTilt so a held tilt doesn't retrigger on next poll
 }
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,6 +68,8 @@ lib_deps =
 
 [env:default]
 extends = base
+lib_ignore =
+  emulator
 build_flags =
   ${base.build_flags}
   ; CROSSPOINT_VERSION is set by scripts/git_branch.py (includes branch + short SHA)
@@ -77,6 +79,8 @@ build_flags =
 
 [env:gh_release]
 extends = base
+lib_ignore =
+  emulator
 build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
@@ -85,6 +89,8 @@ build_flags =
 
 [env:gh_release_rc]
 extends = base
+lib_ignore =
+  emulator
 build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
@@ -93,8 +99,67 @@ build_flags =
 
 [env:slim]
 extends = base
+lib_ignore =
+  emulator
 build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
+
+[env:emulator]
+platform = native
+build_type = debug
+build_flags =
+  -std=gnu++2a
+  -DCROSSPOINT_EMULATED=1
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-emu\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=2
+  -DXML_GE=0
+  -DXML_CONTEXT_BYTES=1024
+  -Ilib/emulator
+  -Ilib/hal
+  -Ilib/GfxRenderer
+  -Ilib/EpdFont
+  -Ilib/I18n
+  -Ilib/Utf8
+  -Ilib/KOReaderSync
+  -Isrc
+  -I.pio/libdeps/emulator/QRCode/src
+  -I.pio/libdeps/emulator/PNGdec/src
+  !sdl2-config --cflags
+build_src_filter =
+  +<*>
+  -<network/*>
+  -<activities/network/*>
+  -<activities/browser/*>
+  -<activities/reader/KOReaderSyncActivity.cpp>
+  -<activities/settings/OtaUpdateActivity.cpp>
+  -<activities/settings/SdFirmwareUpdateActivity.cpp>
+  -<activities/settings/KOReaderAuthActivity.cpp>
+  -<activities/settings/KOReaderSettingsActivity.cpp>
+  -<activities/settings/OpdsServerListActivity.cpp>
+  -<platform/*>
+  -<main.cpp>
+lib_ldf_mode = deep+
+lib_compat_mode = off
+lib_deps =
+  bblanchon/ArduinoJson @ 7.4.2
+  ricmoo/QRCode @ 0.0.1
+  bitbank2/PNGdec @ ^1.0.0
+  https://github.com/bitbank2/JPEGDEC.git#86282979224c8a32fd51e091ed5a35b0c699a52b
+build_unflags =
+  -std=gnu++11
+lib_ignore =
+  BatteryMonitor
+  InputManager
+  EInkDisplay
+  SDCardManager
+  KOReaderSync
+  JsonParser
+  OpdsParser
+extra_scripts =
+  pre:scripts/gen_i18n.py
+  pre:scripts/git_branch.py
+  pre:scripts/emulator_extra.py

--- a/scripts/emulator_extra.py
+++ b/scripts/emulator_extra.py
@@ -1,0 +1,3 @@
+Import("env")
+
+env.ParseConfig("sdl2-config --cflags --libs")

--- a/scripts/run_emulator.sh
+++ b/scripts/run_emulator.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+PIO="${PIO:-pio}"
+if [ -x ".venv/bin/pio" ]; then
+  PIO=".venv/bin/pio"
+fi
+
+mkdir -p emu_sd/books
+"$PIO" run -e emulator
+CROSSPOINT_EMU_SD="$PWD/emu_sd" .pio/build/emulator/program

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -7,18 +7,27 @@
 #include "OpdsServerStore.h"
 #include "boot_sleep/BootActivity.h"
 #include "boot_sleep/SleepActivity.h"
+#if !CROSSPOINT_EMULATED
 #include "browser/OpdsBookBrowserActivity.h"
+#endif
 #include "home/CrashActivity.h"
 #include "home/FileBrowserActivity.h"
 #include "home/HomeActivity.h"
 #include "home/RecentBooksActivity.h"
+#if !CROSSPOINT_EMULATED
 #include "network/CrossPointWebServerActivity.h"
+#endif
 #include "reader/ReaderActivity.h"
+#if !CROSSPOINT_EMULATED
 #include "settings/OpdsServerListActivity.h"
+#endif
 #include "settings/SettingsActivity.h"
 #include "util/FullScreenMessageActivity.h"
 
 void ActivityManager::begin() {
+#if CROSSPOINT_EMULATED
+  renderTaskHandle = reinterpret_cast<TaskHandle_t>(1);
+#else
   xTaskCreate(&renderTaskTrampoline, "ActivityManagerRender",
               8192,              // Stack size
               this,              // Parameters
@@ -26,6 +35,7 @@ void ActivityManager::begin() {
               &renderTaskHandle  // Task handle
   );
   assert(renderTaskHandle != nullptr && "Failed to create render task");
+#endif
 }
 
 void ActivityManager::renderTaskTrampoline(void* param) {
@@ -138,11 +148,16 @@ void ActivityManager::loop() {
 
   if (requestedUpdate) {
     requestedUpdate = false;
+#if CROSSPOINT_EMULATED
+    RenderLock lock;
+    if (currentActivity) currentActivity->render(std::move(lock));
+#else
     // Using direct notification to signal the render task to update
     // Increment counter so multiple rapid calls won't be lost
     if (renderTaskHandle) {
       xTaskNotify(renderTaskHandle, 1, eIncrement);
     }
+#endif
   }
 }
 
@@ -169,7 +184,11 @@ void ActivityManager::replaceActivity(std::unique_ptr<Activity>&& newActivity) {
 }
 
 void ActivityManager::goToFileTransfer() {
+#if CROSSPOINT_EMULATED
+  goToFullScreenMessage("File transfer is not emulated");
+#else
   replaceActivity(std::make_unique<CrossPointWebServerActivity>(renderer, mappedInput));
+#endif
 }
 
 void ActivityManager::goToSettings() { replaceActivity(std::make_unique<SettingsActivity>(renderer, mappedInput)); }
@@ -183,6 +202,9 @@ void ActivityManager::goToRecentBooks() {
 }
 
 void ActivityManager::goToBrowser() {
+#if CROSSPOINT_EMULATED
+  goToFullScreenMessage("OPDS browser is not emulated");
+#else
   const auto& servers = OPDS_STORE.getServers();
   // Skip the server picker when there's only one server configured
   if (servers.size() == 1) {
@@ -190,6 +212,7 @@ void ActivityManager::goToBrowser() {
   } else {
     replaceActivity(std::make_unique<OpdsServerListActivity>(renderer, mappedInput, true));
   }
+#endif
 }
 
 void ActivityManager::goToReader(std::string path) {
@@ -248,6 +271,14 @@ ScreenshotInfo ActivityManager::getScreenshotInfo() const {
 }
 
 void ActivityManager::requestUpdate(bool immediate) {
+#if CROSSPOINT_EMULATED
+  if (immediate || renderTaskHandle) {
+    RenderLock lock;
+    if (currentActivity) currentActivity->render(std::move(lock));
+  } else {
+    requestedUpdate = true;
+  }
+#else
   if (immediate) {
     if (renderTaskHandle) {
       xTaskNotify(renderTaskHandle, 1, eIncrement);
@@ -257,8 +288,12 @@ void ActivityManager::requestUpdate(bool immediate) {
     // This is to avoid multiple updates being requested in the same loop
     requestedUpdate = true;
   }
+#endif
 }
 void ActivityManager::requestUpdateAndWait() {
+#if CROSSPOINT_EMULATED
+  requestUpdate(true);
+#else
   if (!renderTaskHandle) {
     return;
   }
@@ -286,6 +321,7 @@ void ActivityManager::requestUpdateAndWait() {
 
   xTaskNotify(renderTaskHandle, 1, eIncrement);
   ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+#endif
 }
 
 // RenderLock

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -6,15 +6,21 @@
 #include "ButtonRemapActivity.h"
 #include "ClearCacheActivity.h"
 #include "CrossPointSettings.h"
+#if !CROSSPOINT_EMULATED
 #include "KOReaderSettingsActivity.h"
+#endif
 #include "LanguageSelectActivity.h"
 #include "MappedInputManager.h"
+#if !CROSSPOINT_EMULATED
 #include "OpdsServerListActivity.h"
 #include "OtaUpdateActivity.h"
 #include "SdFirmwareUpdateActivity.h"
+#endif
 #include "SettingsList.h"
 #include "StatusBarSettingsActivity.h"
+#if !CROSSPOINT_EMULATED
 #include "activities/network/WifiSelectionActivity.h"
+#endif
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -177,22 +183,42 @@ void SettingsActivity::toggleCurrentSetting() {
         startActivityForResult(std::make_unique<StatusBarSettingsActivity>(renderer, mappedInput), resultHandler);
         break;
       case SettingAction::KOReaderSync:
+#if CROSSPOINT_EMULATED
+        activityManager.goToFullScreenMessage("KOReader sync is not emulated");
+#else
         startActivityForResult(std::make_unique<KOReaderSettingsActivity>(renderer, mappedInput), resultHandler);
+#endif
         break;
       case SettingAction::OPDSBrowser:
+#if CROSSPOINT_EMULATED
+        activityManager.goToFullScreenMessage("OPDS settings are not emulated");
+#else
         startActivityForResult(std::make_unique<OpdsServerListActivity>(renderer, mappedInput), resultHandler);
+#endif
         break;
       case SettingAction::Network:
+#if CROSSPOINT_EMULATED
+        activityManager.goToFullScreenMessage("WiFi is not emulated");
+#else
         startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput, false), resultHandler);
+#endif
         break;
       case SettingAction::ClearCache:
         startActivityForResult(std::make_unique<ClearCacheActivity>(renderer, mappedInput), resultHandler);
         break;
       case SettingAction::CheckForUpdates:
+#if CROSSPOINT_EMULATED
+        activityManager.goToFullScreenMessage("OTA updates are not emulated");
+#else
         startActivityForResult(std::make_unique<OtaUpdateActivity>(renderer, mappedInput), resultHandler);
+#endif
         break;
       case SettingAction::SdFirmwareUpdate:
+#if CROSSPOINT_EMULATED
+        activityManager.goToFullScreenMessage("Firmware updates are not emulated");
+#else
         startActivityForResult(std::make_unique<SdFirmwareUpdateActivity>(renderer, mappedInput), resultHandler);
+#endif
         break;
       case SettingAction::Language:
         startActivityForResult(std::make_unique<LanguageSelectActivity>(renderer, mappedInput), resultHandler);

--- a/src/emulator_koreader.cpp
+++ b/src/emulator_koreader.cpp
@@ -1,0 +1,65 @@
+#if CROSSPOINT_EMULATED
+
+#include "KOReaderCredentialStore.h"
+#include "activities/reader/KOReaderSyncActivity.h"
+#include "fontIds.h"
+
+KOReaderCredentialStore KOReaderCredentialStore::instance;
+
+bool KOReaderCredentialStore::saveToFile() const { return true; }
+bool KOReaderCredentialStore::loadFromFile() { return false; }
+bool KOReaderCredentialStore::loadFromBinaryFile() { return false; }
+
+void KOReaderCredentialStore::setCredentials(const std::string& user, const std::string& pass) {
+  username = user;
+  password = pass;
+}
+
+std::string KOReaderCredentialStore::getMd5Password() const { return password; }
+bool KOReaderCredentialStore::hasCredentials() const { return !username.empty() && !password.empty(); }
+
+void KOReaderCredentialStore::clearCredentials() {
+  username.clear();
+  password.clear();
+}
+
+void KOReaderCredentialStore::setServerUrl(const std::string& url) { serverUrl = url; }
+
+std::string KOReaderCredentialStore::getBaseUrl() const {
+  if (serverUrl.empty()) {
+    return "https://sync.koreader.rocks:443";
+  }
+  return serverUrl.find("://") == std::string::npos ? "http://" + serverUrl : serverUrl;
+}
+
+void KOReaderCredentialStore::setMatchMethod(DocumentMatchMethod method) { matchMethod = method; }
+
+void KOReaderSyncActivity::onEnter() {
+  Activity::onEnter();
+  statusMessage = "KOReader sync is not emulated";
+  requestUpdate();
+}
+
+void KOReaderSyncActivity::onExit() { Activity::onExit(); }
+
+void KOReaderSyncActivity::loop() {
+  mappedInput.update();
+  if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
+      mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+    ActivityResult result;
+    result.isCancelled = true;
+    setResult(std::move(result));
+    finish();
+  }
+}
+
+void KOReaderSyncActivity::render(RenderLock&&) {
+  renderer.clearScreen();
+  renderer.drawCenteredText(UI_12_FONT_ID, 240, "KOReader sync is not emulated", true);
+}
+
+void KOReaderSyncActivity::onWifiSelectionComplete(bool) {}
+void KOReaderSyncActivity::performSync() {}
+void KOReaderSyncActivity::performUpload() {}
+
+#endif

--- a/src/emulator_link.cpp
+++ b/src/emulator_link.cpp
@@ -1,0 +1,31 @@
+#if CROSSPOINT_EMULATED
+
+#include <cstdint>
+
+extern "C" {
+uint32_t uzlib_adler32(const void* data, unsigned int length, uint32_t prev_sum) {
+  constexpr uint32_t mod = 65521;
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  uint32_t a = prev_sum & 0xffff;
+  uint32_t b = (prev_sum >> 16) & 0xffff;
+  for (unsigned int i = 0; i < length; ++i) {
+    a = (a + bytes[i]) % mod;
+    b = (b + a) % mod;
+  }
+  return (b << 16) | a;
+}
+
+uint32_t uzlib_crc32(const void* data, unsigned int length, uint32_t crc) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  crc = ~crc;
+  for (unsigned int i = 0; i < length; ++i) {
+    crc ^= bytes[i];
+    for (int bit = 0; bit < 8; ++bit) {
+      crc = (crc >> 1) ^ (0xedb88320u & (0u - (crc & 1u)));
+    }
+  }
+  return ~crc;
+}
+}
+
+#endif

--- a/src/emulator_main.cpp
+++ b/src/emulator_main.cpp
@@ -1,0 +1,190 @@
+#if CROSSPOINT_EMULATED
+#include <Arduino.h>
+#include <FontCacheManager.h>
+#include <FontDecompressor.h>
+#include <GfxRenderer.h>
+#include <HalDisplay.h>
+#include <HalGPIO.h>
+#include <HalPowerManager.h>
+#include <HalStorage.h>
+#include <HalSystem.h>
+#include <HalTiltSensor.h>
+#include <I18n.h>
+#include <Logging.h>
+#include <SDL.h>
+#include <builtinFonts/all.h>
+
+#include "CrossPointSettings.h"
+#include "CrossPointState.h"
+#include "MappedInputManager.h"
+#include "OpdsServerStore.h"
+#include "RecentBooksStore.h"
+#include "activities/Activity.h"
+#include "activities/ActivityManager.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
+#include "util/ButtonNavigator.h"
+
+MappedInputManager mappedInputManager(gpio);
+GfxRenderer renderer(display);
+ActivityManager activityManager(renderer, mappedInputManager);
+FontDecompressor fontDecompressor;
+FontCacheManager fontCacheManager(renderer.getFontMap());
+static bool emulatorSleeping = false;
+
+EpdFont ui10RegularFont(&ubuntu_10_regular);
+EpdFont ui10BoldFont(&ubuntu_10_bold);
+EpdFontFamily ui10FontFamily(&ui10RegularFont, &ui10BoldFont);
+EpdFont ui12RegularFont(&ubuntu_12_regular);
+EpdFont ui12BoldFont(&ubuntu_12_bold);
+EpdFontFamily ui12FontFamily(&ui12RegularFont, &ui12BoldFont);
+EpdFont smallFont(&notosans_8_regular);
+EpdFontFamily smallFontFamily(&smallFont);
+EpdFont notoserif14RegularFont(&notoserif_14_regular);
+EpdFont notoserif14BoldFont(&notoserif_14_bold);
+EpdFont notoserif14ItalicFont(&notoserif_14_italic);
+EpdFont notoserif14BoldItalicFont(&notoserif_14_bolditalic);
+EpdFontFamily notoserif14FontFamily(&notoserif14RegularFont, &notoserif14BoldFont, &notoserif14ItalicFont,
+                                    &notoserif14BoldItalicFont);
+EpdFont notoserif12RegularFont(&notoserif_12_regular);
+EpdFont notoserif12BoldFont(&notoserif_12_bold);
+EpdFont notoserif12ItalicFont(&notoserif_12_italic);
+EpdFont notoserif12BoldItalicFont(&notoserif_12_bolditalic);
+EpdFontFamily notoserif12FontFamily(&notoserif12RegularFont, &notoserif12BoldFont, &notoserif12ItalicFont,
+                                    &notoserif12BoldItalicFont);
+EpdFont notoserif16RegularFont(&notoserif_16_regular);
+EpdFont notoserif16BoldFont(&notoserif_16_bold);
+EpdFont notoserif16ItalicFont(&notoserif_16_italic);
+EpdFont notoserif16BoldItalicFont(&notoserif_16_bolditalic);
+EpdFontFamily notoserif16FontFamily(&notoserif16RegularFont, &notoserif16BoldFont, &notoserif16ItalicFont,
+                                    &notoserif16BoldItalicFont);
+EpdFont notoserif18RegularFont(&notoserif_18_regular);
+EpdFont notoserif18BoldFont(&notoserif_18_bold);
+EpdFont notoserif18ItalicFont(&notoserif_18_italic);
+EpdFont notoserif18BoldItalicFont(&notoserif_18_bolditalic);
+EpdFontFamily notoserif18FontFamily(&notoserif18RegularFont, &notoserif18BoldFont, &notoserif18ItalicFont,
+                                    &notoserif18BoldItalicFont);
+
+EpdFont notosans12RegularFont(&notosans_12_regular);
+EpdFont notosans12BoldFont(&notosans_12_bold);
+EpdFont notosans12ItalicFont(&notosans_12_italic);
+EpdFont notosans12BoldItalicFont(&notosans_12_bolditalic);
+EpdFontFamily notosans12FontFamily(&notosans12RegularFont, &notosans12BoldFont, &notosans12ItalicFont,
+                                   &notosans12BoldItalicFont);
+EpdFont notosans14RegularFont(&notosans_14_regular);
+EpdFont notosans14BoldFont(&notosans_14_bold);
+EpdFont notosans14ItalicFont(&notosans_14_italic);
+EpdFont notosans14BoldItalicFont(&notosans_14_bolditalic);
+EpdFontFamily notosans14FontFamily(&notosans14RegularFont, &notosans14BoldFont, &notosans14ItalicFont,
+                                   &notosans14BoldItalicFont);
+EpdFont notosans16RegularFont(&notosans_16_regular);
+EpdFont notosans16BoldFont(&notosans_16_bold);
+EpdFont notosans16ItalicFont(&notosans_16_italic);
+EpdFont notosans16BoldItalicFont(&notosans_16_bolditalic);
+EpdFontFamily notosans16FontFamily(&notosans16RegularFont, &notosans16BoldFont, &notosans16ItalicFont,
+                                   &notosans16BoldItalicFont);
+EpdFont notosans18RegularFont(&notosans_18_regular);
+EpdFont notosans18BoldFont(&notosans_18_bold);
+EpdFont notosans18ItalicFont(&notosans_18_italic);
+EpdFont notosans18BoldItalicFont(&notosans_18_bolditalic);
+EpdFontFamily notosans18FontFamily(&notosans18RegularFont, &notosans18BoldFont, &notosans18ItalicFont,
+                                   &notosans18BoldItalicFont);
+
+EpdFont opendyslexic8RegularFont(&opendyslexic_8_regular);
+EpdFont opendyslexic8BoldFont(&opendyslexic_8_bold);
+EpdFont opendyslexic8ItalicFont(&opendyslexic_8_italic);
+EpdFont opendyslexic8BoldItalicFont(&opendyslexic_8_bolditalic);
+EpdFontFamily opendyslexic8FontFamily(&opendyslexic8RegularFont, &opendyslexic8BoldFont, &opendyslexic8ItalicFont,
+                                      &opendyslexic8BoldItalicFont);
+EpdFont opendyslexic10RegularFont(&opendyslexic_10_regular);
+EpdFont opendyslexic10BoldFont(&opendyslexic_10_bold);
+EpdFont opendyslexic10ItalicFont(&opendyslexic_10_italic);
+EpdFont opendyslexic10BoldItalicFont(&opendyslexic_10_bolditalic);
+EpdFontFamily opendyslexic10FontFamily(&opendyslexic10RegularFont, &opendyslexic10BoldFont, &opendyslexic10ItalicFont,
+                                       &opendyslexic10BoldItalicFont);
+EpdFont opendyslexic12RegularFont(&opendyslexic_12_regular);
+EpdFont opendyslexic12BoldFont(&opendyslexic_12_bold);
+EpdFont opendyslexic12ItalicFont(&opendyslexic_12_italic);
+EpdFont opendyslexic12BoldItalicFont(&opendyslexic_12_bolditalic);
+EpdFontFamily opendyslexic12FontFamily(&opendyslexic12RegularFont, &opendyslexic12BoldFont, &opendyslexic12ItalicFont,
+                                       &opendyslexic12BoldItalicFont);
+EpdFont opendyslexic14RegularFont(&opendyslexic_14_regular);
+EpdFont opendyslexic14BoldFont(&opendyslexic_14_bold);
+EpdFont opendyslexic14ItalicFont(&opendyslexic_14_italic);
+EpdFont opendyslexic14BoldItalicFont(&opendyslexic_14_bolditalic);
+EpdFontFamily opendyslexic14FontFamily(&opendyslexic14RegularFont, &opendyslexic14BoldFont, &opendyslexic14ItalicFont,
+                                       &opendyslexic14BoldItalicFont);
+
+static void setupEmulator() {
+  HalSystem::begin();
+  gpio.begin();
+  powerManager.begin();
+  halTiltSensor.begin();
+  Serial.begin(115200);
+
+  Storage.begin();
+  SETTINGS.loadFromFile();
+  I18N.setLanguage(static_cast<Language>(SETTINGS.language));
+  OPDS_STORE.loadFromFile();
+  RECENT_BOOKS.loadFromFile();
+  UITheme::getInstance().reload();
+  ButtonNavigator::setMappedInputManager(mappedInputManager);
+
+  display.begin();
+  renderer.begin();
+  if (!fontDecompressor.init()) {
+    LOG_ERR("MAIN", "Font decompressor init failed");
+  }
+  fontCacheManager.setFontDecompressor(&fontDecompressor);
+  renderer.setFontCacheManager(&fontCacheManager);
+  renderer.insertFont(UI_10_FONT_ID, ui10FontFamily);
+  renderer.insertFont(UI_12_FONT_ID, ui12FontFamily);
+  renderer.insertFont(SMALL_FONT_ID, smallFontFamily);
+  renderer.insertFont(NOTOSERIF_12_FONT_ID, notoserif12FontFamily);
+  renderer.insertFont(NOTOSERIF_14_FONT_ID, notoserif14FontFamily);
+  renderer.insertFont(NOTOSERIF_16_FONT_ID, notoserif16FontFamily);
+  renderer.insertFont(NOTOSERIF_18_FONT_ID, notoserif18FontFamily);
+  renderer.insertFont(NOTOSANS_12_FONT_ID, notosans12FontFamily);
+  renderer.insertFont(NOTOSANS_14_FONT_ID, notosans14FontFamily);
+  renderer.insertFont(NOTOSANS_16_FONT_ID, notosans16FontFamily);
+  renderer.insertFont(NOTOSANS_18_FONT_ID, notosans18FontFamily);
+  renderer.insertFont(OPENDYSLEXIC_8_FONT_ID, opendyslexic8FontFamily);
+  renderer.insertFont(OPENDYSLEXIC_10_FONT_ID, opendyslexic10FontFamily);
+  renderer.insertFont(OPENDYSLEXIC_12_FONT_ID, opendyslexic12FontFamily);
+  renderer.insertFont(OPENDYSLEXIC_14_FONT_ID, opendyslexic14FontFamily);
+
+  activityManager.begin();
+  activityManager.goHome();
+}
+
+static void handleEmulatorPowerButton() {
+  if (!gpio.wasReleased(HalGPIO::BTN_POWER)) return;
+
+  if (emulatorSleeping) {
+    emulatorSleeping = false;
+    activityManager.goHome();
+    return;
+  }
+
+  emulatorSleeping = true;
+  APP_STATE.lastSleepFromReader = activityManager.isReaderActivity();
+  APP_STATE.saveToFile();
+  activityManager.goToSleep();
+}
+
+static void loopEmulator() {
+  gpio.update();
+  handleEmulatorPowerButton();
+  renderer.setFadingFix(SETTINGS.fadingFix);
+  activityManager.loop();
+  delay(activityManager.skipLoopDelay() ? 1 : 10);
+}
+
+int main(int, char**) {
+  setupEmulator();
+  while (true) {
+    loopEmulator();
+  }
+  return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

Draft PR for a native SDL-based emulator target that makes UI and reader changes faster to test locally before flashing hardware.

Changes included:

- Adds a PlatformIO `emulator` environment that builds the firmware as a native desktop binary.
- Adds a lightweight compatibility layer for Arduino, FreeRTOS, Wi-Fi, SPI, Wire, and ESP APIs used by the shared code.
- Adds emulator HAL implementations for display, GPIO, storage, power, system, and tilt sensor behavior.
- Maps the emulated SD card to a local directory via `CROSSPOINT_EMU_SD`, defaulting to `./emu_sd`.
- Supports opening EPUB/TXT/XTC files from `emu_sd/books` and persists `.crosspoint` cache/state data under the emulated SD root.
- Renders the e-paper framebuffer through SDL in portrait orientation.
- Adds keyboard controls: arrows, Enter/Space, Escape/Backspace, and Tab/`p` as the power button.
- Adds a basic sleep toggle in the emulator: Tab enters the sleep screen, Tab again wakes to Home.
- Registers the same built-in reader fonts used by firmware, including Noto Serif, Noto Sans, and OpenDyslexic sizes.
- Stubs hardware/network-only flows that are not useful in the native emulator yet: Wi-Fi setup, OPDS browsing, OTA, browser, file transfer, and KOReader sync.
- Adds `scripts/run_emulator.sh` and contributor docs for setup, controls, adding books, and known limitations.
- Ignores local `emu_sd/` test data so books and generated cache files are not committed.

## Additional Context

This is intentionally a draft. The current emulator is useful for quickly testing reader and UI flows, but it is not a full device simulator.

Known limitations / review focus:

- Grayscale refresh is not fully simulated. The emulator currently keeps the already-rendered monochrome frame instead of showing raw grayscale planes, because displaying the raw planes makes text look like a dotted mask.
- Power behavior is a desktop approximation. It toggles between Sleep and Home instead of modeling real deep sleep and wake state fully.
- Network-oriented activities are intentionally stubbed in the emulator target.
- Hardware validation on Xteink X4 is still required before treating this as complete.
- The emulator source filter excludes hardware-only activities for now; future work could make more screens available through better mocks.

Local validation performed:

```sh
./bin/clang-format-fix
pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
pio run
pio run -e emulator
pio run -e gh_release -e slim
```

Also smoke-tested the emulator startup locally with an emulated SD root and EPUB files under `emu_sd/books`.
