### PR TITLE
fix: remove duplicate 'Download Fonts' menu entry and improve navigation

### DIFF
--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -263,18 +263,27 @@ void FontDownloadActivity::loop() {
       return;
     }
 
-    buttonNavigator_.onNextRelease([this] {
-      if (selectedIndex_ < listItemCount() - 1) {
-        selectedIndex_++;
-        requestUpdate();
-      }
+    const int listSize = listItemCount();
+    const int pageItems = UITheme::getNumberOfItemsPerPage(renderer, true, false, true, false);
+
+    buttonNavigator_.onNextRelease([this, listSize] {
+      selectedIndex_ = ButtonNavigator::nextIndex(selectedIndex_, listSize);
+      requestUpdate();
     });
 
-    buttonNavigator_.onPreviousRelease([this] {
-      if (selectedIndex_ > 0) {
-        selectedIndex_--;
-        requestUpdate();
-      }
+    buttonNavigator_.onPreviousRelease([this, listSize] {
+      selectedIndex_ = ButtonNavigator::previousIndex(selectedIndex_, listSize);
+      requestUpdate();
+    });
+
+    buttonNavigator_.onNextContinuous([this, listSize, pageItems] {
+      selectedIndex_ = ButtonNavigator::nextPageIndex(selectedIndex_, listSize, pageItems);
+      requestUpdate();
+    });
+
+    buttonNavigator_.onPreviousContinuous([this, listSize, pageItems] {
+      selectedIndex_ = ButtonNavigator::previousPageIndex(selectedIndex_, listSize, pageItems);
+      requestUpdate();
     });
 
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -54,7 +54,6 @@ void SettingsActivity::rebuildSettingsLists() {
   systemSettings.push_back(SettingInfo::Action(StrId::STR_KOREADER_SYNC, SettingAction::KOReaderSync));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_OPDS_SERVERS, SettingAction::OPDSBrowser));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_CLEAR_READING_CACHE, SettingAction::ClearCache));
-  systemSettings.push_back(SettingInfo::Action(StrId::STR_DOWNLOAD_FONTS, SettingAction::DownloadFonts));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_CHECK_UPDATES, SettingAction::CheckForUpdates));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_SD_FIRMWARE_UPDATE, SettingAction::SdFirmwareUpdate));
   systemSettings.push_back(SettingInfo::Action(StrId::STR_LANGUAGE, SettingAction::Language));


### PR DESCRIPTION
## Summary
Removes duplicate "Download Fonts" menu entry and adds complete navigation support to the font download activity.

## Problem
"Download Fonts" was appearing in **both** Reader settings and System settings, creating a confusing duplicate menu entry.

## Changes

### 1. Remove Duplicate Menu Entry
- Removed `STR_DOWNLOAD_FONTS` from `systemSettings` in `SettingsActivity.cpp`
- "Download Fonts" now only appears in **Reader settings**, positioned right after the font family setting
- Rationale: Font settings logically belong together in the Reader category

### 2. Navigation Improvements
- **Single-item navigation**: Replaced manual bounds checking with `ButtonNavigator::nextIndex()` and `previousIndex()` methods
  - Navigation now wraps from last item to first (and vice versa)
  
- **Page navigation**: Added continuous navigation handlers
  - Long-pressing up/down buttons now navigates by page
  - Uses `UITheme::getNumberOfItemsPerPage()` for consistent behavior

## Files Changed
- `src/activities/settings/SettingsActivity.cpp`: Removed duplicate entry
- `src/activities/settings/FontDownloadActivity.cpp`: Navigation improvements

## Testing
- Build: ✅ Compiled successfully
- Device testing: Recommended before merge