### PR TITLE
fix: overlap problems in font download list in classic theme

### DIFF
--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -269,10 +269,26 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     renderer.fillRect(0, rect.y + selectedIndex % pageItems * rowHeight - 2, rect.width, rowHeight);
   }
   // Draw all items
+  // Cap value column width and reserve a small gap so a long value can never overlap the title.
+  // Mirrors LyraTheme/RoundedRaffTheme: truncate the value, deduct its measured width from the title's space.
+  constexpr int maxValueWidth = 200;
+  constexpr int valueGap = 10;
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int itemY = rect.y + (i % pageItems) * rowHeight;
-    int textWidth = contentWidth - BaseMetrics::values.contentSidePadding * 2 - (rowValue != nullptr ? 60 : 0);
+
+    // Compute value first so the title's available width is the leftover space.
+    std::string valueText;
+    int valueTextWidth = 0;
+    if (rowValue != nullptr) {
+      valueText = renderer.truncatedText(UI_10_FONT_ID, rowValue(i).c_str(), maxValueWidth);
+      valueTextWidth = renderer.getTextWidth(UI_10_FONT_ID, valueText.c_str());
+    }
+
+    int textWidth = contentWidth - BaseMetrics::values.contentSidePadding * 2;
+    if (rowValue != nullptr) {
+      textWidth -= valueTextWidth + valueGap;
+    }
 
     // Draw name
     auto itemName = rowTitle(i);
@@ -299,9 +315,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     }
 
     if (rowValue != nullptr) {
-      // Draw value
-      std::string valueText = rowValue(i);
-      const auto valueTextWidth = renderer.getTextWidth(UI_10_FONT_ID, valueText.c_str());
+      // Draw value (already truncated and measured above).
       renderer.drawText(UI_10_FONT_ID, rect.x + contentWidth - BaseMetrics::values.contentSidePadding - valueTextWidth,
                         itemY, valueText.c_str(), i != selectedIndex);
     }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -271,8 +271,13 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   // Draw all items
   // Cap value column width and reserve a small gap so a long value can never overlap the title.
   // Mirrors LyraTheme/RoundedRaffTheme: truncate the value, deduct its measured width from the title's space.
+  // Reserve a minimum slice for the title before sizing the value cap, so on pathologically narrow
+  // rows the value gets squeezed instead of the title vanishing (mirrors RoundedRaffTheme::drawList).
   constexpr int maxValueWidth = 200;
   constexpr int valueGap = 10;
+  constexpr int minTitleWidth = 40;
+  const int valueBudget = std::max(
+      0, std::min(maxValueWidth, contentWidth - BaseMetrics::values.contentSidePadding * 2 - valueGap - minTitleWidth));
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int itemY = rect.y + (i % pageItems) * rowHeight;
@@ -281,7 +286,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     std::string valueText;
     int valueTextWidth = 0;
     if (rowValue != nullptr) {
-      valueText = renderer.truncatedText(UI_10_FONT_ID, rowValue(i).c_str(), maxValueWidth);
+      valueText = renderer.truncatedText(UI_10_FONT_ID, rowValue(i).c_str(), valueBudget);
       valueTextWidth = renderer.getTextWidth(UI_10_FONT_ID, valueText.c_str());
     }
 


### PR DESCRIPTION
## Summary

Fixes #1894 by borrowing the truncation approach used in other themes on the font download list.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **Yes - Claude**
